### PR TITLE
feat: switch to public RDS with manual migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,6 @@ ENV NODE_EXTRA_CA_CERTS=/app/rds-global-bundle.pem
 # copy build files and runtime assets
 COPY --from=builder --chown=node:node /app/dist ./dist
 
-# drizzle migration files for opt-in startup migrations (RUN_MIGRATIONS=true)
-COPY --from=builder --chown=node:node /app/src/db/schema/out ./migrations
-ENV MIGRATIONS_FOLDER=/app/migrations
-
 USER node
 EXPOSE 8080
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,7 @@
 import { createServer } from "./server.js";
 import { config } from "./config.js";
 import { logger } from "./middleware/logger.js";
-import { db } from "./db/db.js";
-import { migrate } from "drizzle-orm/node-postgres/migrator";
 import http from "http";
-
-// Opt-in startup migrations: the production image has no drizzle-kit (dev
-// dependency) and the database is only reachable from inside the VPC, so the
-// deployed app itself is the only place migrations can run.
-if (process.env.RUN_MIGRATIONS === "true") {
-  const migrationsFolder =
-    process.env.MIGRATIONS_FOLDER ?? "src/db/schema/out";
-  logger.info(`Running database migrations from ${migrationsFolder}...`);
-  try {
-    await migrate(db, { migrationsFolder });
-    logger.info("Database migrations completed");
-  } catch (err) {
-    logger.error({ msg: "Database migration failed", err });
-    process.exit(1);
-  }
-}
 
 const app = createServer();
 export const server = http.createServer(app);

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -2,7 +2,7 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "../db/db.js";
 import { tempEmailSend } from "./tempEmail.js";
