### PR TITLE
Local-only dev seeding and session routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,15 @@ DATABASE=postgres://localhost:5432/flexi-day
 BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=http://localhost:8080
 
+# --- Local dev tooling (/api/dev/*) — NEVER set in a deployed environment ---
+# Seeds verified users, teams and vacations, and issues session cookies so the
+# UI can be driven locally without SES email verification. The server refuses to
+# start if this is true with NODE_ENV=production or a non-local DATABASE, and
+# every request must come from loopback carrying DEV_TOOLS_TOKEN as x-dev-token.
+DEV_TOOLS_ENABLED=false
+DEV_TOOLS_TOKEN=            # >= 16 chars; required only when enabled
+DEV_SEED_EMAIL_DOMAIN=dev.local   # the only domain seeding may create or reset
+
 # --- Google OAuth (optional) ---
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,12 +34,21 @@ type QuotaRolloverConfig = {
   timezone: string;
 };
 
+type DevToolsConfig = {
+  /** Shared secret every `/api/dev/*` request must present as `x-dev-token`. */
+  token: string;
+  /** The only email domain the dev routes may create — and the only one reset may delete. */
+  seedEmailDomain: string;
+};
+
 type Config = {
   api: APIConfig;
   db: DBConfig;
   auth?: AuthConfig;
   email: EmailConfig;
   quotaRollover: QuotaRolloverConfig;
+  /** Local seeding/session surface. `undefined` means the routes do not exist. */
+  dev?: DevToolsConfig;
 };
 
 const VALID_ENVS = ["production", "dev", "test"] as const;
@@ -72,6 +81,47 @@ const parseTemplateStage = (): "dev" | "prod" => {
   return environment === "production" ? "prod" : "dev";
 };
 
