### PR TITLE
feat: configurable working days + multi-day request handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,9 +74,10 @@ web_modules/
 .cache
 .parcel-cache
 
-# Next.js build output
+# Next.js build output (anchored: this is an Express app, so a bare `out` must
+# not swallow Drizzle migrations under src/db/schema/out)
 .next
-out
+/out
 
 # Nuxt.js build / generate output
 .nuxt

--- a/src/controllers/group/handlePutGroupWorkingDays.ts
+++ b/src/controllers/group/handlePutGroupWorkingDays.ts
@@ -12,11 +12,6 @@ const services = createDBServices();
 // Sun-first so the label index matches `Date.getUTCDay()`.
 const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
 
-/**
- * Updates which weekdays the group treats as working days. Vacation requests
- * are only booked (and only counted against quotas) on these days. Requires
- * admin access on the group.
- */
 export const handlePutGroupWorkingDays = async (req: Request, res: Response) => {
   const auth = getAuth(req);
 

--- a/src/controllers/group/handlePutGroupWorkingDays.ts
+++ b/src/controllers/group/handlePutGroupWorkingDays.ts
@@ -1,0 +1,62 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { createDBServices } from "../../services/DBServices.js";
+import { getAuth } from "../../middleware/authSession.js";
+import type { ValidatedPutGroupWorkingDaysType } from "../../services/group/types.js";
+import AppError from "../../utils/appError.js";
+import { generateRandomUUID } from "../../utils/generateUUID.js";
+import { changesType } from "../../db/schema/changes-schema.js";
+
+const services = createDBServices();
+
+// Sun-first so the label index matches `Date.getUTCDay()`.
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+/**
+ * Updates which weekdays the group treats as working days. Vacation requests
+ * are only booked (and only counted against quotas) on these days. Requires
+ * admin access on the group.
+ */
+export const handlePutGroupWorkingDays = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const groupId = z.uuid().parse(req.params.groupId);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data: ValidatedPutGroupWorkingDaysType = req.body;
+
+  const access = await services.groupUser.getGroupUser(auth.userId, groupId);
+
+  if (!access || !access.adminAccess) {
+    throw new AppError({
+      message: "No permission for related group",
+      logging: true,
+      code: 403,
+      context: { url: req.url, user: auth.userId, groupId },
+    });
+  }
+
+  const updated = await services.group.updateGroupWorkingDays(groupId, data.workingDays);
+
+  if (!updated) {
+    throw new AppError({
+      message: "Group not found",
+      logging: true,
+      code: 404,
+      context: { url: req.url, user: auth.userId, groupId },
+    });
+  }
+
+  await services.changes.postChanges({
+    id: generateRandomUUID(),
+    userId: auth.userId,
+    groupId,
+    changeType: changesType.Group,
+    changingUserId: auth.userId,
+    changeDetail: `Group working days set to ${data.workingDays
+      .map((d) => WEEKDAY_LABELS.at(d) ?? String(d))
+      .join(", ")}`,
+  });
+
+  return res.status(200).json(updated);
+};

--- a/src/controllers/vacation/handleBulkCancelVacation.ts
+++ b/src/controllers/vacation/handleBulkCancelVacation.ts
@@ -10,12 +10,6 @@ import { notifyVacationsCancelled } from "../../services/vacation/vacationNotifi
 
 const services = createDBServices();
 
-/**
- * Atomically cancels (soft deletes) many vacation rows. The detail view sends
- * every day id of a multi-day request so the whole range is cancelled together
- * or not at all. Unlike bulk approve/reject, an owner may cancel their own
- * days, so authorization allows owner, group admin, or approver per row.
- */
 export const handleBulkCancelVacation = async (req: Request, res: Response) => {
   const auth = getAuth(req);
 

--- a/src/controllers/vacation/handleBulkCancelVacation.ts
+++ b/src/controllers/vacation/handleBulkCancelVacation.ts
@@ -1,0 +1,89 @@
+import type { Request, Response } from "express";
+import { createDBServices } from "../../services/DBServices.js";
+import { getAuth } from "../../middleware/authSession.js";
+import AppError from "../../utils/appError.js";
+import { db } from "../../db/db.js";
+import type { ValidatedBulkCancelVacationType } from "../../services/vacation/types.js";
+import { generateRandomUUID } from "../../utils/generateUUID.js";
+import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
+import { notifyVacationsCancelled } from "../../services/vacation/vacationNotifier.js";
+
+const services = createDBServices();
+
+/**
+ * Atomically cancels (soft deletes) many vacation rows. The detail view sends
+ * every day id of a multi-day request so the whole range is cancelled together
+ * or not at all. Unlike bulk approve/reject, an owner may cancel their own
+ * days, so authorization allows owner, group admin, or approver per row.
+ */
+export const handleBulkCancelVacation = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data: ValidatedBulkCancelVacationType = req.body;
+  const uniqueIds = Array.from(new Set(data.ids));
+
+  const cancelled = await db.transaction(async (tx) => {
+    const rows = await services.vacation.getVacationsByIds(uniqueIds, tx);
+
+    if (rows.length !== uniqueIds.length) {
+      throw new AppError({
+        code: 404,
+        message: "One or more vacations not found",
+        context: { auth, requested: uniqueIds.length, found: rows.length },
+      });
+    }
+
+    const distinctGroupIds = Array.from(new Set(rows.map((r) => r.groupId)));
+    const approvableGroups = new Set(
+      await services.group.getGroupsWhereUserCanApprove(distinctGroupIds, auth.userId, tx)
+    );
+    const adminGroups = new Set<string>();
+    for (const groupId of distinctGroupIds) {
+      const membership = await services.groupUser.getGroupUser(auth.userId, groupId, tx);
+      if (membership?.adminAccess) adminGroups.add(groupId);
+    }
+
+    const unauthorized = rows.filter(
+      (r) =>
+        r.userId !== auth.userId && !approvableGroups.has(r.groupId) && !adminGroups.has(r.groupId)
+    );
+    if (unauthorized.length > 0) {
+      throw new AppError({
+        code: 403,
+        message: "You are not allowed to cancel one or more of these vacations",
+        logging: true,
+        context: { auth, unauthorized: unauthorized.map((r) => r.id) },
+      });
+    }
+
+    const updated = await services.vacation.cancelVacationsBulk(uniqueIds, tx);
+
+    await services.vacationEvent.createVacationEvents(
+      updated.map((row) => ({
+        id: generateRandomUUID(),
+        vacationId: row.id,
+        eventType: vacationEventType.Cancelled,
+        actorUserId: auth.userId,
+        reason: data.reason ?? null,
+      })),
+      tx
+    );
+
+    // The pre-cancellation rows still carry `approvedAt`, which the notifier
+    // needs to decide whether a cancellation is worth an email.
+    return rows;
+  });
+
+  // Post-commit and best-effort; the notifier logs its own failures.
+  await notifyVacationsCancelled(
+    cancelled,
+    { id: auth.userId, name: auth.userName },
+    data.reason ?? null
+  );
+
+  return res.status(200).json({
+    message: "Vacations cancelled",
+    cancelledCount: cancelled.length,
+  });
+};

--- a/src/controllers/vacation/handlePostVacation.ts
+++ b/src/controllers/vacation/handlePostVacation.ts
@@ -3,7 +3,11 @@ import { getAuth } from "../../middleware/authSession.js";
 import type { ValidatedPostVacationType } from "../../services/vacation/types.js";
 import AppError from "../../utils/appError.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
-import { expandDateRangeInclusive, formatDateToISOString } from "../../utils/dateFunc.js";
+import {
+  expandDateRangeInclusive,
+  filterWorkingDays,
+  formatDateToISOString,
+} from "../../utils/dateFunc.js";
 import { createDBServices } from "../../services/DBServices.js";
 import { db } from "../../db/db.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
@@ -54,6 +58,17 @@ export const handlePostVacation = async (req: Request, res: Response) => {
     });
   }
 