-import { openAPI } from "better-auth/plugins";
+import { haveIBeenPwned, openAPI } from "better-auth/plugins";
 import { config } from "../config.js";
 
 export const auth = betterAuth({
@@ -37,8 +37,5 @@ export const auth = betterAuth({
     max: 50,
   },
   trustedOrigins: config?.auth?.trustedOrigins ?? [],
-  // haveIBeenPwned() removed: the deployed environment has no outbound
-  // internet access (App Runner VPC egress without NAT), so the call to
-  // api.pwnedpasswords.com would hang. Re-add once egress/NAT exists.
-  plugins: [openAPI()],
+  plugins: [haveIBeenPwned(), openAPI()],
 });

--- a/terraform/apprunner.tf
+++ b/terraform/apprunner.tf
@@ -4,19 +4,10 @@
 # e.g. "main"). Every time CI pushes a new image to that tag, App Runner
 # automatically rolls out a new deployment (auto_deployments_enabled).
 # Manual redeploy: aws apprunner start-deployment --service-arn <arn>
-
-# VPC connector: gives the service network interfaces inside the private
-# subnets so it can reach RDS. NOTE: with egress_type = "VPC", ALL outbound
-# traffic from the app is routed into the VPC — which has no internet path.
-resource "aws_apprunner_vpc_connector" "main" {
-  vpc_connector_name = "${var.project_name}-${var.environment}-vpc-connector"
-  subnets            = aws_subnet.private[*].id
-  security_groups    = [aws_security_group.app.id]
-
-  tags = {
-    Name = "${var.project_name}-${var.environment}-vpc-connector"
-  }
-}
+#
+# Networking: default public egress. The app reaches RDS over its public
+# endpoint (TLS-verified) and has normal outbound internet access (Have I
+# Been Pwned checks, future email provider). No VPC connector needed.
 
 # Cap scaling so a traffic spike (or attack) can't run up the bill.
 resource "aws_apprunner_auto_scaling_configuration_version" "main" {
@@ -52,7 +43,6 @@ resource "aws_apprunner_service" "main" {
           PORT            = tostring(var.app_port)
           BETTER_AUTH_URL = "https://${var.api_domain_name}"
           TRUSTED_ORIGINS = join(",", var.trusted_origins)
-          RUN_MIGRATIONS  = "true"
         }
 
         # Resolved at instance start via the instance role; each env var
@@ -80,20 +70,10 @@ resource "aws_apprunner_service" "main" {
     unhealthy_threshold = 5
   }
 
-  network_configuration {
-    ingress_configuration {
-      is_publicly_accessible = true
-    }
-    egress_configuration {
-      egress_type       = "VPC"
-      vpc_connector_arn = aws_apprunner_vpc_connector.main.arn
-    }
-  }
-
   auto_scaling_configuration_arn = aws_apprunner_auto_scaling_configuration_version.main.arn
 
   # Secret values must exist before the first deployment resolves them, and
-  # the DB must accept connections for startup migrations to succeed.
+  # the schema must be migrated manually before the app can serve traffic.
   depends_on = [
     aws_secretsmanager_secret_version.database_url,
     aws_secretsmanager_secret_version.better_auth_secret,

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,12 +2,12 @@
 # Infrastructure resources are organized into separate files:
 # - provider.tf: AWS provider configuration
 # - variables.tf: Input variables
-# - vpc.tf: VPC, private subnets, DB subnet group (no internet access)
-# - security-groups.tf: App Runner connector SG and RDS SG
+# - vpc.tf: VPC, public subnets, IGW, DB subnet group
+# - security-groups.tf: RDS security group
 # - iam.tf: App Runner ECR-access and instance roles
 # - secrets.tf: Secrets Manager (DATABASE url, BETTER_AUTH_SECRET)
-# - rds.tf: RDS PostgreSQL instance (private)
-# - apprunner.tf: App Runner service, VPC connector, autoscaling
+# - rds.tf: RDS PostgreSQL instance (public endpoint, manual migrations)
+# - apprunner.tf: App Runner service (default egress), autoscaling
 # - dns.tf: Route 53 records + custom domain association (api.flexi-day.com)
 # - outputs.tf: Output values
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -31,14 +31,14 @@ output "vpc_id" {
   value       = aws_vpc.main.id
 }
 
-output "private_subnet_ids" {
-  description = "IDs of private subnets"
-  value       = aws_subnet.private[*].id
+output "public_subnet_ids" {
+  description = "IDs of public subnets"
+  value       = aws_subnet.public[*].id
 }
 
 # RDS
 output "rds_endpoint" {
-  description = "RDS instance endpoint (only reachable from inside the VPC)"
+  description = "RDS instance endpoint (publicly reachable, TLS + password protected)"
   value       = aws_db_instance.main.endpoint
 }
 
@@ -64,12 +64,15 @@ output "get_database_url_command" {
 }
 
 # Security groups
-output "app_security_group_id" {
-  description = "SG attached to the App Runner VPC connector"
-  value       = aws_security_group.app.id
-}
-
 output "rds_security_group_id" {
   description = "SG protecting RDS"
   value       = aws_security_group.rds.id
+}
+
+# Manual migration helper: run from the repo root on your machine.
+# sslmode=no-verify -> encrypted connection without needing the RDS CA
+# bundle installed locally (the app itself does full verification).
+output "manual_migration_command" {
+  description = "Command to run drizzle migrations from your machine"
+  value       = "DATABASE=\"$(aws secretsmanager get-secret-value --secret-id ${aws_secretsmanager_secret.database_url.name} --region ${var.aws_region} --query SecretString --output text)?sslmode=no-verify\" npm run db:migrate"
 }

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -19,11 +19,12 @@ resource "aws_db_instance" "main" {
   password = random_password.db_password.result
   port     = var.db_port
 
-  # Network Configuration: private subnets, no public endpoint. Only the
-  # App Runner VPC connector's security group can reach it.
+  # Network Configuration: public endpoint so App Runner (default egress)
+  # and developer machines (manual migrations) can reach it. Protected by
+  # the security group note in security-groups.tf.
   db_subnet_group_name   = aws_db_subnet_group.main.name
   vpc_security_group_ids = [aws_security_group.rds.id]
-  publicly_accessible    = false
+  publicly_accessible    = true
 
   # High Availability
   multi_az = var.db_multi_az

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -1,20 +1,13 @@
-# Security Group for the App Runner VPC connector.
-# App Runner attaches this SG to the ENIs it creates in the private subnets,
-# so all traffic the app sends into the VPC carries this SG as its source.
-resource "aws_security_group" "app" {
-  name        = "${var.project_name}-${var.environment}-app-sg"
-  description = "App Runner VPC connector - application egress into the VPC"
-  vpc_id      = aws_vpc.main.id
-
-  tags = {
-    Name = "${var.project_name}-${var.environment}-app-sg"
-  }
-}
-
-# Security Group for RDS Instance
+# Security Group for RDS Instance.
+#
+# Port 5432 is open to the internet: App Runner's default egress comes from
+# changing AWS public IPs (no stable range to allowlist), and migrations are
+# run manually from developer machines. The protections are the random
+# 32-char master password, forced SSL (rds.force_ssl=1), and encrypted
+# storage. If you later switch to a VPC connector + private DB, tighten this.
 resource "aws_security_group" "rds" {
   name        = "${var.project_name}-${var.environment}-rds-sg"
-  description = "RDS PostgreSQL - only reachable from the app SG"
+  description = "RDS PostgreSQL - public endpoint, credential + TLS protected"
   vpc_id      = aws_vpc.main.id
 
   tags = {
@@ -22,25 +15,11 @@ resource "aws_security_group" "rds" {
   }
 }
 
-# Rules are separate resources (not inline) because the two SGs reference
-# each other, which would otherwise be a dependency cycle.
-
-# App -> RDS (only egress the app needs inside the VPC)
-resource "aws_vpc_security_group_egress_rule" "app_to_rds" {
-  security_group_id            = aws_security_group.app.id
-  referenced_security_group_id = aws_security_group.rds.id
-  from_port                    = var.db_port
-  to_port                      = var.db_port
-  ip_protocol                  = "tcp"
-  description                  = "PostgreSQL to RDS"
-}
-
-# RDS <- App
-resource "aws_vpc_security_group_ingress_rule" "rds_from_app" {
-  security_group_id            = aws_security_group.rds.id
-  referenced_security_group_id = aws_security_group.app.id
-  from_port                    = var.db_port
-  to_port                      = var.db_port
-  ip_protocol                  = "tcp"
-  description                  = "PostgreSQL from App Runner"
+resource "aws_vpc_security_group_ingress_rule" "rds_postgres" {
+  security_group_id = aws_security_group.rds.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = var.db_port
+  to_port           = var.db_port
+  ip_protocol       = "tcp"
+  description       = "PostgreSQL from anywhere (App Runner egress + manual migrations)"
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -9,46 +9,55 @@ resource "aws_vpc" "main" {
   }
 }
 
-# Private Subnets (for RDS and the App Runner VPC connector).
-#
-# Deliberately NO internet gateway, NAT gateway, or public subnets:
-# - Inbound HTTPS is terminated by App Runner outside the VPC.
-# - The app reaches RDS through the VPC connector (private traffic only).
-# - Nothing inside this VPC needs the internet. If the app ever needs
-#   outbound internet (e.g. an email provider API), add an IGW + NAT gateway
-#   and a default route here, or a VPC interface endpoint for the specific
-#   AWS service (e.g. SES).
-resource "aws_subnet" "private" {
-  count             = length(var.availability_zones)
-  vpc_id            = aws_vpc.main.id
-  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 100)
-  availability_zone = var.availability_zones[count.index]
-
-  tags = {
-    Name = "${var.project_name}-${var.environment}-private-subnet-${count.index + 1}"
-    Type = "Private"
-  }
-}
-
-# Private Route Table (local VPC routes only)
-resource "aws_route_table" "private" {
+# Internet Gateway - required for the RDS public endpoint to be reachable
+resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = "${var.project_name}-${var.environment}-private-rt"
+    Name = "${var.project_name}-${var.environment}-igw"
   }
 }
 
-resource "aws_route_table_association" "private" {
-  count          = length(aws_subnet.private)
-  subnet_id      = aws_subnet.private[count.index].id
-  route_table_id = aws_route_table.private.id
+# Public Subnets (for RDS). The database is publicly accessible so that
+# migrations can be run manually from a developer machine, and so App Runner
+# (default public egress, no VPC connector) can reach it. Access control is
+# the RDS security group + strong password + forced SSL.
+resource "aws_subnet" "public" {
+  count             = length(var.availability_zones)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-public-subnet-${count.index + 1}"
+    Type = "Public"
+  }
+}
+
+# Public Route Table
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
 }
 
 # DB Subnet Group for RDS
 resource "aws_db_subnet_group" "main" {
   name       = "${var.project_name}-${var.environment}-db-subnet-group"
-  subnet_ids = aws_subnet.private[*].id
+  subnet_ids = aws_subnet.public[*].id
 
   tags = {
     Name = "${var.project_name}-${var.environment}-db-subnet-group"


### PR DESCRIPTION
## Summary
Changes the deployment design from private RDS + VPC connector to a **public RDS endpoint with manual migrations**, per discussion. Also fixes the currently failing CD build on `main`.

### Terraform
- **RDS**: `publicly_accessible = true`, sitting in public subnets (new IGW + routes). Protection: random 32-char master password, `rds.force_ssl=1`, encrypted storage. SG allows 5432 from anywhere (App Runner default egress has no stable IPs to allowlist).
- **App Runner**: default public egress; **VPC connector removed**. Outbound internet works again.
- New output `manual_migration_command` — copy-paste command that pulls the connection string from Secrets Manager and runs `npm run db:migrate` from your machine.

### App
- Removed startup-migration code from `src/index.ts` (migrations are manual now)
- Removed the Dockerfile `COPY` of `src/db/schema/out` — **this is what broke the CD build** (the folder is gitignored, so it doesn't exist in CI checkouts)
- Restored the `haveIBeenPwned` plugin (it was only removed because the private-VPC design had no outbound internet)

## Test plan
- [x] `npm run build` + all unit tests pass
- [x] Local `docker build` succeeds (CD will be green again)
- [x] `terraform validate` + full plan against the real account (30 resources, no errors)
- [ ] After merge: `terraform apply`, run `manual_migration_command`, verify `/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)