+const databaseUrl = envOrThrow("DATABASE");
+
+const LOCAL_DB_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/**
+ * Gate for the local dev/seeding surface (`/api/dev/*`). It stays `undefined`
+ * unless explicitly switched on, and it refuses to exist anywhere it could
+ * reach real data. Throwing rather than quietly returning `undefined` is
+ * deliberate: a deploy that somehow carries the flag must fail at boot instead
+ * of silently serving seeding endpoints.
+ */
+const parseDevTools = (): DevToolsConfig | undefined => {
+  if (process.env.DEV_TOOLS_ENABLED !== "true") return undefined;
+
+  if (environment === "production") {
+    throw new Error("DEV_TOOLS_ENABLED must never be set when NODE_ENV=production");
+  }
+
+  let host: string;
+  try {
+    host = new URL(databaseUrl).hostname;
+  } catch {
+    throw new Error("DEV_TOOLS_ENABLED is set but DATABASE is not a parseable URL");
+  }
+  if (!LOCAL_DB_HOSTS.has(host)) {
+    throw new Error(
+      `DEV_TOOLS_ENABLED is set but DATABASE host "${host}" is not local — refusing to start`
+    );
+  }
+
+  const token = envOrThrow("DEV_TOOLS_TOKEN");
+  if (token.length < 16) {
+    throw new Error("DEV_TOOLS_TOKEN must be at least 16 characters");
+  }
+
+  return {
+    token,
+    seedEmailDomain: process.env.DEV_SEED_EMAIL_DOMAIN ?? "dev.local",
+  };
+};
+
 export const config: Config = {
   api: {
     port: (() => {
@@ -83,7 +133,7 @@ export const config: Config = {
     env: environment,
   },
   db: {
-    database: envOrThrow("DATABASE"),
+    database: databaseUrl,
   },
   auth:
     environment !== "test"
@@ -116,4 +166,5 @@ export const config: Config = {
     cron: process.env.QUOTA_ROLLOVER_CRON ?? "0 2 * * *",
     timezone: process.env.QUOTA_ROLLOVER_TIMEZONE ?? "Europe/Prague",
   },
+  dev: parseDevTools(),
 };

--- a/src/controllers/dev/handleGetDevStatus.ts
+++ b/src/controllers/dev/handleGetDevStatus.ts
@@ -1,0 +1,17 @@
+import type { Request, Response } from "express";
+import { config } from "../../config.js";
+import { countSeededUsers } from "../../services/dev/devSeedServices.js";
+
+export const handleGetDevStatus = async (_req: Request, res: Response) => {
+  const databaseHost = new URL(config.db.database).host;
+
+  return res.status(200).json({
+    ok: true,
+    environment: config.api.env,
+    port: config.api.port,
+    databaseHost,
+    seedEmailDomain: config.dev?.seedEmailDomain,
+    seededUsers: await countSeededUsers(),
+    appUrl: config.email.appUrl,
+  });
+};

--- a/src/controllers/dev/handlePostDevReset.ts
+++ b/src/controllers/dev/handlePostDevReset.ts
@@ -1,0 +1,10 @@
+import type { Request, Response } from "express";
+import { resetDevData } from "../../services/dev/devSeedServices.js";
+import { logger } from "../../middleware/logger.js";
+
+export const handlePostDevReset = async (_req: Request, res: Response) => {
+  const summary = await resetDevData();
+  logger.info("dev reset completed", summary);
+
+  return res.status(200).json({ deleted: summary });
+};

--- a/src/controllers/dev/handlePostDevScenario.ts
+++ b/src/controllers/dev/handlePostDevScenario.ts
@@ -1,0 +1,111 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { config } from "../../config.js";
+import { vacationType } from "../../db/schema/vacation-schema.js";
+import {
+  addMember,
+  addVacation,
+  findTeam,
+  generatePassword,
+  seedTeam,
+  seedUser,
+  setQuota,
+  workingDayFromToday,
+  type SeededUser,
+} from "../../services/dev/devSeedServices.js";
+
+export const validatePostDevScenario = z.object({
+  teamName: z.string().min(1).max(120).optional(),
+  ownerEmail: z.email().optional(),
+  password: z.string().min(8).max(256).optional(),
+});
+
+export type ValidatedPostDevScenarioType = z.infer<typeof validatePostDevScenario>;
+
+const MEMBERS = [
+  { local: "alice", name: "Alice Novak" },
+  { local: "bob", name: "Bob Dvorak" },
+  { local: "carol", name: "Carol Svoboda" },
+];
+
+/**
+ * Seeds a whole team the UI can actually be exercised against: an owner who is
+ * also the approver, three members, current-year quotas, and vacations spread
+ * across pending / approved / rejected so every dashboard widget and the
+ * approvals queue have content. Re-running it is a no-op rather than an error.
+ */
+export const handlePostDevScenario = async (req: Request, res: Response) => {
+  const data = req.body as ValidatedPostDevScenarioType;
+  const domain = config.dev?.seedEmailDomain ?? "dev.local";
+
+  const teamName = data.teamName ?? "Dev Team";
+  // One password for the whole team so the response is usable as-is when
+  // signing in through the real form.
+  const password = data.password ?? generatePassword();
+
+  const owner = await seedUser({
+    email: data.ownerEmail ?? `owner@${domain}`,
+    name: "Olivia Owner",
+    password,
+  });
+
+  const team =
+    (await findTeam(owner.id, teamName)) ?? (await seedTeam({ teamName, managerUserId: owner.id }));
+
+  await addMember({ userId: owner.id, groupId: team.id, adminAccess: true });
+  await setQuota({ userId: owner.id, groupId: team.id });
+
+  const members: SeededUser[] = [];
+  for (const member of MEMBERS) {
+    const seeded = await seedUser({
+      email: `${member.local}@${domain}`,
+      name: member.name,
+      password,
+    });
+    await addMember({ userId: seeded.id, groupId: team.id });
+    await setQuota({ userId: seeded.id, groupId: team.id });
+    members.push(seeded);
+  }
+
+  const [alice, bob, carol] = members as [SeededUser, SeededUser, SeededUser];
+
+  const bookings = [
+    { user: owner, day: workingDayFromToday(-21), state: "approved" as const },
+    { user: owner, day: workingDayFromToday(-14), state: "approved" as const },
+    { user: owner, day: workingDayFromToday(7), state: "pending" as const },
+    { user: alice, day: workingDayFromToday(-7), state: "approved" as const },
+    { user: alice, day: workingDayFromToday(3), state: "pending" as const },
+    { user: alice, day: workingDayFromToday(4), state: "pending" as const },
+    { user: bob, day: workingDayFromToday(0), state: "approved" as const },
+    { user: bob, day: workingDayFromToday(10), state: "pending" as const },
+    { user: bob, day: workingDayFromToday(-3), state: "rejected" as const },
+    { user: carol, day: workingDayFromToday(5), state: "approved" as const },
+    {
+      user: carol,
+      day: workingDayFromToday(1),
+      state: "approved" as const,
+      type: vacationType.HomeOffice,
+    },
+  ];
+
+  let created = 0;
+  for (const booking of bookings) {
+    const id = await addVacation({
+      userId: booking.user.id,
+      groupId: team.id,
+      requestedDay: booking.day,
+      state: booking.state,
+      type: booking.type,
+      actorUserId: owner.id,
+    });
+    if (id) created += 1;
+  }
+
+  return res.status(201).json({
+    team,
+    owner,
+    members,
+    vacationsCreated: created,
+    signInUrl: `${config.email.appUrl}/dev-sign-in/?email=${encodeURIComponent(owner.email)}`,
+  });
+};

--- a/src/controllers/dev/handlePostDevSession.ts
+++ b/src/controllers/dev/handlePostDevSession.ts
@@ -1,0 +1,55 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import AppError from "../../utils/appError.js";
+import { findUserByEmail } from "../../services/dev/devSeedServices.js";
+import {
+  SESSION_COOKIE_NAME,
+  createSessionToken,
+  signSessionToken,
+} from "../../utils/devSession.js";
+
+export const validatePostDevSession = z.object({
+  email: z.email(),
+});
+
+export type ValidatedPostDevSessionType = z.infer<typeof validatePostDevSession>;
+
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Signs the caller in as an existing local user: sets the session cookie on the
+ * response (the browser path) and returns the same value in the body (the
+ * cookie-injection path for a test driver).
+ */
+export const handlePostDevSession = async (req: Request, res: Response) => {
+  const { email } = req.body as ValidatedPostDevSessionType;
+
+  const found = await findUserByEmail(email);
+  if (!found) {
+    throw new AppError({
+      message: "No such user in the local database",
+      code: 404,
+      publicContext: { email },
+    });
+  }
+
+  const token = await createSessionToken(found.id);
+  const signed = signSessionToken(token);
+
+  res.cookie(SESSION_COOKIE_NAME, signed, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: SESSION_TTL_MS,
+    // Raw value: better-auth reads the cookie unencoded, and percent-encoding
+    // the base64 signature would break verification.
+    encode: (value) => value,
+  });
+
+  return res.status(200).json({
+    user: { id: found.id, email: found.email, name: found.name },
+    cookieName: SESSION_COOKIE_NAME,
+    cookieValue: signed,
+    cookieHeader: `${SESSION_COOKIE_NAME}=${signed}`,
+  });
+};

--- a/src/controllers/dev/handlePostDevUser.ts
+++ b/src/controllers/dev/handlePostDevUser.ts
@@ -1,0 +1,42 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import {
+  addMember,
+  findTeam,
+  seedTeam,
+  seedUser,
+  setQuota,
+} from "../../services/dev/devSeedServices.js";
+
+export const validatePostDevUser = z.object({
+  email: z.email(),
+  name: z.string().min(1).max(120).optional(),
+  password: z.string().min(8).max(256).optional(),
+  teamName: z.string().min(1).max(120).optional(),
+});
+
+export type ValidatedPostDevUserType = z.infer<typeof validatePostDevUser>;
+
+export const handlePostDevUser = async (req: Request, res: Response) => {
+  const data = req.body as ValidatedPostDevUserType;
+
+  const seeded = await seedUser({
+    email: data.email,
+    name: data.name,
+    password: data.password,
+  });
+
+  let team: { id: string; groupName: string } | undefined;
+  if (data.teamName) {
+    team =
+      (await findTeam(seeded.id, data.teamName)) ??
+      (await seedTeam({
+        teamName: data.teamName,
+        managerUserId: seeded.id,
+      }));
+    await addMember({ userId: seeded.id, groupId: team.id, adminAccess: true });
+    await setQuota({ userId: seeded.id, groupId: team.id });
+  }
+
+  return res.status(201).json({ user: seeded, team: team ?? null });
+};

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -5,7 +5,7 @@ import { config } from "../config.js";
 // better-auth uses for CSRF protection), e.g. the CloudFront frontend URLs.
 const allowedOrigins =
   config.api.env === "production"
-    ? (config.auth?.trustedOrigins ?? [])
+    ? config.auth?.trustedOrigins ?? []
     : [/^http:\/\/localhost:(\d{2,5})$/];
 
 export const serverCors = cors({
@@ -13,7 +13,15 @@ export const serverCors = cors({
   methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
   // `sentry-trace` and `baggage` let the frontend propagate its trace context
   // to the backend for distributed tracing (Sentry).
-  allowedHeaders: ["Content-Type", "Authorization", "sentry-trace", "baggage"],
+  // `x-dev-token` is only accepted outside production, where the local dev
+  // routes exist and the frontend's dev sign-in page needs the preflight to pass.
+  allowedHeaders: [
+    "Content-Type",
+    "Authorization",
+    "sentry-trace",
+    "baggage",
+    ...(config.api.env === "production" ? [] : ["x-dev-token"]),
+  ],
   // The report export sends its filename here; without exposing it the SPA
   // cannot read the header off the cross-origin response.
   exposedHeaders: ["Content-Disposition"],

--- a/src/middleware/devGuard.ts
+++ b/src/middleware/devGuard.ts
@@ -1,0 +1,43 @@
+import type { NextFunction, Request, Response } from "express";
+import crypto from "crypto";
+import { config } from "../config.js";
+import AppError from "../utils/appError.js";
+import { logger } from "./logger.js";
+
+const LOOPBACK_PEERS = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
+
+const tokensMatch = (received: string, expected: string): boolean => {
+  const a = Buffer.from(received);
+  const b = Buffer.from(expected);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+};
+
+/**
+ * Gate for `/api/dev/*`. The router is only mounted when `config.dev` exists,
+ * so this is the second line of defence rather than the first.
+ *
+ * The peer is read off the socket instead of `req.ip` on purpose: `trust proxy`
+ * is enabled, so `req.ip` follows a client-supplied `X-Forwarded-For` and would
+ * be trivially spoofable. Non-loopback callers get a 404 — no hint that the
+ * surface exists at all.
+ */
+export const devGuard = (req: Request, _res: Response, next: NextFunction) => {
+  const dev = config.dev;
+  if (!dev) {
+    return next(new AppError({ message: "Not found", code: 404 }));
+  }
+
+  const peer = req.socket.remoteAddress ?? "";
+  if (!LOOPBACK_PEERS.has(peer)) {
+    logger.warn("devGuard rejected non-loopback request", { peer, path: req.path });
+    return next(new AppError({ message: "Not found", code: 404 }));
+  }
+
+  if (!tokensMatch(req.get("x-dev-token") ?? "", dev.token)) {
+    return next(
+      new AppError({ message: "Invalid dev token", code: 401, logging: true, context: { peer } })
+    );
+  }
+
+  return next();
+};

--- a/src/routes/devRouter.ts
+++ b/src/routes/devRouter.ts
@@ -1,0 +1,47 @@
+import { Router } from "express";
+import { tryCatch } from "../middleware/tryCatch.js";
+import { devGuard } from "../middleware/devGuard.js";
+import { bodyValidationMiddleware } from "../middleware/validationMiddleware.js";
+import { handleGetDevStatus } from "../controllers/dev/handleGetDevStatus.js";
+import { handlePostDevUser, validatePostDevUser } from "../controllers/dev/handlePostDevUser.js";
+import {
+  handlePostDevSession,
+  validatePostDevSession,
+} from "../controllers/dev/handlePostDevSession.js";
+import {
+  handlePostDevScenario,
+  validatePostDevScenario,
+} from "../controllers/dev/handlePostDevScenario.js";
+import { handlePostDevReset } from "../controllers/dev/handlePostDevReset.js";
+
+/**
+ * Local-only seeding and impersonation surface, mounted by `server.ts` only
+ * when `config.dev` exists (see `parseDevTools` for the environment gates).
+ * `devGuard` additionally requires a loopback peer and the shared dev token on
+ * every request. These routes are deliberately absent from the public API docs.
+ */
+export const devRouter = (): Router => {
+  const app = Router();
+
+  app.use(devGuard);
+
+  app.get("/status", tryCatch(handleGetDevStatus));
+
+  app.post("/users", bodyValidationMiddleware(validatePostDevUser), tryCatch(handlePostDevUser));
+
+  app.post(
+    "/session",
+    bodyValidationMiddleware(validatePostDevSession),
+    tryCatch(handlePostDevSession)
+  );
+
+  app.post(
+    "/scenario",
+    bodyValidationMiddleware(validatePostDevScenario),
+    tryCatch(handlePostDevScenario)
+  );
+
+  app.post("/reset", tryCatch(handlePostDevReset));
+
+  return app;
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import { calendarSyncRouter } from "./routes/calendarSyncRouter.js";
 import { reportRouter } from "./routes/reportRouter.js";
 import { tryCatch } from "./middleware/tryCatch.js";
 import { handleGetCalendarFeed } from "./controllers/calendarSync/handleGetCalendarFeed.js";
+import { devRouter } from "./routes/devRouter.js";
 
 export const createServer = () => {
   const app = express();
@@ -33,6 +34,13 @@ export const createServer = () => {
   app.use("/api/auth", authExtRouter());
 
   app.all("/api/auth/{*any}", toNodeHandler(auth)).use(express.json());
+
+  // Local seeding/impersonation routes. `config.dev` is undefined unless the
+  // environment explicitly opts in on a local database, so in every deployed
+  // environment this branch never runs and the routes simply do not exist.
+  if (config.dev) {
+    app.use("/api/dev", devRouter());
+  }
 
   app.use("/api/vacation", authSession, vacationRouter());
   app.use("/api/group", authSession, groupRouter());

--- a/src/services/dev/devSeedServices.ts
+++ b/src/services/dev/devSeedServices.ts
@@ -1,0 +1,316 @@
+import crypto from "crypto";
+import { and, eq, inArray, or, sql } from "drizzle-orm";
+import { hashPassword } from "better-auth/crypto";
+import { db } from "../../db/db.js";
+import { account, user } from "../../db/schema/auth-schema.js";
+import { groups } from "../../db/schema/group-schema.js";
+import { changesSchema } from "../../db/schema/changes-schema.js";
+import { vacation, vacationType } from "../../db/schema/vacation-schema.js";
+import { vacationEvents, vacationEventType } from "../../db/schema/vacation-event-schema.js";
+import { createDBServices } from "../DBServices.js";
+import { generateRandomUUID } from "../../utils/generateUUID.js";
+import { formatDateToISOString } from "../../utils/dateFunc.js";
+import AppError from "../../utils/appError.js";
+import { config } from "../../config.js";
+
+const services = createDBServices();
+
+export type SeededUser = {
+  id: string;
+  email: string;
+  name: string;
+  password: string;
+  created: boolean;
+};
+
+const devDomain = (): string => {
+  if (!config.dev) throw new AppError({ message: "Dev tools are disabled", code: 404 });
+  return config.dev.seedEmailDomain;
+};
+
+/**
+ * Seeded accounts are confined to one domain so that reset has an exact,
+ * verifiable scope — it can never reach an account a developer created by hand.
+ */
+export const assertSeedEmail = (email: string): void => {
+  const domain = devDomain();
+  if (!email.toLowerCase().endsWith(`@${domain}`)) {
+    throw new AppError({
+      message: `Dev seeding is limited to @${domain} addresses`,
+      code: 400,
+      publicContext: { email, allowedDomain: domain },
+    });
+  }
+};
+
+/** Strong enough that better-auth's pwned-password check would pass it too. */
+export const generatePassword = (): string => `Dev-${crypto.randomBytes(9).toString("base64url")}`;
+
+/**
+ * Creates a verified, sign-in-ready user without going through
+ * `auth.api.signUpEmail`. That path runs the haveIBeenPwned plugin (an outbound
+ * HTTPS call that fails offline) and fires a verification email into SES, both
+ * useless locally. Hashing with better-auth's own `hashPassword` keeps the
+ * credentials valid through the real sign-in form.
+ */
+export const seedUser = async (input: {
+  email: string;
+  name?: string;
+  password?: string;
+}): Promise<SeededUser> => {
+  assertSeedEmail(input.email);
+
+  const email = input.email.toLowerCase();
+  const name = input.name ?? email.split("@")[0]!;
+  const password = input.password ?? generatePassword();
+
+  const [existing] = await db.select().from(user).where(eq(user.email, email)).limit(1);
+  if (existing) {
+    // Re-point the credential at the password we are about to report. Without
+    // this, re-running the seeder hands back a password that does not open the
+    // account it names.
+    await db
+      .update(account)
+      .set({ password: await hashPassword(password), updatedAt: new Date() })
+      .where(and(eq(account.userId, existing.id), eq(account.providerId, "credential")));
+
+    return {
+      id: existing.id,
+      email: existing.email,
+      name: existing.name,
+      password,
+      created: false,
+    };
+  }
+
+  const userId = generateRandomUUID();
+  await db.transaction(async (tx) => {
+    await tx.insert(user).values({
+      id: userId,
+      email,
+      name,
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await tx.insert(account).values({
+      id: generateRandomUUID(),
+      accountId: userId,
+      providerId: "credential",
+      userId,
+      password: await hashPassword(password),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  });
+
+  return { id: userId, email, name, password, created: true };
+};
+
+export const seedTeam = async (input: {
+  teamName: string;
+  managerUserId: string;
+}): Promise<{ id: string; groupName: string }> => {
+  const group = await services.group.createGroup({
+    id: generateRandomUUID(),
+    groupName: input.teamName,
+    managerUserId: input.managerUserId,
+    mainApprovalUser: input.managerUserId,
+  });
+
+  if (!group) {
+    throw new AppError({ message: "Failed to create dev team", code: 500, logging: true });
+  }
+
+  return { id: group.id, groupName: group.groupName };
+};
+
+/** Lets the scenario seeder be re-run without stacking up duplicate teams. */
+export const findTeam = async (
+  managerUserId: string,
+  groupName: string
+): Promise<{ id: string; groupName: string } | undefined> => {
+  const [row] = await db
+    .select({ id: groups.id, groupName: groups.groupName })
+    .from(groups)
+    .where(and(eq(groups.managerUserId, managerUserId), eq(groups.groupName, groupName)))
+    .limit(1);
+  return row;
+};
+
+export const addMember = async (input: {
+  userId: string;
+  groupId: string;
+  adminAccess?: boolean;
+}): Promise<void> => {
+  await services.groupUser.createGroupUser({
+    id: generateRandomUUID(),
+    userId: input.userId,
+    groupId: input.groupId,
+    viewAccess: true,
+    adminAccess: input.adminAccess ?? false,
+    controlledUser: true,
+  });
+};
+
+export const setQuota = async (input: {
+  userId: string;
+  groupId: string;
+  year?: string;
+  vacationDays?: number;
+  homeOfficeDays?: number;
+  carriedOverDays?: number;
+}): Promise<void> => {
+  await services.userYearQuotas.upsertUserYearQuota({
+    id: generateRandomUUID(),
+    userId: input.userId,
+    groupId: input.groupId,
+    relatedYear: input.year ?? String(new Date().getUTCFullYear()),
+    vacationDays: input.vacationDays ?? 25,
+    homeOfficeDays: input.homeOfficeDays ?? 10,
+    carriedOverDays: input.carriedOverDays ?? 3,
+  });
+};
+
+type VacationState = "pending" | "approved" | "rejected";
+
+export const addVacation = async (input: {
+  userId: string;
+  groupId: string;
+  requestedDay: string;
+  state: VacationState;
+  type?: vacationType;
+  actorUserId?: string;
+  note?: string;
+}): Promise<string | undefined> => {
+  const id = generateRandomUUID();
+  const now = new Date();
+
+  const [row] = await db
+    .insert(vacation)
+    .values({
+      id,
+      userId: input.userId,
+      groupId: input.groupId,
+      requestedDay: input.requestedDay,
+      vacationType: input.type ?? vacationType.Vacation,
+      note: input.note,
+      approvedAt: input.state === "approved" ? now : null,
+      approvedBy: input.state === "approved" ? input.actorUserId ?? null : null,
+      rejectedAt: input.state === "rejected" ? now : null,
+      rejectedBy: input.state === "rejected" ? input.actorUserId ?? null : null,
+      rejectionReason: input.state === "rejected" ? "Team coverage on that day" : null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    // The (user, day) uniqueness makes re-seeding over existing data a no-op
+    // rather than an error.
+    .onConflictDoNothing()
+    .returning();
+
+  if (!row) return undefined;
+
+  const events: (typeof vacationEvents.$inferInsert)[] = [
+    {
+      id: generateRandomUUID(),
+      vacationId: id,
+      eventType: vacationEventType.Created,
+      actorUserId: input.userId,
+      createdAt: now,
+    },
+  ];
+  if (input.state === "approved") {
+    events.push({
+      id: generateRandomUUID(),
+      vacationId: id,
+      eventType: vacationEventType.Approved,
+      actorUserId: input.actorUserId ?? input.userId,
+      createdAt: now,
+    });
+  }
+  if (input.state === "rejected") {
+    events.push({
+      id: generateRandomUUID(),
+      vacationId: id,
+      eventType: vacationEventType.Rejected,
+      actorUserId: input.actorUserId ?? input.userId,
+      reason: "Team coverage on that day",
+      createdAt: now,
+    });
+  }
+  await db.insert(vacationEvents).values(events);
+
+  return id;
+};
+
+/** ISO date `offset` days from today (UTC), skipped forward off weekends. */
+export const workingDayFromToday = (offset: number): string => {
+  const date = new Date();
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCDate(date.getUTCDate() + offset);
+  while (date.getUTCDay() === 0 || date.getUTCDay() === 6) {
+    date.setUTCDate(date.getUTCDate() + (offset < 0 ? -1 : 1));
+  }
+  return formatDateToISOString(date);
+};
+
+export type ResetSummary = { users: number; groups: number };
+
+/**
+ * Deletes only seeded data. Groups go first because `groups.manager_user_id`
+ * and the approval columns reference `user` without a cascade, as do
+ * `changes.changing_user_id`; everything else hangs off one of those two
+ * deletes via ON DELETE CASCADE.
+ */
+export const resetDevData = async (): Promise<ResetSummary> => {
+  const domain = devDomain();
+  const devUsers = await db
+    .select({ id: user.id })
+    .from(user)
+    .where(sql`lower(${user.email}) like ${`%@${domain}`}`);
+
+  if (devUsers.length === 0) return { users: 0, groups: 0 };
+
+  const ids = devUsers.map((row) => row.id);
+
+  return db.transaction(async (tx) => {
+    await tx.delete(changesSchema).where(inArray(changesSchema.changingUserId, ids));
+
+    const deletedGroups = await tx
+      .delete(groups)
+      .where(
+        or(
+          inArray(groups.managerUserId, ids),
+          inArray(groups.mainApprovalUser, ids),
+          inArray(groups.tempApprovalUser, ids)
+        )
+      )
+      .returning({ id: groups.id });
+
+    const deletedUsers = await tx
+      .delete(user)
+      .where(inArray(user.id, ids))
+      .returning({ id: user.id });
+
+    return { users: deletedUsers.length, groups: deletedGroups.length };
+  });
+};
+
+export const countSeededUsers = async (): Promise<number> => {
+  const domain = devDomain();
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(user)
+    .where(sql`lower(${user.email}) like ${`%@${domain}`}`);
+  return row?.count ?? 0;
+};
+
+export const findUserByEmail = async (email: string) => {
+  const [row] = await db
+    .select()
+    .from(user)
+    .where(and(eq(user.email, email.toLowerCase())))
+    .limit(1);
+  return row;
+};

--- a/src/tests/config.devTools.test.ts
+++ b/src/tests/config.devTools.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The environment gates that decide whether the local `/api/dev/*` surface can
+ * exist at all. Test library/framework: Vitest
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const TOKEN = "local-dev-token-0123456789";
+
+const ORIGINAL_ENV = { ...process.env };
+
+/** Config is evaluated once at import, so each case needs a fresh module graph. */
+const loadConfig = async (env: Record<string, string | undefined>) => {
+  process.env = { ...ORIGINAL_ENV, ...env };
+  vi.resetModules();
+  const mod = await import("../config.js");
+  return (mod as { config: { dev?: { token: string; seedEmailDomain: string } } }).config;
+};
+
+// Every dev var is pinned: config.ts calls dotenv, which would otherwise fill
+// unset ones in from the developer's own `.env` and change what is under test.
+const BASE = {
+  PORT: "8080",
+  DATABASE: "postgres://localhost:5432/flexi-day",
+  BETTER_AUTH_SECRET: "secret",
+  BETTER_AUTH_URL: "http://localhost:8080",
+  DEV_TOOLS_ENABLED: "false",
+  DEV_TOOLS_TOKEN: "",
+  DEV_SEED_EMAIL_DOMAIN: "dev.local",
+};
+
+describe("config dev tools gate", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("is off unless explicitly enabled", async () => {
+    const config = await loadConfig({ ...BASE, NODE_ENV: "dev" });
+    expect(config.dev).toBeUndefined();
+  });
+
+  it("is off when the flag is anything other than the literal true", async () => {
+    const config = await loadConfig({ ...BASE, NODE_ENV: "dev", DEV_TOOLS_ENABLED: "1" });
+    expect(config.dev).toBeUndefined();
+  });
+
+  it("refuses to start in production even when enabled", async () => {
+    await expect(
+      loadConfig({
+        ...BASE,
+        NODE_ENV: "production",
+        DEV_TOOLS_ENABLED: "true",
+        DEV_TOOLS_TOKEN: TOKEN,
+      })
+    ).rejects.toThrow(/never be set when NODE_ENV=production/);
+  });
+
+  it("refuses a non-local database", async () => {
+    await expect(
+      loadConfig({
+        ...BASE,
+        NODE_ENV: "dev",
+        DATABASE: "postgres://db.example.com:5432/flexi-day",
+        DEV_TOOLS_ENABLED: "true",
+        DEV_TOOLS_TOKEN: TOKEN,
+      })
+    ).rejects.toThrow(/is not local/);
+  });
+
+  it("refuses a missing or too-short token", async () => {
+    await expect(
+      loadConfig({ ...BASE, NODE_ENV: "dev", DEV_TOOLS_ENABLED: "true" })
+    ).rejects.toThrow(/DEV_TOOLS_TOKEN/);
+
+    await expect(
+      loadConfig({
+        ...BASE,
+        NODE_ENV: "dev",
+        DEV_TOOLS_ENABLED: "true",
+        DEV_TOOLS_TOKEN: "short",
+      })
+    ).rejects.toThrow(/at least 16 characters/);
+  });
+
+  it("enables on a local database with a valid token", async () => {
+    const config = await loadConfig({
+      ...BASE,
+      NODE_ENV: "dev",
+      DEV_TOOLS_ENABLED: "true",
+      DEV_TOOLS_TOKEN: TOKEN,
+    });
+    expect(config.dev).toEqual({ token: TOKEN, seedEmailDomain: "dev.local" });
+  });
+});

--- a/src/tests/e2e/helpers/authHelper.ts
+++ b/src/tests/e2e/helpers/authHelper.ts
@@ -1,39 +1,18 @@
-import { db } from "../../../db/db.js";
-import { session } from "../../../db/schema/auth-schema.js";
-import { v4 as uuidv4 } from "uuid";
-import { eq } from "drizzle-orm";
-import crypto from "crypto";
+import {
+  createSessionToken,
+  deleteSessionByToken,
+  sessionCookieHeader,
+} from "../../../utils/devSession.js";
+
+// Thin aliases over the shared session helpers so the e2e suite and the local
+// dev routes cannot drift apart on cookie signing.
 
 export async function createTestSession(userId: string): Promise<string> {
-  const sessionToken = crypto.randomBytes(32).toString("hex");
-  const sessionId = uuidv4();
-  const expiresAt = new Date();
-  expiresAt.setDate(expiresAt.getDate() + 7);
-
-  await db.insert(session).values({
-    id: sessionId,
-    userId,
-    token: sessionToken,
-    expiresAt,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-
-  return sessionToken;
+  return createSessionToken(userId);
 }
 
-/**
- * better-auth rejects an unsigned session cookie, so the token has to carry
- * the same HMAC the server would have attached at sign-in: standard base64
- * (not base64url) of HMAC-SHA256(secret, token), appended after a dot.
- */
 export function createAuthCookie(sessionToken: string): string {
-  const secret = process.env.BETTER_AUTH_SECRET;
-  if (!secret) throw new Error("BETTER_AUTH_SECRET is required to sign a test session cookie");
-
-  const signature = crypto.createHmac("sha256", secret).update(sessionToken).digest("base64");
-
-  return `better-auth.session_token=${sessionToken}.${signature}`;
+  return sessionCookieHeader(sessionToken);
 }
 
 /** Creates a session for the user and returns the ready-to-send Cookie header. */
@@ -42,5 +21,5 @@ export async function authCookieFor(userId: string): Promise<string> {
 }
 
 export async function deleteTestSession(sessionToken: string) {
-  await db.delete(session).where(eq(session.token, sessionToken));
+  await deleteSessionByToken(sessionToken);
 }

--- a/src/tests/middleware/devGuard.test.ts
+++ b/src/tests/middleware/devGuard.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the devGuard middleware.
+ * Test library/framework: Vitest
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+
+vi.mock("../../config.js", () => ({
+  config: { dev: undefined as { token: string; seedEmailDomain: string } | undefined },
+}));
+
+vi.mock("../../middleware/logger.js", () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+import { devGuard } from "../../middleware/devGuard.js";
+import { config } from "../../config.js";
+import AppError from "../../utils/appError.js";
+
+const TOKEN = "local-dev-token-0123456789";
+
+const makeReq = (peer: string | undefined, token?: string): Request =>
+  ({
+    socket: { remoteAddress: peer },
+    path: "/status",
+    get: (name: string) => (name === "x-dev-token" ? token : undefined),
+  } as unknown as Request);
+
+const run = (req: Request) => {
+  const next = vi.fn() as unknown as NextFunction & { mock: { calls: unknown[][] } };
+  devGuard(req, {} as Response, next);
+  return next;
+};
+
+const errorFrom = (next: { mock: { calls: unknown[][] } }): AppError =>
+  next.mock.calls[0]![0] as AppError;
+
+describe("devGuard", () => {
+  beforeEach(() => {
+    (config as { dev?: { token: string; seedEmailDomain: string } }).dev = {
+      token: TOKEN,
+      seedEmailDomain: "dev.local",
+    };
+  });
+
+  it("passes a loopback request carrying the right token", () => {
+    const next = run(makeReq("127.0.0.1", TOKEN));
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("accepts IPv6 loopback forms", () => {
+    for (const peer of ["::1", "::ffff:127.0.0.1"]) {
+      expect(run(makeReq(peer, TOKEN))).toHaveBeenCalledWith();
+    }
+  });
+
+  it("404s when dev tools are disabled", () => {
+    (config as { dev?: unknown }).dev = undefined;
+    const error = errorFrom(run(makeReq("127.0.0.1", TOKEN)));
+    expect(error.statusCode).toBe(404);
+  });
+
+  it("404s a non-loopback peer even with a valid token", () => {
+    const error = errorFrom(run(makeReq("10.0.0.5", TOKEN)));
+    expect(error.statusCode).toBe(404);
+  });
+
+  it("ignores X-Forwarded-For and judges the socket peer only", () => {
+    const req = makeReq("10.0.0.5", TOKEN);
+    (req as unknown as { headers: Record<string, string> }).headers = {
+      "x-forwarded-for": "127.0.0.1",
+    };
+    expect(errorFrom(run(req)).statusCode).toBe(404);
+  });
+
+  it("401s a missing or wrong token from loopback", () => {
+    expect(errorFrom(run(makeReq("127.0.0.1"))).statusCode).toBe(401);
+    expect(errorFrom(run(makeReq("127.0.0.1", "wrong"))).statusCode).toBe(401);
+    expect(errorFrom(run(makeReq("127.0.0.1", `${TOKEN}x`))).statusCode).toBe(401);
+  });
+});

--- a/src/utils/devSession.ts
+++ b/src/utils/devSession.ts
@@ -1,0 +1,50 @@
+import crypto from "crypto";
+import { eq } from "drizzle-orm";
+import { db } from "../db/db.js";
+import { session } from "../db/schema/auth-schema.js";
+import { generateRandomUUID } from "./generateUUID.js";
+
+export const SESSION_COOKIE_NAME = "better-auth.session_token";
+
+const SESSION_TTL_DAYS = 7;
+
+/** Inserts a session row directly and returns its raw (unsigned) token. */
+export async function createSessionToken(userId: string): Promise<string> {
+  const token = crypto.randomBytes(32).toString("hex");
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + SESSION_TTL_DAYS);
+
+  await db.insert(session).values({
+    id: generateRandomUUID(),
+    userId,
+    token,
+    expiresAt,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  return token;
+}
+
+/**
+ * better-auth rejects an unsigned session cookie, so the token has to carry the
+ * same HMAC the server would have attached at sign-in: standard base64 (not
+ * base64url) of HMAC-SHA256(secret, token), appended after a dot.
+ */
+export function signSessionToken(token: string): string {
+  const secret = process.env.BETTER_AUTH_SECRET;
+  if (!secret) throw new Error("BETTER_AUTH_SECRET is required to sign a session cookie");
+
+  const signature = crypto.createHmac("sha256", secret).update(token).digest("base64");
+
+  return `${token}.${signature}`;
+}
+
+/** Full `name=value` cookie string, ready to send as a `Cookie` header. */
+export function sessionCookieHeader(token: string): string {
+  return `${SESSION_COOKIE_NAME}=${signSessionToken(token)}`;
+}
+
+export async function deleteSessionByToken(token: string): Promise<void> {
+  await db.delete(session).where(eq(session.token, token));
+}


### PR DESCRIPTION
## Why

Getting an authenticated session against the local stack was a manual hack: `curl` the sign-up endpoint, then flip `email_verified` with `psql`. Email verification goes through SES, which does nothing on a dev machine.

## What

`/api/dev/*` — `status`, `users`, `session`, `scenario`, `reset` — seeds verified users, teams, quotas and vacations, and issues better-auth session cookies.

Users are created by inserting `user` + `account` rows with better-auth's own `hashPassword` rather than through `signUpEmail`, which runs the haveIBeenPwned check (an outbound call that fails offline) and fires a verification email. The seeded credentials still work through the real sign-in form — verified.

Session-cookie signing moves out of `src/tests/e2e/helpers/authHelper.ts` into `src/utils/devSession.ts`, so the e2e suite and the dev routes share one implementation.

## Safety

Five independent gates; any one failing means the surface does not exist:

1. `server.ts` mounts the router only when `config.dev` is defined
2. config **throws at startup** if `DEV_TOOLS_ENABLED=true` with `NODE_ENV=production`
3. config **throws** if `DATABASE` does not point at localhost
4. `devGuard` requires a loopback `socket.remoteAddress` — deliberately *not* `req.ip`, which follows the spoofable `X-Forwarded-For` because `trust proxy` is on
5. `devGuard` requires a timing-safe `x-dev-token` match

Seeding and `reset` are confined to `DEV_SEED_EMAIL_DOMAIN` (default `dev.local`) — no unscoped delete.

### Verified, not just asserted

| Check | Result |
|---|---|
| `DEV_TOOLS_ENABLED=false` | `/api/dev/status` → 404, `/health` → 200 |
| Wrong / missing token from loopback | 401 |
| Real off-loopback request with valid token **and** spoofed `X-Forwarded-For: 127.0.0.1` | 404 (while `/health` on the same interface returned 200) |
| `NODE_ENV=production` + flag on | refuses to boot |
| Flag on + remote `DATABASE` | refuses to boot |

## Tests

- 188 unit tests pass, including new coverage for the guard (loopback forms, XFF spoofing, token mismatch) and the config gates
- 70 e2e tests pass against the Docker test DB — run because this PR refactors a helper the suite depends on
- `npm run build` and `npm run lint` clean (the two pre-existing warnings in `appError.ts` / `vitest.e2e.config.ts` are untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional local development tools for creating users, teams, sample vacation data, and authenticated sessions.
  * Added status and reset actions for inspecting and clearing seeded development data.
  * Added configurable local development settings, including access token and seeded email domain.
* **Security**
  * Development tools are disabled by default and restricted to local requests with token authentication.
  * Production environments and non-local databases cannot enable the development tools.
* **Bug Fixes**
  * Improved test authentication utilities by using shared session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->