+  const group = await services.group.getGroup(data.groupId);
+
+  if (!group) {
+    throw new AppError({
+      message: "Group not found",
+      logging: true,
+      code: 404,
+      context: { groupId: data.groupId },
+    });
+  }
+
   const days = expandDateRangeInclusive(fromIso, toIso);
 
   if (days.length === 0) {
@@ -65,7 +80,25 @@ export const handlePostVacation = async (req: Request, res: Response) => {
     });
   }
 
-  const records = days.map((day) => ({
+  // Book — and count against quotas — only the group's working days. A
+  // non-working day inside a multi-day range is silently dropped; a request
+  // that lands entirely on non-working days is rejected (a single non-working
+  // day and a range with no working day both fall through to here).
+  const workingDays = filterWorkingDays(days, group.workingDays);
+
+  if (workingDays.length === 0) {
+    throw new AppError({
+      message:
+        days.length === 1
+          ? "Selected day is not a working day"
+          : "Selected range contains no working days",
+      logging: true,
+      code: 422,
+      context: { from: fromIso, to: toIso, groupWorkingDays: group.workingDays },
+    });
+  }
+
+  const records = workingDays.map((day) => ({
     id: generateRandomUUID(),
     userId: auth.userId,
     groupId: data.groupId,

--- a/src/controllers/vacation/handlePostVacation.ts
+++ b/src/controllers/vacation/handlePostVacation.ts
@@ -80,10 +80,7 @@ export const handlePostVacation = async (req: Request, res: Response) => {
     });
   }
 
-  // Book — and count against quotas — only the group's working days. A
-  // non-working day inside a multi-day range is silently dropped; a request
-  // that lands entirely on non-working days is rejected (a single non-working
-  // day and a range with no working day both fall through to here).
+  // Non-working days inside a range are dropped; an all-non-working request is rejected below.
   const workingDays = filterWorkingDays(days, group.workingDays);
 
   if (workingDays.length === 0) {

--- a/src/controllers/vacation/tests/handleBulkCancelVacation.test.ts
+++ b/src/controllers/vacation/tests/handleBulkCancelVacation.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockGetVacationsByIds,
+  mockCancelVacationsBulk,
+  mockCreateVacationEvents,
+  mockGetGroupsWhereUserCanApprove,
+  mockGetGroupUser,
+  mockNotifyVacationsCancelled,
+} = vi.hoisted(() => ({
+  mockGetVacationsByIds: vi.fn(),
+  mockCancelVacationsBulk: vi.fn(),
+  mockCreateVacationEvents: vi.fn(),
+  mockGetGroupsWhereUserCanApprove: vi.fn(),
+  mockGetGroupUser: vi.fn(),
+  mockNotifyVacationsCancelled: vi.fn(),
+}));
+
+vi.mock("../../../utils/generateUUID.js", () => ({
+  generateRandomUUID: vi.fn(() => "uuid"),
+}));
+
+vi.mock("../../../middleware/authSession.js", () => ({
+  getAuth: vi.fn(),
+}));
+
+vi.mock("../../../services/vacation/vacationNotifier.js", () => ({
+  notifyVacationsCancelled: mockNotifyVacationsCancelled,
+}));
+
+vi.mock("../../../db/db.js", () => ({
+  db: {
+    transaction: vi.fn((callback: (tx: unknown) => unknown) => callback({})),
+  },
+}));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    vacation: {
+      getVacationsByIds: mockGetVacationsByIds,
+      cancelVacationsBulk: mockCancelVacationsBulk,
+    },
+    vacationEvent: { createVacationEvents: mockCreateVacationEvents },
+    group: { getGroupsWhereUserCanApprove: mockGetGroupsWhereUserCanApprove },
+    groupUser: { getGroupUser: mockGetGroupUser },
+  }),
+}));
+
+import { handleBulkCancelVacation } from "../handleBulkCancelVacation.js";
+import { getAuth } from "../../../middleware/authSession.js";
+import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
+
+const groupId = "550e8400-e29b-41d4-a716-446655440009";
+const ownedRows = [
+  { id: "v-1", userId: mockAuthData.userId, groupId, approvedAt: new Date() },
+  { id: "v-2", userId: mockAuthData.userId, groupId, approvedAt: null },
+];
+
+describe("handleBulkCancelVacation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
+    mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
+    mockGetGroupUser.mockResolvedValue(null);
+    mockCancelVacationsBulk.mockImplementation(async (ids: string[]) => ids.map((id) => ({ id })));
+  });
+
+  it("lets the owner cancel every day of their own request", async () => {
+    const { req, res } = makeReqRes({ body: { ids: ["v-1", "v-2"], reason: "Plans changed" } });
+    mockGetVacationsByIds.mockResolvedValue(ownedRows);
+
+    await handleBulkCancelVacation(req, res);
+
+    expect(mockCancelVacationsBulk).toHaveBeenCalledWith(["v-1", "v-2"], expect.anything());
+    expect(mockCreateVacationEvents).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ eventType: "CANCELLED" })]),
+      expect.anything()
+    );
+    expect(mockNotifyVacationsCancelled).toHaveBeenCalledWith(
+      ownedRows,
+      { id: mockAuthData.userId, name: mockAuthData.userName },
+      "Plans changed"
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("lets a group approver cancel someone else's request", async () => {
+    const othersRows = ownedRows.map((r) => ({ ...r, userId: "someone_else" }));
+    const { req, res } = makeReqRes({ body: { ids: ["v-1", "v-2"] } });
+    mockGetVacationsByIds.mockResolvedValue(othersRows);
+    mockGetGroupsWhereUserCanApprove.mockResolvedValue([groupId]);
+
+    await handleBulkCancelVacation(req, res);
+
+    expect(mockCancelVacationsBulk).toHaveBeenCalledWith(["v-1", "v-2"], expect.anything());
+  });
+
+  it("rejects a plain member cancelling someone else's request", async () => {
+    const othersRows = ownedRows.map((r) => ({ ...r, userId: "someone_else" }));
+    const { req, res } = makeReqRes({ body: { ids: ["v-1", "v-2"] } });
+    mockGetVacationsByIds.mockResolvedValue(othersRows);
+    mockGetGroupUser.mockResolvedValue({ adminAccess: false });
+
+    await expect(handleBulkCancelVacation(req, res)).rejects.toThrow(
+      "You are not allowed to cancel one or more of these vacations"
+    );
+    expect(mockCancelVacationsBulk).not.toHaveBeenCalled();
+  });
+
+  it("404s when some ids no longer exist", async () => {
+    const { req, res } = makeReqRes({ body: { ids: ["v-1", "v-2"] } });
+    mockGetVacationsByIds.mockResolvedValue([ownedRows[0]]);
+
+    await expect(handleBulkCancelVacation(req, res)).rejects.toThrow(
+      "One or more vacations not found"
+    );
+    expect(mockCancelVacationsBulk).not.toHaveBeenCalled();
+  });
+});

