### PR TITLE
chore(sentry): fix continuous-profile-hours quota overage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,40 @@
+# Copy to .env and fill in. .env is gitignored.
+
+# --- Core (required; config.ts throws on startup if missing/invalid) ---
+NODE_ENV=dev            # production | dev | test
+PORT=8080
+DATABASE=postgres://localhost:5432/flexi-day
+BETTER_AUTH_SECRET=
+BETTER_AUTH_URL=http://localhost:8080
+
+# --- Google OAuth (optional) ---
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# --- App / URLs ---
+APP_URL=http://localhost:3000
+APP_VERSION=            # release identifier; also used as Sentry release fallback
+SERVICE_NAME=flexi-day-be
+FEED_BASE_URL=
+TRUSTED_ORIGINS=        # comma-separated allowed origins
+LOG_DIR=
+
+# --- AWS SES / email ---
+AWS_REGION=eu-central-1
+EMAIL_FROM=
+EMAIL_TEMPLATE_STAGE=   # dev | prod (selects flexi-day-email-confirmation-{dev,prod})
+SES_CONFIGURATION_SET=
+
+# --- Sentry ---
+# DSN is code-defaulted; override only to point at a different project.
+SENTRY_DSN=
+# Sentry is on in production automatically; set true to enable it elsewhere.
+SENTRY_ENABLE=false
+SENTRY_DEBUG=false
+SENTRY_RELEASE=         # falls back to APP_VERSION
+# Fraction of requests traced (0.0-1.0). Default 0.2.
+SENTRY_TRACES_SAMPLE_RATE=0.2
+# Fraction of sampled traces that are CPU-profiled (0.0-1.0). Default 0.1.
+# Profiling is trace-lifecycle-bound and accrues profile-hours quota fast on an
+# always-on server, so keep this low. Bump toward 1.0 for targeted debugging.
+SENTRY_PROFILE_SESSION_SAMPLE_RATE=0.1

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -23,8 +23,11 @@ if (enabled) {
     integrations: [nodeProfilingIntegration()],
     // Required for the winston -> Sentry Logs bridge in middleware/logger.ts.
     enableLogs: true,
-    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 1.0),
-    profileSessionSampleRate: 1.0,
+    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0.2),
+    // Profiling is trace-lifecycle-bound: it runs for the duration of every sampled
+    // trace. Keep this low or an always-on server burns through the profile-hours
+    // quota (24h/day/instance at 1.0). Overridable for targeted debugging.
+    profileSessionSampleRate: Number(process.env.SENTRY_PROFILE_SESSION_SAMPLE_RATE ?? 0.1),
     profileLifecycle: "trace",
     debug: process.env.SENTRY_DEBUG === "true",
   });


### PR DESCRIPTION
## Why

Sentry paused monitoring with **Continuous Profile Hours Quota Exceeded**. The backend had continuous profiling running at 100%: `profileSessionSampleRate: 1.0` combined with `tracesSampleRate` defaulting to `1.0`. Because profiling is **trace-lifecycle-bound** (it runs for the duration of every sampled trace), an always-on server profiled essentially all request wall-time — ~24 profile-hours/day/instance — and exhausted the quota.

## Changes

- `tracesSampleRate` default `1.0` → `0.2`
- `profileSessionSampleRate` hardcoded `1.0` → env-overridable, default `0.1` (new `SENTRY_PROFILE_SESSION_SAMPLE_RATE`)
- Add `.env.example` documenting all env vars the code reads

**Net profiling volume: 100% → ~2%** (`0.2 × 0.1`) — a 50× reduction. Both levers stay overridable so profiling can be turned back up for targeted debugging.

## Notes

- Reads at server startup, so it takes effect on the next prod deploy. For immediate relief before deploy, set `SENTRY_PROFILE_SESSION_SAMPLE_RATE=0` in the prod env and restart.
- This prevents recurrence; the current quota stays paused until Sentry's billing cycle resets.
- Frontend has no profiling (tracing/replays only), so it's untouched.

## Test

- `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)