### PR TITLE
fix: allow trusted origins in production CORS

### DIFF
--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -1,11 +1,11 @@
 import cors from "cors";
 import { config } from "../config.js";
 
+// Production origins come from the TRUSTED_ORIGINS env var (same list
+// better-auth uses for CSRF protection), e.g. the CloudFront frontend URLs.
 const allowedOrigins =
   config.api.env === "production"
-    ? [
-        /* todo add production url's */
-      ]
+    ? (config.auth?.trustedOrigins ?? [])
     : [/^http:\/\/localhost:(\d{2,5})$/];
 
 export const serverCors = cors({


### PR DESCRIPTION
## Summary
Browser requests from https://www.flexi-day.com were blocked: the production CORS allowlist in `src/middleware/cors.ts` was an empty array with a `todo` comment, so the `cors` middleware never emitted `Access-Control-Allow-Origin` (verified against the live API with a preflight curl).

Fix: reuse `config.auth.trustedOrigins` — populated from the `TRUSTED_ORIGINS` env var already set on App Runner (`https://flexi-day.com,https://www.flexi-day.com`) and already used by better-auth for CSRF trust.

## Test plan
- [x] `npm run build` + unit tests pass
- [ ] After merge + auto-deploy: preflight `curl -X OPTIONS https://api.flexi-day.com/api/auth/get-session -H 'Origin: https://www.flexi-day.com' -H 'Access-Control-Request-Method: GET'` returns `Access-Control-Allow-Origin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated production cross-origin access settings to use configured trusted origins.
  * Unconfigured production origins are now denied by default for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->