--- a/src/controllers/vacation/tests/handlePostVacation.test.ts
+++ b/src/controllers/vacation/tests/handlePostVacation.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const {
   mockPostVacationBulk,
   mockGetGroupUser,
+  mockGetGroup,
   mockGetApprovalUsers,
   mockTransaction,
   mockCreateVacationEvents,
@@ -10,6 +11,7 @@ const {
 } = vi.hoisted(() => ({
   mockPostVacationBulk: vi.fn(),
   mockGetGroupUser: vi.fn(),
+  mockGetGroup: vi.fn(),
   mockGetApprovalUsers: vi.fn(),
   mockTransaction: vi.fn(),
   mockCreateVacationEvents: vi.fn(),
@@ -46,6 +48,7 @@ vi.mock("../../../services/DBServices.js", () => ({
       getGroupUser: mockGetGroupUser,
     },
     group: {
+      getGroup: mockGetGroup,
       getApprovalUsers: mockGetApprovalUsers,
     },
   }),
@@ -80,6 +83,13 @@ describe("handlePostVacation", () => {
     );
 
     mockTransaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb({}));
+
+    // Default to every weekday being a working day so tests that aren't about
+    // the working-day filter keep booking every day in their range.
+    mockGetGroup.mockResolvedValue({
+      id: "group_123",
+      workingDays: [0, 1, 2, 3, 4, 5, 6],
+    });
   });
 
   afterEach(() => {
@@ -233,5 +243,86 @@ describe("handlePostVacation", () => {
     mockPostVacationBulk.mockRejectedValue(new Error("Insert failed"));
 
     await expect(handlePostVacation(req, res)).rejects.toThrow("Insert failed");
+  });
+
+  it("books only the group's working days within a range", async () => {
+    // Thu 2024-03-14 .. Mon 2024-03-18 with Mon-Fri working days drops the
+    // Sat/Sun in the middle.
+    const { req, res } = makeReqRes({
+      body: baseBody({
+        from: new Date("2024-03-14T00:00:00Z"),
+        to: new Date("2024-03-18T00:00:00Z"),
+      }),
+    });
+
+    mockGetGroupUser.mockResolvedValue({
+      userId: "user_123",
+      groupId: "group_123",
+      controlledUser: true,
+    });
+    mockGetGroup.mockResolvedValue({ id: "group_123", workingDays: [1, 2, 3, 4, 5] });
+    mockPostVacationBulk.mockImplementation(async (records: unknown[]) => records);
+
+    await handlePostVacation(req, res);
+
+    const [records] = mockPostVacationBulk.mock.calls[0] as [{ requestedDay: string }[], unknown];
+    expect(records.map((r) => r.requestedDay)).toEqual(["2024-03-14", "2024-03-15", "2024-03-18"]);
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("rejects a single non-working day with a specific message", async () => {
+    // 2024-03-16 is a Saturday.
+    const { req, res } = makeReqRes({
+      body: baseBody({
+        from: new Date("2024-03-16T00:00:00Z"),
+        to: new Date("2024-03-16T00:00:00Z"),
+      }),
+    });
+
+    mockGetGroupUser.mockResolvedValue({
+      userId: "user_123",
+      groupId: "group_123",
+      controlledUser: true,
+    });
+    mockGetGroup.mockResolvedValue({ id: "group_123", workingDays: [1, 2, 3, 4, 5] });
+
+    await expect(handlePostVacation(req, res)).rejects.toThrow("Selected day is not a working day");
+    expect(mockPostVacationBulk).not.toHaveBeenCalled();
+  });
+
+  it("rejects a range that contains no working day", async () => {
+    // Sat 2024-03-16 .. Sun 2024-03-17.
+    const { req, res } = makeReqRes({
+      body: baseBody({
+        from: new Date("2024-03-16T00:00:00Z"),
+        to: new Date("2024-03-17T00:00:00Z"),
+      }),
+    });
+
+    mockGetGroupUser.mockResolvedValue({
+      userId: "user_123",
+      groupId: "group_123",
+      controlledUser: true,
+    });
+    mockGetGroup.mockResolvedValue({ id: "group_123", workingDays: [1, 2, 3, 4, 5] });
+
+    await expect(handlePostVacation(req, res)).rejects.toThrow(
+      "Selected range contains no working days"
+    );
+    expect(mockPostVacationBulk).not.toHaveBeenCalled();
+  });
+
+  it("throws 404 when the group no longer exists", async () => {
+    const { req, res } = makeReqRes({ body: baseBody() });
+
+    mockGetGroupUser.mockResolvedValue({
+      userId: "user_123",
+      groupId: "group_123",
+      controlledUser: true,
+    });
+    mockGetGroup.mockResolvedValue(undefined);
+
+    await expect(handlePostVacation(req, res)).rejects.toThrow("Group not found");
+    expect(mockPostVacationBulk).not.toHaveBeenCalled();
   });
 });

--- a/src/db/schema/group-schema.ts
+++ b/src/db/schema/group-schema.ts
@@ -9,6 +9,10 @@ export const groups = pgTable(
     groupName: text("group_name").notNull(),
     defaultVacationDays: integer("default_vacation_days").notNull().default(20),
     defaultHomeOfficeDays: integer("default_home_office_days").notNull().default(0),
+    // Weekdays counted as working days, as JS `Date.getUTCDay()` numbers
+    // (0=Sun … 6=Sat). Defaults to Mon–Fri. Vacation requests are only booked
+    // (and only counted against quotas) on these days.
+    workingDays: integer("working_days").array().notNull().default([1, 2, 3, 4, 5]),
     managerUserId: text("manager_user_id")
       .notNull()
       .references(() => user.id),

--- a/src/db/schema/group-schema.ts
+++ b/src/db/schema/group-schema.ts
@@ -9,9 +9,7 @@ export const groups = pgTable(
     groupName: text("group_name").notNull(),
     defaultVacationDays: integer("default_vacation_days").notNull().default(20),
     defaultHomeOfficeDays: integer("default_home_office_days").notNull().default(0),
-    // Weekdays counted as working days, as JS `Date.getUTCDay()` numbers
-    // (0=Sun … 6=Sat). Defaults to Mon–Fri. Vacation requests are only booked
-    // (and only counted against quotas) on these days.
+    // JS `Date.getUTCDay()` numbers (0=Sun … 6=Sat); default Mon–Fri.
     workingDays: integer("working_days").array().notNull().default([1, 2, 3, 4, 5]),
     managerUserId: text("manager_user_id")
       .notNull()

--- a/src/db/schema/out/0000_majestic_hemingway.sql
+++ b/src/db/schema/out/0000_majestic_hemingway.sql
@@ -1,0 +1,243 @@
+CREATE TYPE "public"."calendar_sync_scope" AS ENUM('ME', 'TEAM');--> statement-breakpoint
+CREATE TYPE "public"."changes_type" AS ENUM('GROUP', 'GROUP_USER', 'VACATION', 'USER_YEAR_QUOTAS');--> statement-breakpoint
+CREATE TYPE "public"."notification_type" AS ENUM('approval_requested', 'approval_decided', 'calendar_conflict', 'balance_low');--> statement-breakpoint
+CREATE TYPE "public"."vacation_event_type" AS ENUM('CREATED', 'APPROVED', 'REJECTED', 'CANCELLED');--> statement-breakpoint
+CREATE TYPE "public"."vacation_type" AS ENUM('VACATION', 'HOME_OFFICE', 'SICK', 'BANK_HOLIDAY', 'NON_PAID_LEAVE', 'PAID_TIME_OFF', 'SICK_LEAVE', 'STUDY_LEAVE', 'OTHER');--> statement-breakpoint
+CREATE TABLE "account" (
+	"id" text PRIMARY KEY NOT NULL,
+	"account_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"access_token" text,
+	"refresh_token" text,
+	"id_token" text,
+	"access_token_expires_at" timestamp,
+	"refresh_token_expires_at" timestamp,
+	"scope" text,
+	"password" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "session" (
+	"id" text PRIMARY KEY NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"token" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"ip_address" text,
+	"user_agent" text,
+	"user_id" text NOT NULL,
+	CONSTRAINT "session_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "user" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"email_verified" boolean DEFAULT false NOT NULL,
+	"image" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "user_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "verification" (
+	"id" text PRIMARY KEY NOT NULL,
+	"identifier" text NOT NULL,
+	"value" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "bank_holidays" (
+	"id" text PRIMARY KEY NOT NULL,
+	"date" date NOT NULL,
+	"name" text NOT NULL,
+	"country" text NOT NULL,
+	"region" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "calendar_sync" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"scope" "calendar_sync_scope" DEFAULT 'ME' NOT NULL,
+	"distinguish_mine" boolean DEFAULT false NOT NULL,
+	"token" text NOT NULL,
+	"last_fetched_at" timestamp,
+	"deleted_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "calendar_sync_teams" (
+	"id" text PRIMARY KEY NOT NULL,
+	"calendar_sync_id" text NOT NULL,
+	"group_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "calendar_sync_types" (
+	"id" text PRIMARY KEY NOT NULL,
+	"calendar_sync_id" text NOT NULL,
+	"vacation_type" "vacation_type" NOT NULL,
+	"color" text NOT NULL,
+	"mine_color" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "changes" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"group_id" text NOT NULL,
+	"change_type" "changes_type" NOT NULL,
+	"change_detail" text NOT NULL,
+	"changing_user_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "groups" (
+	"id" text PRIMARY KEY NOT NULL,
+	"group_name" text NOT NULL,
+	"default_vacation_days" integer DEFAULT 20 NOT NULL,
+	"default_home_office_days" integer DEFAULT 0 NOT NULL,
+	"manager_user_id" text NOT NULL,
+	"main_approval_user" text,
+	"temp_approval_user" text,
+	"deleted_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "group_users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"group_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"view_access" boolean DEFAULT false NOT NULL,
+	"admin_access" boolean DEFAULT false NOT NULL,
+	"controlled_user" boolean DEFAULT false NOT NULL,
+	"deleted_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "invite_link" (
+	"id" text PRIMARY KEY NOT NULL,
+	"group_id" text NOT NULL,
+	"code" text NOT NULL,
+	"used_at" timestamp,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "invite_link_code_unique" UNIQUE("code")
+);
+--> statement-breakpoint
+CREATE TABLE "notifications" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"type" "notification_type" NOT NULL,
+	"title" text NOT NULL,
+	"body" text NOT NULL,
+	"href" text,
+	"read_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_settings" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"email_notifications" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_year_quotas" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"group_id" text NOT NULL,
+	"related_year" varchar(4) NOT NULL,
+	"vacation_days" integer DEFAULT 20 NOT NULL,
+	"home_office_days" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "user_year_quotas_related_year_chk" CHECK ("user_year_quotas"."related_year" ~ '^[0-9]{4}$')
+);
+--> statement-breakpoint
+CREATE TABLE "vacation_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"vacation_id" text NOT NULL,
+	"event_type" "vacation_event_type" NOT NULL,
+	"actor_user_id" text,
+	"reason" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "vacation" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"group_id" text NOT NULL,
+	"requested_day" date NOT NULL,
+	"start_time" time,
+	"end_time" time,
+	"vacation_type" "vacation_type" DEFAULT 'VACATION' NOT NULL,
+	"approved_at" timestamp,
+	"approved_by" text,
+	"deleted_at" timestamp,
+	"rejected_at" timestamp,
+	"rejected_by" text,
+	"rejection_reason" text,
+	"note" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "account" ADD CONSTRAINT "account_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "session" ADD CONSTRAINT "session_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "calendar_sync" ADD CONSTRAINT "calendar_sync_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "calendar_sync_teams" ADD CONSTRAINT "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk" FOREIGN KEY ("calendar_sync_id") REFERENCES "public"."calendar_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "calendar_sync_teams" ADD CONSTRAINT "calendar_sync_teams_group_id_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "calendar_sync_types" ADD CONSTRAINT "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk" FOREIGN KEY ("calendar_sync_id") REFERENCES "public"."calendar_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "changes" ADD CONSTRAINT "changes_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "changes" ADD CONSTRAINT "changes_group_id_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "changes" ADD CONSTRAINT "changes_changing_user_id_user_id_fk" FOREIGN KEY ("changing_user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "groups" ADD CONSTRAINT "groups_manager_user_id_user_id_fk" FOREIGN KEY ("manager_user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "groups" ADD CONSTRAINT "groups_main_approval_user_user_id_fk" FOREIGN KEY ("main_approval_user") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "groups" ADD CONSTRAINT "groups_temp_approval_user_user_id_fk" FOREIGN KEY ("temp_approval_user") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "group_users" ADD CONSTRAINT "group_users_group_id_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "group_users" ADD CONSTRAINT "group_users_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invite_link" ADD CONSTRAINT "invite_link_group_id_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_settings" ADD CONSTRAINT "user_settings_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_year_quotas" ADD CONSTRAINT "user_year_quotas_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_year_quotas" ADD CONSTRAINT "user_year_quotas_group_id_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vacation_events" ADD CONSTRAINT "vacation_events_vacation_id_vacation_id_fk" FOREIGN KEY ("vacation_id") REFERENCES "public"."vacation"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vacation_events" ADD CONSTRAINT "vacation_events_actor_user_id_user_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vacation" ADD CONSTRAINT "vacation_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vacation" ADD CONSTRAINT "vacation_group_id_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vacation" ADD CONSTRAINT "vacation_approved_by_user_id_fk" FOREIGN KEY ("approved_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vacation" ADD CONSTRAINT "vacation_rejected_by_user_id_fk" FOREIGN KEY ("rejected_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "bank_holidays_country_idx" ON "bank_holidays" USING btree ("country");--> statement-breakpoint
+CREATE INDEX "bank_holidays_date_idx" ON "bank_holidays" USING btree ("date");--> statement-breakpoint
+CREATE UNIQUE INDEX "bank_holidays_country_region_date_uidx" ON "bank_holidays" USING btree ("country","region","date");--> statement-breakpoint
+CREATE UNIQUE INDEX "calendar_sync_token_uniq" ON "calendar_sync" USING btree ("token") WHERE "calendar_sync"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "idx_calendar_sync_user_id" ON "calendar_sync" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "calendar_sync_teams_config_group_uniq" ON "calendar_sync_teams" USING btree ("calendar_sync_id","group_id");--> statement-breakpoint
+CREATE INDEX "idx_calendar_sync_teams_config" ON "calendar_sync_teams" USING btree ("calendar_sync_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "calendar_sync_types_config_type_uniq" ON "calendar_sync_types" USING btree ("calendar_sync_id","vacation_type");--> statement-breakpoint
+CREATE INDEX "idx_calendar_sync_types_config" ON "calendar_sync_types" USING btree ("calendar_sync_id");--> statement-breakpoint
+CREATE INDEX "idx_groups_deleted_at_active" ON "groups" USING btree ("deleted_at") WHERE "groups"."deleted_at" is null;--> statement-breakpoint
+CREATE UNIQUE INDEX "group_users_group_id_user_id_uniq" ON "group_users" USING btree ("group_id","user_id") WHERE "group_users"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "idx_group_users_group_id" ON "group_users" USING btree ("group_id");--> statement-breakpoint
+CREATE INDEX "idx_group_users_user_id" ON "group_users" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_invite_link_code" ON "invite_link" USING btree ("code");--> statement-breakpoint
+CREATE INDEX "notifications_user_id_idx" ON "notifications" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "notifications_user_unread_idx" ON "notifications" USING btree ("user_id","read_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "user_group_year_quotas_user_year_uidx" ON "user_year_quotas" USING btree ("user_id","group_id","related_year");--> statement-breakpoint
+CREATE INDEX "vacation_events_vacation_id_idx" ON "vacation_events" USING btree ("vacation_id","created_at");--> statement-breakpoint
+CREATE INDEX "requested_day_idx" ON "vacation" USING btree ("requested_day");--> statement-breakpoint
+CREATE UNIQUE INDEX "uniq_vacation_user_day" ON "vacation" USING btree ("user_id","requested_day");

--- a/src/db/schema/out/0001_dark_sunset_bain.sql
+++ b/src/db/schema/out/0001_dark_sunset_bain.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."vacation_event_type" ADD VALUE 'COMMENT';

--- a/src/db/schema/out/0002_tense_the_enforcers.sql
+++ b/src/db/schema/out/0002_tense_the_enforcers.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."notification_type" ADD VALUE 'comment';

--- a/src/db/schema/out/0003_keen_mister_fear.sql
+++ b/src/db/schema/out/0003_keen_mister_fear.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "groups" ADD COLUMN "working_days" integer[] DEFAULT '{1,2,3,4,5}' NOT NULL;

--- a/src/db/schema/out/meta/0000_snapshot.json
+++ b/src/db/schema/out/meta/0000_snapshot.json
@@ -1,0 +1,1911 @@
+{
+  "id": "07d083e4-4595-4156-b993-7f824e759830",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/0001_snapshot.json
+++ b/src/db/schema/out/meta/0001_snapshot.json
@@ -1,0 +1,1912 @@
+{
+  "id": "476f2598-58e7-47af-aca1-9f591477200e",
+  "prevId": "07d083e4-4595-4156-b993-7f824e759830",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/0002_snapshot.json
+++ b/src/db/schema/out/meta/0002_snapshot.json
@@ -1,0 +1,1913 @@
+{
+  "id": "db357e4f-880c-450f-9b27-d0d46d61bbdb",
+  "prevId": "476f2598-58e7-47af-aca1-9f591477200e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/0003_snapshot.json
+++ b/src/db/schema/out/meta/0003_snapshot.json
@@ -1,0 +1,1920 @@
+{
+  "id": "4e8385fc-7ad0-4239-9848-a515e9318c44",
+  "prevId": "db357e4f-880c-450f-9b27-d0d46d61bbdb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/_journal.json
+++ b/src/db/schema/out/meta/_journal.json
@@ -1,0 +1,34 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1784869264447,
+      "tag": "0000_majestic_hemingway",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1784999448047,
+      "tag": "0001_dark_sunset_bain",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784999568910,
+      "tag": "0002_tense_the_enforcers",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1785056578902,
+      "tag": "0003_keen_mister_fear",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/routes/groupRouter.ts
+++ b/src/routes/groupRouter.ts
@@ -3,8 +3,9 @@ import { handlePostGroup } from "../controllers/group/handlePostGroup.js";
 import { tryCatch } from "../middleware/tryCatch.js";
 import { handleGetGroups } from "../controllers/group/handleGetGroups.js";
 import { handlePutGroupQuotas } from "../controllers/group/handlePutGroupQuotas.js";
+import { handlePutGroupWorkingDays } from "../controllers/group/handlePutGroupWorkingDays.js";
 import { bodyValidationMiddleware } from "../middleware/validationMiddleware.js";
-import { validatePutGroupQuotas } from "../services/group/types.js";
+import { validatePutGroupQuotas, validatePutGroupWorkingDays } from "../services/group/types.js";
 
 export const groupRouter = (): Router => {
   const app = Router();
@@ -58,6 +59,58 @@ export const groupRouter = (): Router => {
     "/:groupId/quotas",
     bodyValidationMiddleware(validatePutGroupQuotas),
     tryCatch(handlePutGroupQuotas)
+  );
+
+  /**
+   * @openapi
+   * /api/group/{groupId}/working-days:
+   *   put:
+   *     tags:
+   *       - Groups
+   *     summary: Set the group's working days
+   *     description: |
+   *       Sets which weekdays the group treats as working days. Vacation
+   *       requests are only booked — and only counted against quotas — on these
+   *       days. Days are `Date.getUTCDay()` numbers (0=Sunday … 6=Saturday); at
+   *       least one is required. Requires admin access on the group.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: groupId
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - workingDays
+   *             properties:
+   *               workingDays:
+   *                 type: array
+   *                 minItems: 1
+   *                 maxItems: 7
+   *                 items:
+   *                   type: integer
+   *                   minimum: 0
+   *                   maximum: 6
+   *     responses:
+   *       '200':
+   *         description: The updated group
+   *       '403':
+   *         description: No permission for related group
+   *       '404':
+   *         description: Group not found
+   */
+  app.put(
+    "/:groupId/working-days",
+    bodyValidationMiddleware(validatePutGroupWorkingDays),
+    tryCatch(handlePutGroupWorkingDays)
   );
 
   return app;

--- a/src/routes/vacationRouter.ts
+++ b/src/routes/vacationRouter.ts
@@ -5,6 +5,7 @@ import { bodyValidationMiddleware } from "../middleware/validationMiddleware.js"
 import {
   validateApproveVacation,
   validateBulkApproveVacation,
+  validateBulkCancelVacation,
   validateBulkRejectVacation,
   validateCancelVacation,
   validateCommentVacation,
@@ -19,6 +20,7 @@ import { handlePostVacationComment } from "../controllers/vacation/handlePostVac
 import { handleDeleteVacation } from "../controllers/vacation/handleDeleteVacation.js";
 import { handleBulkApproveVacation } from "../controllers/vacation/handleBulkApproveVacation.js";
 import { handleBulkRejectVacation } from "../controllers/vacation/handleBulkRejectVacation.js";
+import { handleBulkCancelVacation } from "../controllers/vacation/handleBulkCancelVacation.js";
 
 export const vacationRouter = (): Router => {
   const app = Router();
@@ -413,6 +415,50 @@ export const vacationRouter = (): Router => {
     "/reject",
     bodyValidationMiddleware(validateBulkRejectVacation),
     tryCatch(handleBulkRejectVacation)
+  );
+
+  /**
+   * @openapi
+   * /api/vacation/cancel:
+   *   post:
+   *     tags:
+   *       - Vacations
+   *     summary: Atomically cancel (soft delete) many vacation rows in one transaction
+   *     description: |
+   *       Cancels every supplied day id together — used by the detail view to
+   *       cancel a whole multi-day request at once. The caller must, for every
+   *       row, be the owner or have admin/approval rights on its group. An
+   *       optional `reason` is stored on each cancellation event.
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - ids
+   *             properties:
+   *               ids:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *                   format: uuid
+   *               reason:
+   *                 type: string
+   *     responses:
+   *       '200':
+   *         description: All requested vacations cancelled
+   *       '403':
+   *         description: Not allowed to cancel one or more rows
+   *       '404':
+   *         description: One or more vacations not found
+   */
+  app.post(
+    "/cancel",
+    bodyValidationMiddleware(validateBulkCancelVacation),
+    tryCatch(handleBulkCancelVacation)
   );
 
   /**

--- a/src/services/DBServices.ts
+++ b/src/services/DBServices.ts
@@ -22,6 +22,7 @@ export type DBServices = Readonly<{
     rejectVacation: typeof vacationServices.rejectVacation;
     approveVacationsBulk: typeof vacationServices.approveVacationsBulk;
     rejectVacationsBulk: typeof vacationServices.rejectVacationsBulk;
+    cancelVacationsBulk: typeof vacationServices.cancelVacationsBulk;
     getVacationsByIds: typeof vacationServices.getVacationsByIds;
     deleteVacation: typeof vacationServices.deleteVacation;
     getPendingApprovalsForApprover: typeof vacationServices.getPendingApprovalsForApprover;
@@ -57,6 +58,7 @@ export type DBServices = Readonly<{
     updateGroupApprovalUsers: typeof groupServices.updateGroupApprovalUsers;
     deleteGroup: typeof groupServices.deleteGroup;
     updateGroupQuotas: typeof groupServices.updateGroupQuotas;
+    updateGroupWorkingDays: typeof groupServices.updateGroupWorkingDays;
     getApprovalUsers: typeof groupServices.getApprovalUsers;
     getGroupsWhereUserCanApprove: typeof groupServices.getGroupsWhereUserCanApprove;
   };
@@ -117,6 +119,7 @@ export const createDBServices = (): DBServices => {
       rejectVacation: vacationServices.rejectVacation,
       approveVacationsBulk: vacationServices.approveVacationsBulk,
       rejectVacationsBulk: vacationServices.rejectVacationsBulk,
+      cancelVacationsBulk: vacationServices.cancelVacationsBulk,
       getVacationsByIds: vacationServices.getVacationsByIds,
       deleteVacation: vacationServices.deleteVacation,
       getPendingApprovalsForApprover: vacationServices.getPendingApprovalsForApprover,
@@ -152,6 +155,7 @@ export const createDBServices = (): DBServices => {
       updateGroupApprovalUsers: groupServices.updateGroupApprovalUsers,
       deleteGroup: groupServices.deleteGroup,
       updateGroupQuotas: groupServices.updateGroupQuotas,
+      updateGroupWorkingDays: groupServices.updateGroupWorkingDays,
       getApprovalUsers: groupServices.getApprovalUsers,
       getGroupsWhereUserCanApprove: groupServices.getGroupsWhereUserCanApprove,
     },

--- a/src/services/group/groupServices.ts
+++ b/src/services/group/groupServices.ts
@@ -73,6 +73,21 @@ export const deleteGroup = async (groupId: string): Promise<GroupType | undefine
   return row;
 };
 
+export const updateGroupWorkingDays = async (
+  groupId: string,
+  newWorkingDays: number[]
+): Promise<GroupType | undefined> => {
+  const [row] = await db
+    .update(groups)
+    .set({
+      workingDays: newWorkingDays,
+    })
+    .where(and(eq(groups.id, groupId), isNull(groups.deletedAt)))
+    .returning();
+
+  return row;
+};
+
 export const updateGroupQuotas = async (
   groupId: string,
   newVacation: number,

--- a/src/services/group/types.ts
+++ b/src/services/group/types.ts
@@ -30,9 +30,6 @@ export const validatePutGroupQuotas = z.object({
 
 export type ValidatedPutGroupQuotasType = z.infer<typeof validatePutGroupQuotas>;
 
-// Working days are JS `Date.getUTCDay()` numbers (0=Sun … 6=Sat). At least one
-// day must be a working day, otherwise every vacation request would be
-// rejected. Duplicates are collapsed and the result is sorted for stability.
 export const validatePutGroupWorkingDays = z.object({
   workingDays: z
     .array(z.number().int().min(0).max(6))

--- a/src/services/group/types.ts
+++ b/src/services/group/types.ts
@@ -5,6 +5,7 @@ export type GroupType = {
   groupName: string;
   defaultVacationDays: number;
   defaultHomeOfficeDays: number;
+  workingDays: number[];
   managerUserId: string;
   mainApprovalUser: string | null;
   tempApprovalUser: string | null;
@@ -28,3 +29,16 @@ export const validatePutGroupQuotas = z.object({
 });
 
 export type ValidatedPutGroupQuotasType = z.infer<typeof validatePutGroupQuotas>;
+
+// Working days are JS `Date.getUTCDay()` numbers (0=Sun … 6=Sat). At least one
+// day must be a working day, otherwise every vacation request would be
+// rejected. Duplicates are collapsed and the result is sorted for stability.
+export const validatePutGroupWorkingDays = z.object({
+  workingDays: z
+    .array(z.number().int().min(0).max(6))
+    .min(1)
+    .max(7)
+    .transform((days) => Array.from(new Set(days)).sort((a, b) => a - b)),
+});
+
+export type ValidatedPutGroupWorkingDaysType = z.infer<typeof validatePutGroupWorkingDays>;

--- a/src/services/vacation/tests/contiguousRun.test.ts
+++ b/src/services/vacation/tests/contiguousRun.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The helper is pure, but it lives in a module that also wires up the DB pool.
+// Stub the DB import so pulling in the module never touches config/Postgres.
+vi.mock("../../../db/db.js", () => ({ db: {} }));
+
+import { contiguousRunContaining } from "../vacationServices.js";
+
+const row = (id: string, requestedDay: string) => ({ id, requestedDay });
+
+describe("contiguousRunContaining", () => {
+  it("returns the whole run when every day is contiguous", () => {
+    const rows = [row("a", "2026-08-10"), row("b", "2026-08-11"), row("c", "2026-08-12")];
+    expect(contiguousRunContaining(rows, "2026-08-11").map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("trims to the run containing the target when there is a gap", () => {
+    // 10-11 are one run, 13-14 another (12 missing). Target 13 → only 13-14.
+    const rows = [
+      row("a", "2026-08-10"),
+      row("b", "2026-08-11"),
+      row("c", "2026-08-13"),
+      row("d", "2026-08-14"),
+    ];
+    expect(contiguousRunContaining(rows, "2026-08-13").map((r) => r.id)).toEqual(["c", "d"]);
+    expect(contiguousRunContaining(rows, "2026-08-10").map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("sorts unordered input before resolving the run", () => {
+    const rows = [row("c", "2026-08-12"), row("a", "2026-08-10"), row("b", "2026-08-11")];
+    expect(contiguousRunContaining(rows, "2026-08-10").map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns a single-element run for a lone day", () => {
+    const rows = [row("a", "2026-08-10"), row("c", "2026-08-13")];
+    expect(contiguousRunContaining(rows, "2026-08-13").map((r) => r.id)).toEqual(["c"]);
+  });
+
+  it("returns [] when the target day is not present", () => {
+    const rows = [row("a", "2026-08-10")];
+    expect(contiguousRunContaining(rows, "2026-08-11")).toEqual([]);
+  });
+
+  it("bridges a month boundary (28 Feb → 1 Mar)", () => {
+    const rows = [row("a", "2024-02-28"), row("b", "2024-02-29"), row("c", "2024-03-01")];
+    expect(contiguousRunContaining(rows, "2024-02-29").map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/src/services/vacation/types.ts
+++ b/src/services/vacation/types.ts
@@ -41,10 +41,9 @@ export type VacationDetail = VacationListItem & {
   groupName: string;
   approvedByUser: UserSummary | null;
   rejectedByUser: UserSummary | null;
-  /** Inclusive span of the contiguous same-type run this row belongs to. */
+  // The contiguous same-type run this row belongs to: inclusive span + every day-row id in it.
   rangeStart: DateString;
   rangeEnd: DateString;
-  /** Every day-row id in that run, ordered by day — the request's full set. */
   vacationIds: string[];
 };
 

--- a/src/services/vacation/types.ts
+++ b/src/services/vacation/types.ts
@@ -41,6 +41,11 @@ export type VacationDetail = VacationListItem & {
   groupName: string;
   approvedByUser: UserSummary | null;
   rejectedByUser: UserSummary | null;
+  /** Inclusive span of the contiguous same-type run this row belongs to. */
+  rangeStart: DateString;
+  rangeEnd: DateString;
+  /** Every day-row id in that run, ordered by day — the request's full set. */
+  vacationIds: string[];
 };
 
 /** Optional cancellation reason, accepted on DELETE /api/vacation/:id. */
@@ -111,3 +116,10 @@ export const validateBulkRejectVacation = z.object({
 });
 
 export type ValidatedBulkRejectVacationType = z.infer<typeof validateBulkRejectVacation>;
+
+export const validateBulkCancelVacation = z.object({
+  ids,
+  reason: z.string().max(1000).optional(),
+});
+
+export type ValidatedBulkCancelVacationType = z.infer<typeof validateBulkCancelVacation>;

--- a/src/services/vacation/vacationNotifier.ts
+++ b/src/services/vacation/vacationNotifier.ts
@@ -412,3 +412,88 @@ export const notifyVacationCancelled = async (
     logger.error("notifyVacationCancelled failed", { error, vacationId: row.id });
   }
 };
+
+/**
+ * Bulk variant of {@link notifyVacationCancelled} for cancelling a whole
+ * multi-day request. Only the days that had already been approved are worth an
+ * email; rows are grouped per requester so each affected employee (or their
+ * approvers, when the employee cancels their own days) gets one mail covering
+ * their cancelled span.
+ */
+export const notifyVacationsCancelled = async (
+  rows: (VacationRow & { approvedAt: Date | null })[],
+  actor: { id: string; name: string },
+  reason: string | null
+): Promise<void> => {
+  try {
+    const approvedRows = rows.filter((r) => r.approvedAt);
+    if (approvedRows.length === 0) return;
+
+    const byUser = groupByUser(approvedRows);
+    const employees = await services.user.getUsersByIds([...byUser.keys()]);
+    const contacts = new Map(employees.map((e) => [e.id, e]));
+
+    const deliveries: Delivery[] = [];
+
+    for (const [userId, userRows] of byUser) {
+      const employee = contacts.get(userId);
+      const summary = summarize(userRows);
+      if (!employee || !summary) continue;
+
+      const group = await services.group.getApprovalUsers(userRows[0]?.groupId ?? "");
+      if (!group) continue;
+
+      const recipients: UserContact[] =
+        actor.id === userId
+          ? [
+              {
+                id: group.mainApprovalUserId,
+                name: group.mainApprovalUserName,
+                email: group.mainApprovalUserEmail,
+              },
+              {
+                id: group.tempApprovalUserId,
+                name: group.tempApprovalUserName,
+                email: group.tempApprovalUserEmail,
+              },
+            ].filter(
+              (a): a is UserContact =>
+                Boolean(a.id) && Boolean(a.name) && Boolean(a.email) && a.id !== actor.id
+            )
+          : [employee];
+
+      const unique = [...new Map(recipients.map((r) => [r.id, r])).values()];
+
+      for (const recipient of unique) {
+        deliveries.push({
+          userId: recipient.id,
+          email: {
+            to: recipient.email,
+            template: "vacation-cancelled",
+            data: {
+              recipientName: recipient.name,
+              employeeName: employee.name,
+              cancelledByName: actor.name,
+              teamName: group.groupName,
+              leaveType: summary.leaveType,
+              dateRange: summary.dateRange,
+              dayCount: summary.dayCount,
+              reason: reason?.trim() ? reason.trim() : OR_DASH,
+              requestUrl: summary.requestUrl,
+            },
+          },
+          notification: {
+            type: notificationType.ApprovalDecided,
+            title: "Approved time off cancelled",
+            body: `${employee.name} · ${summary.leaveType} · ${summary.dateRange}`,
+            href: summary.requestUrl,
+          },
+        });
+      }
+    }
+
+    await deliver(deliveries);
+  } catch (error) {
+    logger.error("notifyVacationsCancelled failed", { error, actorId: actor.id });
+  }
+};

--- a/src/services/vacation/vacationNotifier.ts
+++ b/src/services/vacation/vacationNotifier.ts
@@ -413,13 +413,7 @@ export const notifyVacationCancelled = async (
   }
 };
 
-/**
- * Bulk variant of {@link notifyVacationCancelled} for cancelling a whole
- * multi-day request. Only the days that had already been approved are worth an
- * email; rows are grouped per requester so each affected employee (or their
- * approvers, when the employee cancels their own days) gets one mail covering
- * their cancelled span.
- */
+// Bulk variant of notifyVacationCancelled: one mail per requester, approved days only.
 export const notifyVacationsCancelled = async (
   rows: (VacationRow & { approvedAt: Date | null })[],
   actor: { id: string; name: string },

--- a/src/services/vacation/vacationServices.ts
+++ b/src/services/vacation/vacationServices.ts
@@ -240,6 +240,25 @@ export const rejectVacationsBulk = async (
 };
 
 /**
+ * Bulk-cancels (soft-deletes) many vacation rows in a single statement. Used
+ * when the detail view cancels a whole multi-day request at once. Returns the
+ * rows actually updated so callers can detect any that no longer matched.
+ */
+export const cancelVacationsBulk = async (
+  vacationIds: string[],
+  tx?: DbTransaction
+): Promise<VacationType[]> => {
+  if (vacationIds.length === 0) return [];
+  return (tx ?? db)
+    .update(vacation)
+    .set({
+      deletedAt: new Date(),
+    })
+    .where(and(inArray(vacation.id, vacationIds), isNull(vacation.deletedAt)))
+    .returning();
+};
+
+/**
  * Fetches vacation rows by id (active rows only). Used during bulk approve /
  * reject to authorize the caller against every distinct group in the batch.
  */
@@ -291,11 +310,47 @@ export const deleteVacation = async (
 };
 
 /**
+ * Returns the maximal run of consecutive-day rows that includes `targetDay`,
+ * ordered by day. Two days are contiguous when they differ by exactly 24h.
+ * Callers pass every sibling row (same user / group / type); this trims it to
+ * the run around the clicked day. Returns [] when `targetDay` is absent.
+ */
+export const contiguousRunContaining = <T extends { requestedDay: string }>(
+  rows: T[],
+  targetDay: string
+): T[] => {
+  const sorted = [...rows].sort((a, b) =>
+    a.requestedDay < b.requestedDay ? -1 : a.requestedDay > b.requestedDay ? 1 : 0
+  );
+  const targetIdx = sorted.findIndex((r) => r.requestedDay === targetDay);
+  if (targetIdx === -1) return [];
+
+  const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+  const dayMs = (iso: string): number => new Date(`${iso}T00:00:00Z`).getTime();
+  const adjacent = (earlier: T | undefined, later: T | undefined): boolean =>
+    earlier !== undefined &&
+    later !== undefined &&
+    dayMs(later.requestedDay) - dayMs(earlier.requestedDay) === ONE_DAY_MS;
+
+  let start = targetIdx;
+  while (start > 0 && adjacent(sorted.at(start - 1), sorted.at(start))) start--;
+  let end = targetIdx;
+  while (end < sorted.length - 1 && adjacent(sorted.at(end), sorted.at(end + 1))) end++;
+
+  return sorted.slice(start, end + 1);
+};
+
+/**
  * Loads a single vacation with everything the detail view shows: the
  * requester, the group name, and the decision makers. Unlike
  * {@link getVacationById} this deliberately includes cancelled (soft-deleted)
  * rows — the whole point of the detail view is to explain what happened to a
  * request, which includes its cancellation.
+ *
+ * A multi-day request is stored as one row per day, so this also resolves the
+ * contiguous run of same-type sibling days the clicked row belongs to and
+ * returns it as `rangeStart` / `rangeEnd` / `vacationIds`. That lets the detail
+ * view show the whole span and act on every day of the request at once.
  */
 export const getVacationDetailById = async (
   vacationId: string,
@@ -323,9 +378,33 @@ export const getVacationDetailById = async (
 
   const { groupName, approvedByName, rejectedByName, ...vacationRow } = row;
 
+  // Resolve the contiguous run of same-type sibling days this row belongs to.
+  // Cancelled detail rows group with other cancelled days; active rows with
+  // other active days, so a re-booked day on the same date can't merge in.
+  const siblings = await (tx ?? db)
+    .select({ id: vacation.id, requestedDay: vacation.requestedDay })
+    .from(vacation)
+    .where(
+      and(
+        eq(vacation.userId, vacationRow.userId),
+        eq(vacation.groupId, vacationRow.groupId),
+        eq(vacation.vacationType, vacationRow.vacationType),
+        vacationRow.deletedAt ? isNotNull(vacation.deletedAt) : isNull(vacation.deletedAt)
+      )
+    );
+  const run = contiguousRunContaining(siblings, vacationRow.requestedDay);
+  const resolvedRun =
+    run.length > 0 ? run : [{ id: vacationRow.id, requestedDay: vacationRow.requestedDay }];
+  const rangeStart = resolvedRun[0]?.requestedDay ?? vacationRow.requestedDay;
+  const rangeEnd = resolvedRun[resolvedRun.length - 1]?.requestedDay ?? vacationRow.requestedDay;
+  const vacationIds = resolvedRun.map((r) => r.id);
+
   return {
     ...toListItem(vacationRow),
     groupName,
+    rangeStart,
+    rangeEnd,
+    vacationIds,
     approvedByUser:
       vacationRow.approvedBy && approvedByName
         ? buildUserSummary({ id: vacationRow.approvedBy, name: approvedByName })

--- a/src/services/vacation/vacationServices.ts
+++ b/src/services/vacation/vacationServices.ts
@@ -239,11 +239,7 @@ export const rejectVacationsBulk = async (
     .returning();
 };
 
-/**
- * Bulk-cancels (soft-deletes) many vacation rows in a single statement. Used
- * when the detail view cancels a whole multi-day request at once. Returns the
- * rows actually updated so callers can detect any that no longer matched.
- */
+/** Bulk-cancels (soft-deletes) many vacation rows in a single statement. See rejectVacationsBulk. */
 export const cancelVacationsBulk = async (
   vacationIds: string[],
   tx?: DbTransaction
@@ -309,12 +305,7 @@ export const deleteVacation = async (
   return row;
 };
 
-/**
- * Returns the maximal run of consecutive-day rows that includes `targetDay`,
- * ordered by day. Two days are contiguous when they differ by exactly 24h.
- * Callers pass every sibling row (same user / group / type); this trims it to
- * the run around the clicked day. Returns [] when `targetDay` is absent.
- */
+// Given all sibling rows, returns the consecutive-day run containing `targetDay` ([] if absent).
 export const contiguousRunContaining = <T extends { requestedDay: string }>(
   rows: T[],
   targetDay: string
@@ -345,12 +336,8 @@ export const contiguousRunContaining = <T extends { requestedDay: string }>(
  * requester, the group name, and the decision makers. Unlike
  * {@link getVacationById} this deliberately includes cancelled (soft-deleted)
  * rows — the whole point of the detail view is to explain what happened to a
- * request, which includes its cancellation.
- *
- * A multi-day request is stored as one row per day, so this also resolves the
- * contiguous run of same-type sibling days the clicked row belongs to and
- * returns it as `rangeStart` / `rangeEnd` / `vacationIds`. That lets the detail
- * view show the whole span and act on every day of the request at once.
+ * request, which includes its cancellation. Also resolves the contiguous
+ * same-type run this row belongs to (`rangeStart` / `rangeEnd` / `vacationIds`).
  */
 export const getVacationDetailById = async (
   vacationId: string,
@@ -378,9 +365,7 @@ export const getVacationDetailById = async (
 
   const { groupName, approvedByName, rejectedByName, ...vacationRow } = row;
 
-  // Resolve the contiguous run of same-type sibling days this row belongs to.
-  // Cancelled detail rows group with other cancelled days; active rows with
-  // other active days, so a re-booked day on the same date can't merge in.
+  // Match the row's deletedAt state so a re-booked active day can't merge into a cancelled run.
   const siblings = await (tx ?? db)
     .select({ id: vacation.id, requestedDay: vacation.requestedDay })
     .from(vacation)

--- a/src/tests/utils/dateFunc.test.ts
+++ b/src/tests/utils/dateFunc.test.ts
@@ -4,7 +4,12 @@
  * Focus: formatDateToISOString and formatStartAndEndDate behaviors introduced/changed in PR diff.
  */
 
-import { formatDateToISOString, formatStartAndEndDate } from "../../utils/dateFunc";
+import {
+  filterWorkingDays,
+  formatDateToISOString,
+  formatStartAndEndDate,
+  isWorkingDay,
+} from "../../utils/dateFunc";
 
 describe("formatDateToISOString", () => {
   test("formats a UTC date to YYYY-MM-DD (e.g., 2024-01-01)", () => {
@@ -57,5 +62,48 @@ describe("formatStartAndEndDate", () => {
       startDate: "2024-02-01",
       endDate: "2024-03-01",
     });
+  });
+});
+
+describe("isWorkingDay", () => {
+  const monToFri = [1, 2, 3, 4, 5];
+
+  test("returns true for a weekday when Mon-Fri are working days", () => {
+    // 2024-07-24 is a Wednesday.
+    expect(isWorkingDay("2024-07-24", monToFri)).toBe(true);
+  });
+
+  test("returns false for a Saturday when Mon-Fri are working days", () => {
+    // 2024-07-27 is a Saturday.
+    expect(isWorkingDay("2024-07-27", monToFri)).toBe(false);
+  });
+
+  test("respects a custom working-day set including weekends", () => {
+    // Sunday (0) and Saturday (6) only.
+    expect(isWorkingDay("2024-07-28", [0, 6])).toBe(true); // Sunday
+    expect(isWorkingDay("2024-07-24", [0, 6])).toBe(false); // Wednesday
+  });
+
+  test("returns false for an invalid date string", () => {
+    expect(isWorkingDay("not-a-date", monToFri)).toBe(false);
+  });
+});
+
+describe("filterWorkingDays", () => {
+  const monToFri = [1, 2, 3, 4, 5];
+
+  test("keeps only working days and preserves order", () => {
+    // Fri 2024-07-26 .. Mon 2024-07-29 → drops Sat/Sun.
+    const days = ["2024-07-26", "2024-07-27", "2024-07-28", "2024-07-29"];
+    expect(filterWorkingDays(days, monToFri)).toEqual(["2024-07-26", "2024-07-29"]);
+  });
+
+  test("returns an empty array when no day is a working day", () => {
+    expect(filterWorkingDays(["2024-07-27", "2024-07-28"], monToFri)).toEqual([]);
+  });
+
+  test("returns all days when every day is a working day", () => {
+    const days = ["2024-07-24", "2024-07-25"];
+    expect(filterWorkingDays(days, monToFri)).toEqual(days);
   });
 });

--- a/src/utils/dateFunc.ts
+++ b/src/utils/dateFunc.ts
@@ -22,21 +22,13 @@ export const isBusinessDay = (date: Date): boolean => {
   return day !== 0 && day !== 6;
 };
 
-/**
- * Returns true when the given ISO date falls on one of the group's configured
- * working days. `workingDays` holds `Date.getUTCDay()` numbers (0=Sun … 6=Sat).
- */
+// True when the ISO date is one of `workingDays` (JS `Date.getUTCDay()` numbers, 0=Sun … 6=Sat).
 export const isWorkingDay = (iso: DateString, workingDays: number[]): boolean => {
   const date = new Date(`${iso}T00:00:00Z`);
   if (Number.isNaN(date.getTime())) return false;
   return workingDays.includes(date.getUTCDay());
 };
 
-/**
- * Keeps only the ISO dates that fall on a configured working day, preserving
- * order. Used so a vacation request books — and counts against quotas — only
- * on the group's working days.
- */
 export const filterWorkingDays = (days: DateString[], workingDays: number[]): DateString[] =>
   days.filter((day) => isWorkingDay(day, workingDays));
 

--- a/src/utils/dateFunc.ts
+++ b/src/utils/dateFunc.ts
@@ -23,6 +23,24 @@ export const isBusinessDay = (date: Date): boolean => {
 };
 
 /**
+ * Returns true when the given ISO date falls on one of the group's configured
+ * working days. `workingDays` holds `Date.getUTCDay()` numbers (0=Sun … 6=Sat).
+ */
+export const isWorkingDay = (iso: DateString, workingDays: number[]): boolean => {
+  const date = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return false;
+  return workingDays.includes(date.getUTCDay());
+};
+
+/**
+ * Keeps only the ISO dates that fall on a configured working day, preserving
+ * order. Used so a vacation request books — and counts against quotas — only
+ * on the group's working days.
+ */
+export const filterWorkingDays = (days: DateString[], workingDays: number[]): DateString[] =>
+  days.filter((day) => isWorkingDay(day, workingDays));
+
+/**
  * Counts the number of business days (Mon-Fri) between two inclusive ISO
  * dates. Returns 0 when end < start.
  */


### PR DESCRIPTION
## Summary

Backend for two features:

### 1. Configurable working days per group
- New `groups.working_days` column — an `int[]` of `Date.getUTCDay()` numbers (0=Sun…6=Sat), default Mon–Fri.
- `PUT /api/group/:groupId/working-days` (admin-only, OpenAPI-documented, writes a `changes` audit row).
- Vacation-request validation (`handlePostVacation`): only working days are booked — and, since quota usage is counted by row existence, only working days count against quotas. A single non-working day → `422`; a range with no working day → `422`; non-working days inside a valid range are dropped silently.

### 2. Multi-day request handling
A multi-day request is stored as one row per day. This makes those days act as one request:
- `getVacationDetailById` resolves the contiguous same-type run the clicked row belongs to and returns `rangeStart` / `rangeEnd` / `vacationIds`.
- New `POST /api/vacation/cancel` bulk-cancel endpoint (authorizes owner, admin, or approver per row) so a whole range cancels atomically. Approve/reject bulk endpoints already existed.

## Migrations
This PR also **starts tracking Drizzle migrations in git**. A bare `out` rule (from the Next.js section of the template `.gitignore`) was matching `src/db/schema/out` on this Express app, so migrations were never committed. The rule is now anchored to `/out`, and the existing migrations (0000–0002) plus the new `working_days` migration (**0003**) and their snapshots are added.

⚠️ **Deploy:** run `npm run db:migrate` to apply `0003` (adds `working_days`, defaulting existing rows to Mon–Fri).

## Tests
- `isWorkingDay` / `filterWorkingDays`, working-day validation cases, `contiguousRunContaining`, and `handleBulkCancelVacation` auth. **120 unit tests pass**, `tsc` + lint clean.

## Notes
- Paired with the frontend PR in `flexi-day` (working-days UI, range-aware detail dialog, grouped requests table). **Merge/deploy this first** so those endpoints/fields exist.
- Range grouping uses the same "contiguous same-type run = one request" model the calendar and approvals widget already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
