### PR TITLE
feat: optional group at sign-up, email invites, and group mirroring

### DIFF
--- a/src/controllers/auth/handleSignUpWithTeam.ts
+++ b/src/controllers/auth/handleSignUpWithTeam.ts
@@ -16,7 +16,15 @@ export const validateSignUpWithTeam = z.object({
   name: z.string().min(1).max(120),
   email: z.email(),
   password: z.string().min(8).max(256),
-  teamName: z.string().min(1).max(120),
+  // Optional: an account may exist with no group at all. Without one the user
+  // simply cannot book time off until they create or join a group — booking is
+  // authorized per-membership in `handlePostVacation`.
+  teamName: z
+    .string()
+    .max(120)
+    .transform((value) => value.trim())
+    .optional()
+    .transform((value) => (value ? value : undefined)),
 });
 
 export type ValidatedSignUpWithTeamType = z.infer<typeof validateSignUpWithTeam>;
@@ -91,51 +99,11 @@ export const handleSignUpWithTeam = async (req: Request, res: Response) => {
     });
   }
 
-  let group;
+  const teamName = data.teamName;
+
+  let group = null;
   try {
-    group = await db.transaction(async (tx) => {
-      const newGroup = await services.group.createGroup(
-        {
-          id: generateRandomUUID(),
-          groupName: data.teamName,
-          managerUserId: userId,
-          mainApprovalUser: userId,
-        },
-        tx
-      );
-
-      if (!newGroup) {
-        throw new AppError({
-          message: "Failed to create team for new user",
-          logging: true,
-          code: 500,
-          context: { userId, teamName: data.teamName },
-        });
-      }
-
-      const membership = await services.groupUser.createGroupUser(
-        {
-          id: generateRandomUUID(),
-          userId,
-          groupId: newGroup.id,
-          viewAccess: true,
-          adminAccess: true,
-          controlledUser: true,
-        },
-        tx
-      );
-
-      if (!membership) {
-        throw new AppError({
-          message: "Failed to attach new user to their team",
-          logging: true,
-          code: 500,
-          context: { userId, groupId: newGroup.id },
-        });
-      }
-
-      return newGroup;
-    });
+    group = teamName === undefined ? null : await createTeamForUser(userId, teamName);
   } catch (err) {
     await rollbackAuthUser(userId, data.email);
     throw err;
@@ -148,9 +116,9 @@ export const handleSignUpWithTeam = async (req: Request, res: Response) => {
     res.appendHeader(key, value);
   });
 
-  logger.info("sign-up-with-team completed", {
+  logger.info("sign-up completed", {
     userId,
-    groupId: group.id,
+    groupId: group?.id ?? null,
   });
 
   return res.status(201).json({
@@ -159,3 +127,48 @@ export const handleSignUpWithTeam = async (req: Request, res: Response) => {
     group,
   });
 };
+
+const createTeamForUser = async (userId: string, teamName: string) =>
+  db.transaction(async (tx) => {
+    const newGroup = await services.group.createGroup(
+      {
+        id: generateRandomUUID(),
+        groupName: teamName,
+        managerUserId: userId,
+        mainApprovalUser: userId,
+      },
+      tx
+    );
+
+    if (!newGroup) {
+      throw new AppError({
+        message: "Failed to create team for new user",
+        logging: true,
+        code: 500,
+        context: { userId, teamName },
+      });
+    }
+
+    const membership = await services.groupUser.createGroupUser(
+      {
+        id: generateRandomUUID(),
+        userId,
+        groupId: newGroup.id,
+        viewAccess: true,
+        adminAccess: true,
+        controlledUser: true,
+      },
+      tx
+    );
+
+    if (!membership) {
+      throw new AppError({
+        message: "Failed to attach new user to their team",
+        logging: true,
+        code: 500,
+        context: { userId, groupId: newGroup.id },
+      });
+    }
+
+    return newGroup;
+  });

--- a/src/controllers/auth/tests/handleSignUpWithTeam.test.ts
+++ b/src/controllers/auth/tests/handleSignUpWithTeam.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockSignUpEmail, mockCreateGroup, mockCreateGroupUser, mockDelete } = vi.hoisted(() => ({
+  mockSignUpEmail: vi.fn(),
+  mockCreateGroup: vi.fn(),
+  mockCreateGroupUser: vi.fn(),
+  mockDelete: vi.fn(),
+}));
+
+vi.mock("../../../utils/auth.js", () => ({
+  auth: { api: { signUpEmail: mockSignUpEmail } },
+}));
+
+vi.mock("better-auth/node", () => ({ fromNodeHeaders: () => ({}) }));
+
+vi.mock("../../../db/db.js", () => ({
+  db: {
+    transaction: vi.fn((callback) => callback({})),
+    delete: mockDelete,
+  },
+}));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    group: { createGroup: mockCreateGroup },
+    groupUser: { createGroupUser: mockCreateGroupUser },
+  }),
+}));
+
+import { handleSignUpWithTeam, validateSignUpWithTeam } from "../handleSignUpWithTeam.js";
+import { makeReqRes } from "../../../tests/testUtils.js";
+
+const NEW_USER = { id: "user-1", name: "Dana Holt", email: "dana@northwind.co" };
+
+const okSignUp = () => ({
+  ok: true,
+  status: 200,
+  headers: new Headers(),
+  json: () => Promise.resolve({ user: NEW_USER, token: "tok" }),
+});
+
+const body = (extra: Record<string, unknown> = {}) => ({
+  name: "Dana Holt",
+  email: "dana@northwind.co",
+  password: "supersecret",
+  ...extra,
+});
+
+const makeReq = (raw: Record<string, unknown>) => {
+  const parsed = validateSignUpWithTeam.parse(raw);
+  const { req, res } = makeReqRes({ body: parsed });
+  (req as unknown as { headers: object }).headers = {};
+  return { req, res };
+};
+
+describe("validateSignUpWithTeam", () => {
+  it("accepts a payload with no teamName", () => {
+    expect(validateSignUpWithTeam.parse(body()).teamName).toBeUndefined();
+  });
+
+  it("treats a blank teamName as absent", () => {
+    expect(validateSignUpWithTeam.parse(body({ teamName: "   " })).teamName).toBeUndefined();
+  });
+
+  it("keeps a real teamName", () => {
+    expect(validateSignUpWithTeam.parse(body({ teamName: "Platform" })).teamName).toBe("Platform");
+  });
+});
+
+describe("handleSignUpWithTeam", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSignUpEmail.mockResolvedValue(okSignUp());
+    mockCreateGroup.mockResolvedValue({ id: "group-1", groupName: "Platform" });
+    mockCreateGroupUser.mockResolvedValue({ id: "membership-1" });
+    mockDelete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+  });
+
+  it("creates an account with no group when teamName is omitted", async () => {
+    const { req, res } = makeReq(body());
+
+    await handleSignUpWithTeam(req, res);
+
+    expect(mockCreateGroup).not.toHaveBeenCalled();
+    expect(mockCreateGroupUser).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ group: null }));
+  });
+
+  it("still creates the group when a teamName is supplied", async () => {
+    const { req, res } = makeReq(body({ teamName: "Platform" }));
+
+    await handleSignUpWithTeam(req, res);
+
+    expect(mockCreateGroup).toHaveBeenCalledWith(
+      expect.objectContaining({ groupName: "Platform", managerUserId: NEW_USER.id }),
+      expect.anything()
+    );
+    expect(mockCreateGroupUser).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: NEW_USER.id, adminAccess: true, controlledUser: true }),
+      expect.anything()
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ group: { id: "group-1", groupName: "Platform" } })
+    );
+  });
+
+  it("rolls the auth user back when group creation fails", async () => {
+    mockCreateGroup.mockResolvedValue(undefined);
+    const { req, res } = makeReq(body({ teamName: "Platform" }));
+
+    await expect(handleSignUpWithTeam(req, res)).rejects.toMatchObject({ code: 500 });
+    expect(mockDelete).toHaveBeenCalled();
+    // The session cookie must never reach a caller we just rolled back.
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a better-auth failure without creating anything locally", async () => {
+    mockSignUpEmail.mockResolvedValue({
+      ok: false,
+      status: 422,
+      headers: new Headers(),
+      json: () => Promise.resolve({ message: "Email already taken" }),
+    });
+    const { req, res } = makeReq(body());
+
+    await expect(handleSignUpWithTeam(req, res)).rejects.toMatchObject({ code: 422 });
+    expect(mockCreateGroup).not.toHaveBeenCalled();
+  });
+});

--- a/src/controllers/group/handleGetGroupMirrors.ts
+++ b/src/controllers/group/handleGetGroupMirrors.ts
@@ -1,0 +1,46 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+import AppError from "../../utils/appError.js";
+import type { MirrorCandidate } from "../../services/groupMirror/types.js";
+
+const services = createDBServices();
+
+/**
+ * The caller's mirroring setup for one group: every other group they belong to,
+ * and whether their records from it are currently shown here. Mirroring is a
+ * per-user choice, so this is scoped to the caller — not the whole group.
+ */
+export const handleGetGroupMirrors = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const groupId = z.uuid().parse(req.params.groupId);
+
+  const membership = await services.groupUser.getGroupUser(auth.userId, groupId);
+  if (!membership) {
+    throw new AppError({
+      message: "No access for related group",
+      logging: true,
+      code: 403,
+      context: { url: req.url, userId: auth.userId, groupId },
+    });
+  }
+
+  const [memberships, mirrors] = await Promise.all([
+    services.groupUser.getAllGroupsForUser(auth.userId),
+    services.groupMirror.getMirrorsIntoGroupForUser(auth.userId, groupId),
+  ]);
+
+  const otherGroupIds = memberships.map((row) => row.groupId).filter((id) => id !== groupId);
+  const otherGroups = await services.group.getAllGroups(otherGroupIds);
+  const mirroredIds = new Set(mirrors.map((mirror) => mirror.sourceGroupId));
+
+  const candidates: MirrorCandidate[] = otherGroups.map((group) => ({
+    groupId: group.id,
+    groupName: group.groupName,
+    mirrored: mirroredIds.has(group.id),
+  }));
+
+  return res.status(200).json({ groupId, candidates });
+};

--- a/src/controllers/group/handlePutGroupMirrors.ts
+++ b/src/controllers/group/handlePutGroupMirrors.ts
@@ -1,0 +1,67 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+import AppError from "../../utils/appError.js";
+import { db } from "../../db/db.js";
+import type { ValidatedPutGroupMirrorsType } from "../../services/groupMirror/types.js";
+
+const services = createDBServices();
+
+/**
+ * Replaces the caller's mirror sources for one group. Mirroring only ever
+ * projects the caller's own records, so membership of the target and of every
+ * source group is the whole authorization story — no admin rights are needed
+ * and none are enough on someone else's behalf.
+ */
+export const handlePutGroupMirrors = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const targetGroupId = z.uuid().parse(req.params.groupId);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data: ValidatedPutGroupMirrorsType = req.body;
+
+  if (data.sourceGroupIds.includes(targetGroupId)) {
+    throw new AppError({
+      message: "A group cannot mirror itself",
+      logging: true,
+      code: 422,
+      context: { url: req.url, userId: auth.userId, targetGroupId },
+    });
+  }
+
+  const memberships = await services.groupUser.getAllGroupsForUser(auth.userId);
+  const memberOf = new Set(memberships.map((row) => row.groupId));
+
+  if (!memberOf.has(targetGroupId)) {
+    throw new AppError({
+      message: "No access for related group",
+      logging: true,
+      code: 403,
+      context: { url: req.url, userId: auth.userId, targetGroupId },
+    });
+  }
+
+  const notAMember = data.sourceGroupIds.filter((id) => !memberOf.has(id));
+  if (notAMember.length > 0) {
+    throw new AppError({
+      message: "You can only mirror groups you belong to",
+      logging: true,
+      code: 403,
+      context: { url: req.url, userId: auth.userId, targetGroupId, notAMember },
+      publicContext: { groupIds: notAMember },
+    });
+  }
+
+  const mirrors = await db.transaction((tx) =>
+    services.groupMirror.setMirrorsIntoGroupForUser(
+      auth.userId,
+      targetGroupId,
+      data.sourceGroupIds,
+      tx
+    )
+  );
+
+  return res.status(200).json(mirrors);
+};

--- a/src/controllers/group/tests/handleGroupMirrors.test.ts
+++ b/src/controllers/group/tests/handleGroupMirrors.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockGetGroupUser,
+  mockGetAllGroupsForUser,
+  mockGetAllGroups,
+  mockGetMirrorsIntoGroupForUser,
+  mockSetMirrorsIntoGroupForUser,
+} = vi.hoisted(() => ({
+  mockGetGroupUser: vi.fn(),
+  mockGetAllGroupsForUser: vi.fn(),
+  mockGetAllGroups: vi.fn(),
+  mockGetMirrorsIntoGroupForUser: vi.fn(),
+  mockSetMirrorsIntoGroupForUser: vi.fn(),
+}));
+
+vi.mock("../../../middleware/authSession.js", () => ({ getAuth: vi.fn() }));
+
+vi.mock("../../../db/db.js", () => ({
+  db: { transaction: vi.fn((callback) => callback({})) },
+}));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    groupUser: {
+      getGroupUser: mockGetGroupUser,
+      getAllGroupsForUser: mockGetAllGroupsForUser,
+    },
+    group: { getAllGroups: mockGetAllGroups },
+    groupMirror: {
+      getMirrorsIntoGroupForUser: mockGetMirrorsIntoGroupForUser,
+      setMirrorsIntoGroupForUser: mockSetMirrorsIntoGroupForUser,
+    },
+  }),
+}));
+
+import { handleGetGroupMirrors } from "../handleGetGroupMirrors.js";
+import { handlePutGroupMirrors } from "../handlePutGroupMirrors.js";
+import { getAuth } from "../../../middleware/authSession.js";
+import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
+
+const TARGET = "550e8400-e29b-41d4-a716-446655440000";
+const SOURCE_A = "550e8400-e29b-41d4-a716-446655440001";
+const SOURCE_B = "550e8400-e29b-41d4-a716-446655440002";
+const OUTSIDER = "550e8400-e29b-41d4-a716-446655440009";
+
+describe("handleGetGroupMirrors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
+    mockGetGroupUser.mockResolvedValue({ viewAccess: true });
+    mockGetAllGroupsForUser.mockResolvedValue([
+      { groupId: TARGET },
+      { groupId: SOURCE_A },
+      { groupId: SOURCE_B },
+    ]);
+    mockGetAllGroups.mockResolvedValue([
+      { id: SOURCE_A, groupName: "Team A" },
+      { id: SOURCE_B, groupName: "Leadership" },
+    ]);
+    mockGetMirrorsIntoGroupForUser.mockResolvedValue([{ sourceGroupId: SOURCE_A }]);
+  });
+
+  it("lists the caller's other groups, flagging the mirrored ones", async () => {
+    const { req, res } = makeReqRes({ params: { groupId: TARGET } });
+
+    await handleGetGroupMirrors(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      groupId: TARGET,
+      candidates: [
+        { groupId: SOURCE_A, groupName: "Team A", mirrored: true },
+        { groupId: SOURCE_B, groupName: "Leadership", mirrored: false },
+      ],
+    });
+  });
+
+  it("never offers the group itself as a mirror source", async () => {
+    const { req, res } = makeReqRes({ params: { groupId: TARGET } });
+
+    await handleGetGroupMirrors(req, res);
+
+    expect(mockGetAllGroups).toHaveBeenCalledWith([SOURCE_A, SOURCE_B]);
+  });
+
+  it("403s for a caller who does not belong to the group", async () => {
+    mockGetGroupUser.mockResolvedValue(undefined);
+    const { req, res } = makeReqRes({ params: { groupId: TARGET } });
+
+    await expect(handleGetGroupMirrors(req, res)).rejects.toMatchObject({ code: 403 });
+  });
+});
+
+describe("handlePutGroupMirrors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
+    mockGetAllGroupsForUser.mockResolvedValue([
+      { groupId: TARGET },
+      { groupId: SOURCE_A },
+      { groupId: SOURCE_B },
+    ]);
+    mockSetMirrorsIntoGroupForUser.mockResolvedValue([]);
+  });
+
+  const put = (sourceGroupIds: string[]) =>
+    makeReqRes({ params: { groupId: TARGET }, body: { sourceGroupIds } });
+
+  it("replaces the caller's mirror sources", async () => {
+    const { req, res } = put([SOURCE_A, SOURCE_B]);
+
+    await handlePutGroupMirrors(req, res);
+
+    expect(mockSetMirrorsIntoGroupForUser).toHaveBeenCalledWith(
+      mockAuthData.userId,
+      TARGET,
+      [SOURCE_A, SOURCE_B],
+      expect.anything()
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("turns mirroring off with an empty array", async () => {
+    const { req, res } = put([]);
+
+    await handlePutGroupMirrors(req, res);
+
+    expect(mockSetMirrorsIntoGroupForUser).toHaveBeenCalledWith(
+      mockAuthData.userId,
+      TARGET,
+      [],
+      expect.anything()
+    );
+  });
+
+  it("refuses a source group the caller does not belong to", async () => {
+    const { req, res } = put([SOURCE_A, OUTSIDER]);
+
+    await expect(handlePutGroupMirrors(req, res)).rejects.toMatchObject({ code: 403 });
+    expect(mockSetMirrorsIntoGroupForUser).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the caller does not belong to the target group", async () => {
+    mockGetAllGroupsForUser.mockResolvedValue([{ groupId: SOURCE_A }]);
+    const { req, res } = put([SOURCE_A]);
+
+    await expect(handlePutGroupMirrors(req, res)).rejects.toMatchObject({ code: 403 });
+    expect(mockSetMirrorsIntoGroupForUser).not.toHaveBeenCalled();
+  });
+
+  it("refuses to mirror a group into itself", async () => {
+    const { req, res } = put([TARGET]);
+
+    await expect(handlePutGroupMirrors(req, res)).rejects.toMatchObject({ code: 422 });
+    expect(mockSetMirrorsIntoGroupForUser).not.toHaveBeenCalled();
+  });
+});

--- a/src/controllers/groupUser/handleDeleteGroupInvite.ts
+++ b/src/controllers/groupUser/handleDeleteGroupInvite.ts
@@ -1,0 +1,42 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+import { assertGroupAdmin } from "./utils.js";
+import AppError from "../../utils/appError.js";
+
+const services = createDBServices();
+
+/** Revokes an outstanding invite so its code stops working. */
+export const handleDeleteGroupInvite = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const inviteId = z.uuid().parse(req.params.inviteId);
+
+  const invite = await services.inviteLinks.getInviteLinkById(inviteId);
+
+  if (!invite) {
+    throw new AppError({
+      message: "Invite not found",
+      logging: true,
+      code: 404,
+      context: { url: req.url, userId: auth.userId, inviteId },
+    });
+  }
+
+  // Authorize against the invite's own group — the caller never names it.
+  await assertGroupAdmin(auth.userId, invite.groupId);
+
+  const revoked = await services.inviteLinks.revokeInviteLink(inviteId);
+
+  if (!revoked) {
+    throw new AppError({
+      message: "Invite is already used or revoked",
+      logging: true,
+      code: 409,
+      context: { url: req.url, userId: auth.userId, inviteId },
+    });
+  }
+
+  return res.status(200).json(revoked);
+};

--- a/src/controllers/groupUser/handleGetGroupInvites.ts
+++ b/src/controllers/groupUser/handleGetGroupInvites.ts
@@ -1,0 +1,20 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+import { assertGroupAdmin } from "./utils.js";
+
+const services = createDBServices();
+
+/** The group's still-redeemable invites. Admin-only: the codes are secrets. */
+export const handleGetGroupInvites = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const groupId = z.uuid().parse(req.params.groupId);
+
+  await assertGroupAdmin(auth.userId, groupId);
+
+  const invites = await services.inviteLinks.getOpenInvitesForGroup(groupId);
+
+  return res.status(200).json(invites);
+};

--- a/src/controllers/groupUser/handlePostGroupInvite.ts
+++ b/src/controllers/groupUser/handlePostGroupInvite.ts
@@ -1,0 +1,93 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+import { assertGroupAdmin } from "./utils.js";
+import type { ValidatedPostGroupInviteType } from "../../services/groupUser/types.js";
+import AppError from "../../utils/appError.js";
+import { generateRandomUUID } from "../../utils/generateUUID.js";
+import { generateInviteCode } from "../../utils/inviteCode.js";
+import { db } from "../../db/db.js";
+import { inviteExpiryFrom, notifyGroupInvited } from "../../services/groupUser/inviteNotifier.js";
+
+const services = createDBServices();
+
+/**
+ * Issues a single-use invite code for a group and emails it to the invited
+ * address. The code is bound to that address — see `handlePostGroupUser` — so
+ * a forwarded email does not let a third party into the group.
+ */
+export const handlePostGroupInvite = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const groupId = z.uuid().parse(req.params.groupId);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data: ValidatedPostGroupInviteType = req.body;
+
+  await assertGroupAdmin(auth.userId, groupId);
+
+  const group = await services.group.getGroup(groupId);
+  if (!group) {
+    throw new AppError({
+      message: "Group not found",
+      logging: true,
+      code: 404,
+      context: { url: req.url, userId: auth.userId, groupId },
+    });
+  }
+
+  const existingUser = await services.user.getUserByEmail(data.email);
+  if (existingUser) {
+    const membership = await services.groupUser.getGroupUser(existingUser.id, groupId);
+    if (membership) {
+      throw new AppError({
+        message: "That person is already a member of this group",
+        logging: true,
+        code: 409,
+        context: { url: req.url, userId: auth.userId, groupId, email: data.email },
+        publicContext: { email: data.email },
+      });
+    }
+  }
+
+  const invite = await db.transaction(async (tx) => {
+    // Supersede any open invite for this address so only the newest code works
+    // — and so the partial unique index does not reject the insert.
+    await services.inviteLinks.revokeOpenInviteForEmail(groupId, data.email, tx);
+
+    const created = await services.inviteLinks.createInviteLink(
+      {
+        id: generateRandomUUID(),
+        groupId,
+        code: generateInviteCode(),
+        email: data.email,
+        invitedByUserId: auth.userId,
+        expiresAt: inviteExpiryFrom(new Date()),
+      },
+      tx
+    );
+
+    if (!created) {
+      throw new AppError({
+        message: "Failed to create invite",
+        logging: true,
+        code: 500,
+        context: { url: req.url, userId: auth.userId, groupId, email: data.email },
+      });
+    }
+
+    return created;
+  });
+
+  // Committed already: the admin gets the code back either way, so a mail
+  // failure downgrades to "share it yourself" rather than failing the request.
+  const emailDelivered = await notifyGroupInvited({
+    email: data.email,
+    groupName: group.groupName,
+    inviterName: auth.userName,
+    code: invite.code,
+  });
+
+  return res.status(201).json({ invite, emailDelivered });
+};

--- a/src/controllers/groupUser/handlePostGroupUser.ts
+++ b/src/controllers/groupUser/handlePostGroupUser.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { db } from "../../db/db.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
+import { normalizeInviteCode } from "../../utils/inviteCode.js";
 import AppError from "../../utils/appError.js";
 
 const services = createDBServices();
@@ -11,11 +12,15 @@ const services = createDBServices();
 export const handlePostGroupUser = async (req: Request, res: Response) => {
   const auth = getAuth(req);
 
-  const { data: validationCode, error: validationCodeError } = z
+  const { data: rawCode, error: validationCodeError } = z
     .string()
+    .min(1)
+    .max(64)
     .safeParse(req.params.validationCode);
 
-  if (validationCodeError) {
+  const validationCode = rawCode ? normalizeInviteCode(rawCode) : null;
+
+  if (validationCodeError || !validationCode) {
     throw new AppError({
       message: "Invalid validation code format",
       logging: true,
@@ -26,7 +31,12 @@ export const handlePostGroupUser = async (req: Request, res: Response) => {
   const result = await db.transaction(async (tx) => {
     const validateLink = await services.inviteLinks.getInviteLinkByCode(validationCode, tx);
 
-    if (!validateLink || Boolean(validateLink.usedAt) || validateLink.expiresAt <= new Date()) {
+    if (
+      !validateLink ||
+      Boolean(validateLink.usedAt) ||
+      Boolean(validateLink.revokedAt) ||
+      validateLink.expiresAt <= new Date()
+    ) {
       throw new AppError({
         message: "Invalid or expired validation code",
         logging: true,
@@ -34,8 +44,40 @@ export const handlePostGroupUser = async (req: Request, res: Response) => {
         context: {
           url: req.url,
           userId: auth.userId,
-          validationCode: validationCode,
+          validationCode,
         },
+      });
+    }
+
+    // Invites issued to an address may only be redeemed by that address, so a
+    // forwarded or leaked code is useless to anyone else. Rows with no email
+    // predate email invites and stay unrestricted.
+    if (validateLink.email && validateLink.email !== auth.userEmail.toLowerCase()) {
+      throw new AppError({
+        message: "This invite was issued for a different email address",
+        logging: true,
+        code: 403,
+        context: {
+          url: req.url,
+          userId: auth.userId,
+          invitedEmail: validateLink.email,
+        },
+        publicContext: { invitedEmail: validateLink.email },
+      });
+    }
+
+    const existingMembership = await services.groupUser.getGroupUser(
+      auth.userId,
+      validateLink.groupId,
+      tx
+    );
+
+    if (existingMembership) {
+      throw new AppError({
+        message: "You are already a member of this group",
+        logging: true,
+        code: 409,
+        context: { url: req.url, userId: auth.userId, groupId: validateLink.groupId },
       });
     }
 
@@ -65,13 +107,15 @@ export const handlePostGroupUser = async (req: Request, res: Response) => {
       });
     }
 
+    // `usedAt IS NULL` in the update is what makes the code single-use: a
+    // concurrent second redemption matches no row and rolls this back.
     const updateInviteLink = await services.inviteLinks.useInviteLink(validationCode, tx);
 
     if (!updateInviteLink) {
       throw new AppError({
         message: "Failed to update invite link",
         logging: true,
-        code: 500,
+        code: 409,
         context: {
           url: req.url,
           userId: auth.userId,
@@ -83,10 +127,6 @@ export const handlePostGroupUser = async (req: Request, res: Response) => {
 
     return createGroupUser;
   });
-
-  //todo email send to group manager
-
-  //todo add history record
 
   return res.status(201).json(result);
 };

--- a/src/controllers/groupUser/tests/handlePostGroupInvite.test.ts
+++ b/src/controllers/groupUser/tests/handlePostGroupInvite.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockGetGroupUser,
+  mockGetGroup,
+  mockGetUserByEmail,
+  mockCreateInviteLink,
+  mockRevokeOpenInviteForEmail,
+  mockNotifyGroupInvited,
+} = vi.hoisted(() => ({
+  mockGetGroupUser: vi.fn(),
+  mockGetGroup: vi.fn(),
+  mockGetUserByEmail: vi.fn(),
+  mockCreateInviteLink: vi.fn(),
+  mockRevokeOpenInviteForEmail: vi.fn(),
+  mockNotifyGroupInvited: vi.fn(),
+}));
+
+vi.mock("../../../middleware/authSession.js", () => ({ getAuth: vi.fn() }));
+
+vi.mock("../../../db/db.js", () => ({
+  db: { transaction: vi.fn((callback) => callback({})) },
+}));
+
+// `assertGroupAdmin` reaches for the service module directly rather than
+// through createDBServices, so both routes must resolve to the same mock.
+vi.mock("../../../services/groupUser/groupUserServices.js", () => ({
+  getGroupUser: mockGetGroupUser,
+}));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    groupUser: { getGroupUser: mockGetGroupUser },
+    group: { getGroup: mockGetGroup },
+    user: { getUserByEmail: mockGetUserByEmail },
+    inviteLinks: {
+      createInviteLink: mockCreateInviteLink,
+      revokeOpenInviteForEmail: mockRevokeOpenInviteForEmail,
+    },
+  }),
+}));
+
+vi.mock("../../../services/groupUser/inviteNotifier.js", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../services/groupUser/inviteNotifier.js")
+  >();
+  return { ...actual, notifyGroupInvited: mockNotifyGroupInvited };
+});
+
+import { handlePostGroupInvite } from "../handlePostGroupInvite.js";
+import { getAuth } from "../../../middleware/authSession.js";
+import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
+
+const GROUP_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+const admin = { viewAccess: true, adminAccess: true, controlledUser: true };
+const plainMember = { viewAccess: true, adminAccess: false, controlledUser: true };
+
+describe("handlePostGroupInvite", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
+    mockGetGroupUser.mockResolvedValue(admin);
+    mockGetGroup.mockResolvedValue({ id: GROUP_ID, groupName: "Platform" });
+    mockGetUserByEmail.mockResolvedValue(undefined);
+    mockCreateInviteLink.mockImplementation((data: { code: string }) =>
+      Promise.resolve({ id: "invite-1", ...data })
+    );
+    mockNotifyGroupInvited.mockResolvedValue(true);
+  });
+
+  const invite = (email = "sam@northwind.co") =>
+    makeReqRes({ params: { groupId: GROUP_ID }, body: { email } });
+
+  it("issues a code and emails it to the invited address", async () => {
+    const { req, res } = invite();
+
+    await handlePostGroupInvite(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    const created = mockCreateInviteLink.mock.calls[0]?.[0] as {
+      email: string;
+      groupId: string;
+      code: string;
+      invitedByUserId: string;
+    };
+    expect(created.email).toBe("sam@northwind.co");
+    expect(created.groupId).toBe(GROUP_ID);
+    expect(created.invitedByUserId).toBe(mockAuthData.userId);
+    expect(created.code).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{4}-[A-Z2-9]{4}$/);
+
+    expect(mockNotifyGroupInvited).toHaveBeenCalledWith({
+      email: "sam@northwind.co",
+      groupName: "Platform",
+      inviterName: mockAuthData.userName,
+      code: created.code,
+    });
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ emailDelivered: true }));
+  });
+
+  it("stores the address lower-cased so redemption matches", async () => {
+    const { req, res } = invite();
+    // The route's zod schema lower-cases before the handler sees it.
+    req.body = { email: "sam@northwind.co" };
+
+    await handlePostGroupInvite(req, res);
+
+    expect(mockCreateInviteLink.mock.calls[0]?.[0]).toMatchObject({
+      email: "sam@northwind.co",
+    });
+  });
+
+  it("revokes any earlier open invite for the same address first", async () => {
+    const { req, res } = invite();
+
+    await handlePostGroupInvite(req, res);
+
+    expect(mockRevokeOpenInviteForEmail).toHaveBeenCalledWith(
+      GROUP_ID,
+      "sam@northwind.co",
+      expect.anything()
+    );
+  });
+
+  it("still returns the code when the email could not be sent", async () => {
+    mockNotifyGroupInvited.mockResolvedValue(false);
+    const { req, res } = invite();
+
+    await handlePostGroupInvite(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ emailDelivered: false }));
+  });
+
+  it("sets an expiry in the future", async () => {
+    const { req, res } = invite();
+
+    await handlePostGroupInvite(req, res);
+
+    const { expiresAt } = mockCreateInviteLink.mock.calls[0]?.[0] as { expiresAt: Date };
+    expect(expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("rejects a caller without admin access", async () => {
+    mockGetGroupUser.mockResolvedValue(plainMember);
+    const { req, res } = invite();
+
+    await expect(handlePostGroupInvite(req, res)).rejects.toMatchObject({ code: 403 });
+    expect(mockCreateInviteLink).not.toHaveBeenCalled();
+  });
+
+  it("rejects a caller who is not in the group at all", async () => {
+    mockGetGroupUser.mockResolvedValue(undefined);
+    const { req, res } = invite();
+
+    await expect(handlePostGroupInvite(req, res)).rejects.toMatchObject({ code: 403 });
+  });
+
+  it("404s when the group does not exist", async () => {
+    mockGetGroup.mockResolvedValue(undefined);
+    const { req, res } = invite();
+
+    await expect(handlePostGroupInvite(req, res)).rejects.toMatchObject({ code: 404 });
+  });
+
+  it("409s when the invited person already belongs to the group", async () => {
+    mockGetUserByEmail.mockResolvedValue({ id: "existing-user" });
+    // First call is the caller's admin check, second is the invitee's membership.
+    mockGetGroupUser.mockResolvedValueOnce(admin).mockResolvedValueOnce(plainMember);
+    const { req, res } = invite();
+
+    await expect(handlePostGroupInvite(req, res)).rejects.toMatchObject({ code: 409 });
+    expect(mockCreateInviteLink).not.toHaveBeenCalled();
+  });
+
+  it("invites an existing account that is not in this group yet", async () => {
+    mockGetUserByEmail.mockResolvedValue({ id: "existing-user" });
+    mockGetGroupUser.mockResolvedValueOnce(admin).mockResolvedValueOnce(undefined);
+    const { req, res } = invite();
+
+    await handlePostGroupInvite(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+});

--- a/src/controllers/groupUser/tests/handlePostGroupUser.test.ts
+++ b/src/controllers/groupUser/tests/handlePostGroupUser.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockGetInviteLinkByCode, mockUseInviteLink, mockCreateGroupUser, mockGetGroupUser } =
+  vi.hoisted(() => ({
+    mockGetInviteLinkByCode: vi.fn(),
+    mockUseInviteLink: vi.fn(),
+    mockCreateGroupUser: vi.fn(),
+    mockGetGroupUser: vi.fn(),
+  }));
+
+vi.mock("../../../middleware/authSession.js", () => ({ getAuth: vi.fn() }));
+
+vi.mock("../../../db/db.js", () => ({
+  db: { transaction: vi.fn((callback) => callback({})) },
+}));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    groupUser: { createGroupUser: mockCreateGroupUser, getGroupUser: mockGetGroupUser },
+    inviteLinks: {
+      getInviteLinkByCode: mockGetInviteLinkByCode,
+      useInviteLink: mockUseInviteLink,
+    },
+  }),
+}));
+
+import { handlePostGroupUser } from "../handlePostGroupUser.js";
+import { getAuth } from "../../../middleware/authSession.js";
+import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
+
+const GROUP_ID = "550e8400-e29b-41d4-a716-446655440000";
+const CODE = "ABCD-EFGH-JKMN";
+
+const tomorrow = () => new Date(Date.now() + 24 * 60 * 60 * 1000);
+const yesterday = () => new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+const openInvite = (overrides: Record<string, unknown> = {}) => ({
+  id: "invite-1",
+  groupId: GROUP_ID,
+  code: CODE,
+  email: mockAuthData.userEmail,
+  usedAt: null,
+  revokedAt: null,
+  expiresAt: tomorrow(),
+  ...overrides,
+});
+
+describe("handlePostGroupUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
+    mockGetInviteLinkByCode.mockResolvedValue(openInvite());
+    mockGetGroupUser.mockResolvedValue(undefined);
+    mockCreateGroupUser.mockResolvedValue({ id: "membership-1", groupId: GROUP_ID });
+    mockUseInviteLink.mockResolvedValue(openInvite({ usedAt: new Date() }));
+  });
+
+  const redeem = (code = CODE) => makeReqRes({ params: { validationCode: code } });
+
+  it("joins the group and burns the code", async () => {
+    const { req, res } = redeem();
+
+    await handlePostGroupUser(req, res);
+
+    expect(mockCreateGroupUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: mockAuthData.userId,
+        groupId: GROUP_ID,
+        viewAccess: true,
+        adminAccess: false,
+        controlledUser: true,
+      }),
+      expect.anything()
+    );
+    expect(mockUseInviteLink).toHaveBeenCalledWith(CODE, expect.anything());
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("accepts the code lower-cased and without dashes", async () => {
+    const { req, res } = redeem("abcdefghjkmn");
+
+    await handlePostGroupUser(req, res);
+
+    // Normalised to the stored form before the lookup.
+    expect(mockGetInviteLinkByCode).toHaveBeenCalledWith(CODE, expect.anything());
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("refuses an invite issued to a different address", async () => {
+    mockGetInviteLinkByCode.mockResolvedValue(openInvite({ email: "someone.else@northwind.co" }));
+    const { req, res } = redeem();
+
+    await expect(handlePostGroupUser(req, res)).rejects.toMatchObject({ code: 403 });
+    expect(mockCreateGroupUser).not.toHaveBeenCalled();
+    expect(mockUseInviteLink).not.toHaveBeenCalled();
+  });
+
+  it("matches the invited address case-insensitively", async () => {
+    mockGetInviteLinkByCode.mockResolvedValue(
+      openInvite({ email: mockAuthData.userEmail.toLowerCase() })
+    );
+    (getAuth as ReturnType<typeof vi.fn>).mockReturnValue({
+      ...mockAuthData,
+      userEmail: mockAuthData.userEmail.toUpperCase(),
+    });
+    const { req, res } = redeem();
+
+    await handlePostGroupUser(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("lets anyone redeem a legacy invite that carries no address", async () => {
+    mockGetInviteLinkByCode.mockResolvedValue(openInvite({ email: null }));
+    const { req, res } = redeem();
+
+    await handlePostGroupUser(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("rejects a revoked invite", async () => {
+    mockGetInviteLinkByCode.mockResolvedValue(openInvite({ revokedAt: new Date() }));
+    const { req, res } = redeem();
+
+    await expect(handlePostGroupUser(req, res)).rejects.toMatchObject({ code: 404 });
+    expect(mockCreateGroupUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects an already used invite", async () => {
+    mockGetInviteLinkByCode.mockResolvedValue(openInvite({ usedAt: new Date() }));
+    const { req, res } = redeem();
+
+    await expect(handlePostGroupUser(req, res)).rejects.toMatchObject({ code: 404 });
+  });
+
+  it("rejects an expired invite", async () => {
+    mockGetInviteLinkByCode.mockResolvedValue(openInvite({ expiresAt: yesterday() }));
+    const { req, res } = redeem();
+
+    await expect(handlePostGroupUser(req, res)).rejects.toMatchObject({ code: 404 });
+  });
+
+  it("rejects an unknown code", async () => {
+    mockGetInviteLinkByCode.mockResolvedValue(undefined);
+    const { req, res } = redeem();
+
+    await expect(handlePostGroupUser(req, res)).rejects.toMatchObject({ code: 404 });
+  });
+
+  it("rejects a malformed code without touching the database", async () => {
+    const { req, res } = redeem("not-a-code");
+
+    await expect(handlePostGroupUser(req, res)).rejects.toMatchObject({ code: 400 });
+    expect(mockGetInviteLinkByCode).not.toHaveBeenCalled();
+  });
+
+  it("409s when the caller already belongs to the group", async () => {
+    mockGetGroupUser.mockResolvedValue({ id: "existing" });
+    const { req, res } = redeem();
+
+    await expect(handlePostGroupUser(req, res)).rejects.toMatchObject({ code: 409 });
+    expect(mockCreateGroupUser).not.toHaveBeenCalled();
+  });
+
+  it("409s when a concurrent redemption burned the code first", async () => {
+    // The `usedAt IS NULL` predicate in useInviteLink matched no row.
+    mockUseInviteLink.mockResolvedValue(undefined);
+    const { req, res } = redeem();
+
+    await expect(handlePostGroupUser(req, res)).rejects.toMatchObject({ code: 409 });
+  });
+});

--- a/src/controllers/groupUser/utils.ts
+++ b/src/controllers/groupUser/utils.ts
@@ -1,4 +1,5 @@
 import { getGroupUser } from "../../services/groupUser/groupUserServices.js";
+import AppError from "../../utils/appError.js";
 
 export const validateUserGroupAccess = async (
   userId: string,
@@ -6,4 +7,17 @@ export const validateUserGroupAccess = async (
 ): Promise<boolean> => {
   const groupUser = await getGroupUser(userId, groupId);
   return groupUser?.viewAccess ?? false;
+};
+
+/** Throws 403 unless the caller's membership carries `adminAccess`. */
+export const assertGroupAdmin = async (userId: string, groupId: string): Promise<void> => {
+  const groupUser = await getGroupUser(userId, groupId);
+  if (!groupUser?.adminAccess) {
+    throw new AppError({
+      message: "No permission for related group",
+      logging: true,
+      code: 403,
+      context: { userId, groupId },
+    });
+  }
 };

--- a/src/db/schema/group-mirror-schema.ts
+++ b/src/db/schema/group-mirror-schema.ts
@@ -1,0 +1,40 @@
+import { index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { groups } from "./group-schema.js";
+import { user } from "./auth-schema.js";
+
+/**
+ * One user's opt-in to have their records from `sourceGroupId` shown inside
+ * `targetGroupId`. Purely a read-side projection: no vacation row is ever
+ * copied, so quota accounting, approvals and reports all continue to belong to
+ * the source group alone. A mirrored record is therefore never approvable in
+ * the target group — the approval queries key on `vacation.groupId`.
+ */
+export const groupMirrors = pgTable(
+  "group_mirrors",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    sourceGroupId: text("source_group_id")
+      .notNull()
+      .references(() => groups.id, { onDelete: "cascade" }),
+    targetGroupId: text("target_group_id")
+      .notNull()
+      .references(() => groups.id, { onDelete: "cascade" }),
+    deletedAt: timestamp("deleted_at"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => ({
+    uniqActiveMirror: uniqueIndex("group_mirrors_user_source_target_uniq")
+      .on(table.userId, table.sourceGroupId, table.targetGroupId)
+      .where(sql`${table.deletedAt} IS NULL`),
+    idxTargetGroup: index("idx_group_mirrors_target_group_id").on(table.targetGroupId),
+    idxUser: index("idx_group_mirrors_user_id").on(table.userId),
+  })
+);

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,6 +1,7 @@
 import { account, session, user, verification } from "./auth-schema.js";
 import { groupUsers } from "./group-users-schema.js";
 import { groups } from "./group-schema.js";
+import { groupMirrors } from "./group-mirror-schema.js";
 import { userYearQuotas } from "./user-year-quotas-schema.js";
 import { vacation } from "./vacation-schema.js";
 import { inviteLink } from "./invite-link-schema.js";
@@ -18,6 +19,7 @@ export const schema = {
   verification,
   groupUsers,
   groups,
+  groupMirrors,
   userSettings,
   userYearQuotas,
   vacation,

--- a/src/db/schema/invite-link-schema.ts
+++ b/src/db/schema/invite-link-schema.ts
@@ -1,5 +1,7 @@
-import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { groups } from "./group-schema.js";
+import { user } from "./auth-schema.js";
 
 export const inviteLink = pgTable(
   "invite_link",
@@ -9,7 +11,13 @@ export const inviteLink = pgTable(
       .notNull()
       .references(() => groups.id),
     code: text("code").unique().notNull(),
+    // Lower-cased address the invite was issued to. Redeeming is restricted to
+    // an account with this email, so a forwarded code is useless to a stranger.
+    // Nullable only for rows predating email invites — those stay unrestricted.
+    email: text("email"),
+    invitedByUserId: text("invited_by_user_id").references(() => user.id, { onDelete: "set null" }),
     usedAt: timestamp("used_at"),
+    revokedAt: timestamp("revoked_at"),
     expiresAt: timestamp("expires_at").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at")
@@ -19,5 +27,11 @@ export const inviteLink = pgTable(
   },
   (table) => ({
     idxInviteLinkCode: index("idx_invite_link_code").on(table.code),
+    idxInviteLinkGroupId: index("idx_invite_link_group_id").on(table.groupId),
+    // At most one live invite per (group, email); re-inviting the same address
+    // reuses that row instead of leaving several codes that all still work.
+    uniqOpenInvite: uniqueIndex("invite_link_group_email_open_uniq")
+      .on(table.groupId, table.email)
+      .where(sql`${table.usedAt} IS NULL AND ${table.revokedAt} IS NULL`),
   })
 );

--- a/src/db/schema/out/0007_illegal_marauders.sql
+++ b/src/db/schema/out/0007_illegal_marauders.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "group_mirrors" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"source_group_id" text NOT NULL,
+	"target_group_id" text NOT NULL,
+	"deleted_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "invite_link" ADD COLUMN "email" text;--> statement-breakpoint
+ALTER TABLE "invite_link" ADD COLUMN "invited_by_user_id" text;--> statement-breakpoint
+ALTER TABLE "invite_link" ADD COLUMN "revoked_at" timestamp;--> statement-breakpoint
+ALTER TABLE "group_mirrors" ADD CONSTRAINT "group_mirrors_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "group_mirrors" ADD CONSTRAINT "group_mirrors_source_group_id_groups_id_fk" FOREIGN KEY ("source_group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "group_mirrors" ADD CONSTRAINT "group_mirrors_target_group_id_groups_id_fk" FOREIGN KEY ("target_group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "group_mirrors_user_source_target_uniq" ON "group_mirrors" USING btree ("user_id","source_group_id","target_group_id") WHERE "group_mirrors"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "idx_group_mirrors_target_group_id" ON "group_mirrors" USING btree ("target_group_id");--> statement-breakpoint
+CREATE INDEX "idx_group_mirrors_user_id" ON "group_mirrors" USING btree ("user_id");--> statement-breakpoint
+ALTER TABLE "invite_link" ADD CONSTRAINT "invite_link_invited_by_user_id_user_id_fk" FOREIGN KEY ("invited_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_invite_link_group_id" ON "invite_link" USING btree ("group_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "invite_link_group_email_open_uniq" ON "invite_link" USING btree ("group_id","email") WHERE "invite_link"."used_at" IS NULL AND "invite_link"."revoked_at" IS NULL;

--- a/src/db/schema/out/meta/0007_snapshot.json
+++ b/src/db/schema/out/meta/0007_snapshot.json
@@ -1,0 +1,2257 @@
+{
+  "id": "95dc126d-2c08-4825-869b-fa4ff5031eb2",
+  "prevId": "505e65a2-665d-4c07-a4fc-04f97c404c7d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_mirrors": {
+      "name": "group_mirrors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_group_id": {
+          "name": "target_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_mirrors_user_source_target_uniq": {
+          "name": "group_mirrors_user_source_target_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_mirrors\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_target_group_id": {
+          "name": "idx_group_mirrors_target_group_id",
+          "columns": [
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_user_id": {
+          "name": "idx_group_mirrors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_mirrors_user_id_user_id_fk": {
+          "name": "group_mirrors_user_id_user_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_source_group_id_groups_id_fk": {
+          "name": "group_mirrors_source_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_target_group_id_groups_id_fk": {
+          "name": "group_mirrors_target_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "target_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invite_link_group_id": {
+          "name": "idx_invite_link_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_group_email_open_uniq": {
+          "name": "invite_link_group_email_open_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_link\".\"used_at\" IS NULL AND \"invite_link\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invite_link_invited_by_user_id_user_id_fk": {
+          "name": "invite_link_invited_by_user_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_exports_user_id_idx": {
+          "name": "report_exports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_exports_created_at_idx": {
+          "name": "report_exports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_user_id_user_id_fk": {
+          "name": "report_exports_user_id_user_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "carried_over_days": {
+          "name": "carried_over_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        },
+        "user_year_quotas_related_year_range_chk": {
+          "name": "user_year_quotas_related_year_range_chk",
+          "value": "\"user_year_quotas\".\"related_year\"::int BETWEEN 2025 AND 2100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "half_day": {
+          "name": "half_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/_journal.json
+++ b/src/db/schema/out/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1785087514606,
       "tag": "0006_slimy_wolverine",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1785571165719,
+      "tag": "0007_illegal_marauders",
+      "breakpoints": true
     }
   ]
 }

--- a/src/routes/authExtRouter.ts
+++ b/src/routes/authExtRouter.ts
@@ -20,7 +20,11 @@ export const authExtRouter = (): Router => {
    *   post:
    *     tags:
    *       - Auth
-   *     summary: Provision a user and their first group in one call
+   *     summary: Provision a user, optionally with their first group
+   *     description: |
+   *       `teamName` is optional. When omitted the account is created with no
+   *       group and `group` comes back `null`; the user can then create a group
+   *       or redeem an invite code. Booking time off requires a group.
    *     requestBody:
    *       required: true
    *       content:
@@ -31,7 +35,6 @@ export const authExtRouter = (): Router => {
    *               - name
    *               - email
    *               - password
-   *               - teamName
    *             properties:
    *               name:
    *                 type: string
@@ -41,9 +44,10 @@ export const authExtRouter = (): Router => {
    *                 type: string
    *               teamName:
    *                 type: string
+   *                 description: Creates and joins a group when present.
    *     responses:
    *       '201':
-   *         description: User + group created
+   *         description: User created; `group` is null when no teamName was sent
    */
   app.post(
     "/sign-up-with-team",

--- a/src/routes/groupRouter.ts
+++ b/src/routes/groupRouter.ts
@@ -6,6 +6,9 @@ import { handlePutGroupQuotas } from "../controllers/group/handlePutGroupQuotas.
 import { handlePutGroupWorkingDays } from "../controllers/group/handlePutGroupWorkingDays.js";
 import { bodyValidationMiddleware } from "../middleware/validationMiddleware.js";
 import { validatePutGroupQuotas, validatePutGroupWorkingDays } from "../services/group/types.js";
+import { validatePutGroupMirrors } from "../services/groupMirror/types.js";
+import { handleGetGroupMirrors } from "../controllers/group/handleGetGroupMirrors.js";
+import { handlePutGroupMirrors } from "../controllers/group/handlePutGroupMirrors.js";
 
 export const groupRouter = (): Router => {
   const app = Router();
@@ -111,6 +114,79 @@ export const groupRouter = (): Router => {
     "/:groupId/working-days",
     bodyValidationMiddleware(validatePutGroupWorkingDays),
     tryCatch(handlePutGroupWorkingDays)
+  );
+
+  /**
+   * @openapi
+   * /api/group/{groupId}/mirrors:
+   *   get:
+   *     tags:
+   *       - Groups
+   *     summary: The caller's mirroring setup for this group
+   *     description: |
+   *       Lists every other group the caller belongs to and whether their
+   *       records from it are currently shown inside this group. Mirroring is a
+   *       per-user choice, so this only ever describes the caller.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: groupId
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *     responses:
+   *       '200':
+   *         description: Candidate source groups with their mirrored state
+   *       '403':
+   *         description: Caller does not belong to the group
+   *   put:
+   *     tags:
+   *       - Groups
+   *     summary: Set which groups the caller mirrors into this one
+   *     description: |
+   *       Replaces the caller's mirror sources for this group. Mirrored records
+   *       are shown here read-only: they are approved, counted against quotas
+   *       and reported in their source group alone, and never need a decision
+   *       in this one. The caller must belong to the target and to every source
+   *       group; an empty array turns mirroring off.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: groupId
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - sourceGroupIds
+   *             properties:
+   *               sourceGroupIds:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *                   format: uuid
+   *     responses:
+   *       '200':
+   *         description: The caller's mirrors into this group after the update
+   *       '403':
+   *         description: Caller does not belong to the target or a source group
+   *       '422':
+   *         description: A group cannot mirror itself
+   */
+  app.get("/:groupId/mirrors", tryCatch(handleGetGroupMirrors));
+  app.put(
+    "/:groupId/mirrors",
+    bodyValidationMiddleware(validatePutGroupMirrors),
+    tryCatch(handlePutGroupMirrors)
   );
 
   return app;

--- a/src/routes/groupUsersRouter.ts
+++ b/src/routes/groupUsersRouter.ts
@@ -4,13 +4,156 @@ import { handlePostGroupUser } from "../controllers/groupUser/handlePostGroupUse
 import { tryCatch } from "../middleware/tryCatch.js";
 import { bodyValidationMiddleware } from "../middleware/validationMiddleware.js";
 import { handleUpdateGroupUsers } from "../controllers/groupUser/handleUpdateGroupUsers.js";
-import { validatePutGroupUserUpdate } from "../services/groupUser/types.js";
+import {
+  validatePostGroupInvite,
+  validatePutGroupUserUpdate,
+} from "../services/groupUser/types.js";
+import { handlePostGroupInvite } from "../controllers/groupUser/handlePostGroupInvite.js";
+import { handleGetGroupInvites } from "../controllers/groupUser/handleGetGroupInvites.js";
+import { handleDeleteGroupInvite } from "../controllers/groupUser/handleDeleteGroupInvite.js";
 
 export const groupUsersRouter = (): Router => {
   const app = Router();
 
-  app.get("/:groupId", tryCatch(handleGetGroupUsers));
+  /**
+   * @openapi
+   * /api/group-user/invites/{inviteId}:
+   *   delete:
+   *     tags:
+   *       - Group members
+   *     summary: Revoke an outstanding invite
+   *     description: |
+   *       Stops the invite's code from working. Requires admin access on the
+   *       group the invite belongs to. Already used or already revoked invites
+   *       return 409.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: inviteId
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *     responses:
+   *       '200':
+   *         description: The revoked invite
+   *       '403':
+   *         description: No permission for related group
+   *       '404':
+   *         description: Invite not found
+   *       '409':
+   *         description: Invite already used or revoked
+   */
+  app.delete("/invites/:inviteId", tryCatch(handleDeleteGroupInvite));
+
+  /**
+   * @openapi
+   * /api/group-user/code/{validationCode}:
+   *   post:
+   *     tags:
+   *       - Group members
+   *     summary: Join a group with an invite code
+   *     description: |
+   *       Redeems a single-use invite code for the signed-in user. Codes are
+   *       accepted case-insensitively and with or without their dashes. An
+   *       invite issued to an email address may only be redeemed by an account
+   *       with that address.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: validationCode
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       '201':
+   *         description: The created membership
+   *       '400':
+   *         description: Malformed code
+   *       '403':
+   *         description: Invite was issued for a different email address
+   *       '404':
+   *         description: Invalid, revoked or expired code
+   *       '409':
+   *         description: Already a member, or the code was just redeemed
+   */
   app.post("/code/:validationCode", tryCatch(handlePostGroupUser));
+
+  app.get("/:groupId", tryCatch(handleGetGroupUsers));
+
+  /**
+   * @openapi
+   * /api/group-user/{groupId}/invites:
+   *   get:
+   *     tags:
+   *       - Group members
+   *     summary: List the group's outstanding invites
+   *     description: |
+   *       Invites that can still be redeemed — not used, not revoked, not
+   *       expired — newest first. Admin-only: the response carries the codes.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: groupId
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *     responses:
+   *       '200':
+   *         description: Outstanding invites
+   *       '403':
+   *         description: No permission for related group
+   *   post:
+   *     tags:
+   *       - Group members
+   *     summary: Invite someone to the group by email
+   *     description: |
+   *       Issues a single-use code, emails it to the address with instructions,
+   *       and returns it so the admin can also share it directly. Any earlier
+   *       open invite for the same address is revoked. `emailDelivered` is
+   *       false when the code was created but the mail could not be sent.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: groupId
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - email
+   *             properties:
+   *               email:
+   *                 type: string
+   *                 format: email
+   *     responses:
+   *       '201':
+   *         description: The created invite plus whether the email went out
+   *       '403':
+   *         description: No permission for related group
+   *       '404':
+   *         description: Group not found
+   *       '409':
+   *         description: That person already belongs to the group
+   */
+  app.get("/:groupId/invites", tryCatch(handleGetGroupInvites));
+  app.post(
+    "/:groupId/invites",
+    bodyValidationMiddleware(validatePostGroupInvite),
+    tryCatch(handlePostGroupInvite)
+  );
+
   app.put(
     "/",
     bodyValidationMiddleware(validatePutGroupUserUpdate),

--- a/src/services/DBServices.ts
+++ b/src/services/DBServices.ts
@@ -2,6 +2,7 @@ import * as vacationServices from "./vacation/vacationServices.js";
 import * as vacationEventServices from "./vacationEvent/vacationEventServices.js";
 import * as groupUserServices from "./groupUser/groupUserServices.js";
 import * as groupServices from "./group/groupServices.js";
+import * as groupMirrorServices from "./groupMirror/groupMirrorServices.js";
 import * as userYearQuotasServices from "./userYearQuotas/userYearQuotasServices.js";
 import * as changesServices from "./changes/changesServices.js";
 import * as userSettingsServices from "./userSettings/userSettingsServices.js";
@@ -49,7 +50,11 @@ export type DBServices = Readonly<{
   inviteLinks: {
     createInviteLink: typeof groupUserServices.createInviteLink;
     getInviteLinksForGroup: typeof groupUserServices.getInviteLinksForGroup;
+    getOpenInvitesForGroup: typeof groupUserServices.getOpenInvitesForGroup;
     getInviteLinkByCode: typeof groupUserServices.getInviteLinkByCode;
+    getInviteLinkById: typeof groupUserServices.getInviteLinkById;
+    revokeOpenInviteForEmail: typeof groupUserServices.revokeOpenInviteForEmail;
+    revokeInviteLink: typeof groupUserServices.revokeInviteLink;
     useInviteLink: typeof groupUserServices.useInviteLink;
   };
   group: {
@@ -63,6 +68,11 @@ export type DBServices = Readonly<{
     updateGroupWorkingDays: typeof groupServices.updateGroupWorkingDays;
     getApprovalUsers: typeof groupServices.getApprovalUsers;
     getGroupsWhereUserCanApprove: typeof groupServices.getGroupsWhereUserCanApprove;
+  };
+  groupMirror: {
+    getMirrorsIntoGroupForUser: typeof groupMirrorServices.getMirrorsIntoGroupForUser;
+    getMirrorsForUser: typeof groupMirrorServices.getMirrorsForUser;
+    setMirrorsIntoGroupForUser: typeof groupMirrorServices.setMirrorsIntoGroupForUser;
   };
   userYearQuotas: {
     getUserYearGroupQuotas: typeof userYearQuotasServices.getUserYearGroupQuotas;
@@ -78,6 +88,7 @@ export type DBServices = Readonly<{
   };
   user: {
     getUserById: typeof userServices.getUserById;
+    getUserByEmail: typeof userServices.getUserByEmail;
     getUsersByIds: typeof userServices.getUsersByIds;
   };
   userSettings: {
@@ -163,7 +174,11 @@ export const createDBServices = (): DBServices => {
     inviteLinks: {
       createInviteLink: groupUserServices.createInviteLink,
       getInviteLinksForGroup: groupUserServices.getInviteLinksForGroup,
+      getOpenInvitesForGroup: groupUserServices.getOpenInvitesForGroup,
       getInviteLinkByCode: groupUserServices.getInviteLinkByCode,
+      getInviteLinkById: groupUserServices.getInviteLinkById,
+      revokeOpenInviteForEmail: groupUserServices.revokeOpenInviteForEmail,
+      revokeInviteLink: groupUserServices.revokeInviteLink,
       useInviteLink: groupUserServices.useInviteLink,
     },
     group: {
@@ -177,6 +192,11 @@ export const createDBServices = (): DBServices => {
       updateGroupWorkingDays: groupServices.updateGroupWorkingDays,
       getApprovalUsers: groupServices.getApprovalUsers,
       getGroupsWhereUserCanApprove: groupServices.getGroupsWhereUserCanApprove,
+    },
+    groupMirror: {
+      getMirrorsIntoGroupForUser: groupMirrorServices.getMirrorsIntoGroupForUser,
+      getMirrorsForUser: groupMirrorServices.getMirrorsForUser,
+      setMirrorsIntoGroupForUser: groupMirrorServices.setMirrorsIntoGroupForUser,
     },
     userYearQuotas: {
       getUserYearGroupQuotas: userYearQuotasServices.getUserYearGroupQuotas,
@@ -192,6 +212,7 @@ export const createDBServices = (): DBServices => {
     },
     user: {
       getUserById: userServices.getUserById,
+      getUserByEmail: userServices.getUserByEmail,
       getUsersByIds: userServices.getUsersByIds,
     },
     userSettings: {

--- a/src/services/email/emailSender.ts
+++ b/src/services/email/emailSender.ts
@@ -84,6 +84,23 @@ export interface VacationCommentData {
 }
 
 /**
+ * `group-invite`: sent to someone an admin invited to join their group. The
+ * code is deliberately in the email body only — `signUpUrl` is the plain
+ * sign-up page and carries nothing, so a leaked link grants no access.
+ */
+export interface GroupInviteData {
+  groupName: string;
+  inviterName: string;
+  inviteCode: string;
+  /** Plain sign-up page, no token in it. */
+  signUpUrl: string;
+  /** Where an existing account redeems the code. */
+  joinUrl: string;
+  invitedEmail: string;
+  expiresIn: string;
+}
+
+/**
  * A templated email to send. `template` is the logical template name; the
  * adapter maps it to the concrete, stage-suffixed SES template name. The
  * union keeps each template's variables tied to its name.
@@ -94,7 +111,8 @@ export type TemplatedEmail =
   | { to: string; template: "vacation-approved"; data: VacationApprovedData }
   | { to: string; template: "vacation-rejected"; data: VacationRejectedData }
   | { to: string; template: "vacation-cancelled"; data: VacationCancelledData }
-  | { to: string; template: "vacation-comment"; data: VacationCommentData };
+  | { to: string; template: "vacation-comment"; data: VacationCommentData }
+  | { to: string; template: "group-invite"; data: GroupInviteData };
 
 export type EmailTemplateName = TemplatedEmail["template"];
 

--- a/src/services/email/index.ts
+++ b/src/services/email/index.ts
@@ -13,6 +13,7 @@ export type {
   VacationCancelledData,
   VacationRejectedData,
   VacationCommentData,
+  GroupInviteData,
 } from "./emailSender.js";
 
 /**

--- a/src/services/groupMirror/groupMirrorServices.ts
+++ b/src/services/groupMirror/groupMirrorServices.ts
@@ -1,0 +1,103 @@
+import { and, eq, isNull, notInArray } from "drizzle-orm";
+import { db, type DbTransaction } from "../../db/db.js";
+import { groupMirrors } from "../../db/schema/group-mirror-schema.js";
+import { groups } from "../../db/schema/group-schema.js";
+import { generateRandomUUID } from "../../utils/generateUUID.js";
+import type { GroupMirror, GroupMirrorListItem } from "./types.js";
+
+/** The caller's active mirrors into one group, with the source group's name. */
+export const getMirrorsIntoGroupForUser = async (
+  userId: string,
+  targetGroupId: string,
+  tx?: DbTransaction
+): Promise<GroupMirrorListItem[]> => {
+  const rows = await (tx ?? db)
+    .select({
+      id: groupMirrors.id,
+      userId: groupMirrors.userId,
+      sourceGroupId: groupMirrors.sourceGroupId,
+      targetGroupId: groupMirrors.targetGroupId,
+      deletedAt: groupMirrors.deletedAt,
+      createdAt: groupMirrors.createdAt,
+      updatedAt: groupMirrors.updatedAt,
+      sourceGroupName: groups.groupName,
+    })
+    .from(groupMirrors)
+    .innerJoin(groups, eq(groupMirrors.sourceGroupId, groups.id))
+    .where(
+      and(
+        eq(groupMirrors.userId, userId),
+        eq(groupMirrors.targetGroupId, targetGroupId),
+        isNull(groupMirrors.deletedAt),
+        isNull(groups.deletedAt)
+      )
+    );
+
+  return rows;
+};
+
+/** Every active mirror the user has, in any direction. */
+export const getMirrorsForUser = async (userId: string): Promise<GroupMirror[]> => {
+  return db
+    .select()
+    .from(groupMirrors)
+    .where(and(eq(groupMirrors.userId, userId), isNull(groupMirrors.deletedAt)));
+};
+
+/**
+ * Makes the user's mirrors into `targetGroupId` exactly `sourceGroupIds`.
+ * Diffed rather than wiped and re-inserted so an untouched mirror keeps its
+ * original `createdAt`. Callers must have already verified the user is an
+ * active member of the target and of every source group.
+ */
+export const setMirrorsIntoGroupForUser = async (
+  userId: string,
+  targetGroupId: string,
+  sourceGroupIds: string[],
+  tx?: DbTransaction
+): Promise<GroupMirrorListItem[]> => {
+  const runner = tx ?? db;
+
+  const existing = await runner
+    .select({ sourceGroupId: groupMirrors.sourceGroupId })
+    .from(groupMirrors)
+    .where(
+      and(
+        eq(groupMirrors.userId, userId),
+        eq(groupMirrors.targetGroupId, targetGroupId),
+        isNull(groupMirrors.deletedAt)
+      )
+    );
+
+  const existingIds = new Set(existing.map((row) => row.sourceGroupId));
+
+  const removedBase = and(
+    eq(groupMirrors.userId, userId),
+    eq(groupMirrors.targetGroupId, targetGroupId),
+    isNull(groupMirrors.deletedAt)
+  );
+
+  await runner
+    .update(groupMirrors)
+    .set({ deletedAt: new Date() })
+    .where(
+      sourceGroupIds.length === 0
+        ? removedBase
+        : and(removedBase, notInArray(groupMirrors.sourceGroupId, sourceGroupIds))
+    );
+
+  const added = sourceGroupIds.filter((id) => !existingIds.has(id));
+
+  if (added.length > 0) {
+    await runner.insert(groupMirrors).values(
+      added.map((sourceGroupId) => ({
+        id: generateRandomUUID(),
+        userId,
+        sourceGroupId,
+        targetGroupId,
+      }))
+    );
+  }
+
+  return getMirrorsIntoGroupForUser(userId, targetGroupId, tx);
+};

--- a/src/services/groupMirror/types.ts
+++ b/src/services/groupMirror/types.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export type GroupMirror = {
+  id: string;
+  userId: string;
+  sourceGroupId: string;
+  targetGroupId: string;
+  deletedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/** A mirror plus the source group's name, for the settings screen. */
+export type GroupMirrorListItem = GroupMirror & {
+  sourceGroupName: string;
+};
+
+/**
+ * One of the caller's other groups, and whether its records are currently
+ * mirrored into the group being configured.
+ */
+export type MirrorCandidate = {
+  groupId: string;
+  groupName: string;
+  mirrored: boolean;
+};
+
+export const validatePutGroupMirrors = z.object({
+  sourceGroupIds: z
+    .array(z.uuid())
+    .max(50)
+    .transform((ids) => Array.from(new Set(ids))),
+});
+
+export type ValidatedPutGroupMirrorsType = z.infer<typeof validatePutGroupMirrors>;

--- a/src/services/groupUser/groupUserServices.ts
+++ b/src/services/groupUser/groupUserServices.ts
@@ -1,6 +1,7 @@
 import { db, type DbTransaction } from "../../db/db.js";
 import { groupUsers } from "../../db/schema/group-users-schema.js";
-import { and, asc, countDistinct, eq, inArray, isNull } from "drizzle-orm";
+import { and, asc, countDistinct, desc, eq, gt, inArray, isNull } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import type {
   GroupUser,
   GroupUserInsertType,
@@ -8,6 +9,7 @@ import type {
   GroupUserPermissions,
   InviteLink,
   InviteLinkInsertType,
+  InviteLinkListItem,
 } from "./types.js";
 import { inviteLink } from "../../db/schema/invite-link-schema.js";
 import { user } from "../../db/schema/auth-schema.js";
@@ -128,15 +130,94 @@ export const countDistinctUsersInGroups = async (groupIds: string[]): Promise<nu
 };
 
 export const createInviteLink = async (
-  data: InviteLinkInsertType
+  data: InviteLinkInsertType,
+  tx?: DbTransaction
 ): Promise<InviteLink | undefined> => {
-  const [row] = await db.insert(inviteLink).values(data).returning();
+  const [row] = await (tx ?? db).insert(inviteLink).values(data).returning();
 
   return row;
 };
 
 export const getInviteLinksForGroup = async (groupId: string): Promise<InviteLink[]> => {
   return db.select().from(inviteLink).where(eq(inviteLink.groupId, groupId));
+};
+
+/**
+ * The group's invites that can still be redeemed, newest first — what the
+ * members screen lists so an admin can see who has an outstanding invite and
+ * re-read or revoke the code.
+ */
+export const getOpenInvitesForGroup = async (groupId: string): Promise<InviteLinkListItem[]> => {
+  const inviter = alias(user, "invitedByUser");
+
+  const rows = await db
+    .select({
+      id: inviteLink.id,
+      groupId: inviteLink.groupId,
+      code: inviteLink.code,
+      email: inviteLink.email,
+      invitedByUserId: inviteLink.invitedByUserId,
+      usedAt: inviteLink.usedAt,
+      revokedAt: inviteLink.revokedAt,
+      expiresAt: inviteLink.expiresAt,
+      createdAt: inviteLink.createdAt,
+      updatedAt: inviteLink.updatedAt,
+      invitedByName: inviter.name,
+    })
+    .from(inviteLink)
+    .leftJoin(inviter, eq(inviteLink.invitedByUserId, inviter.id))
+    .where(
+      and(
+        eq(inviteLink.groupId, groupId),
+        isNull(inviteLink.usedAt),
+        isNull(inviteLink.revokedAt),
+        gt(inviteLink.expiresAt, new Date())
+      )
+    )
+    .orderBy(desc(inviteLink.createdAt));
+
+  return rows;
+};
+
+export const getInviteLinkById = async (inviteId: string): Promise<InviteLink | undefined> => {
+  const [row] = await db.select().from(inviteLink).where(eq(inviteLink.id, inviteId)).limit(1);
+
+  return row;
+};
+
+/**
+ * Retires the open invite for (group, email) if there is one, so re-inviting
+ * the same address issues a fresh code instead of tripping the partial unique
+ * index — and so the superseded code stops working.
+ */
+export const revokeOpenInviteForEmail = async (
+  groupId: string,
+  email: string,
+  tx?: DbTransaction
+): Promise<void> => {
+  await (tx ?? db)
+    .update(inviteLink)
+    .set({ revokedAt: new Date() })
+    .where(
+      and(
+        eq(inviteLink.groupId, groupId),
+        eq(inviteLink.email, email),
+        isNull(inviteLink.usedAt),
+        isNull(inviteLink.revokedAt)
+      )
+    );
+};
+
+export const revokeInviteLink = async (inviteId: string): Promise<InviteLink | undefined> => {
+  const [row] = await db
+    .update(inviteLink)
+    .set({ revokedAt: new Date() })
+    .where(
+      and(eq(inviteLink.id, inviteId), isNull(inviteLink.usedAt), isNull(inviteLink.revokedAt))
+    )
+    .returning();
+
+  return row;
 };
 
 export const getInviteLinkByCode = async (
@@ -152,6 +233,11 @@ export const getInviteLinkByCode = async (
   return row;
 };
 
+/**
+ * Marks the code as redeemed. The `usedAt IS NULL` predicate is what makes an
+ * invite single-use even under concurrent redemptions: the second update
+ * matches no row and the caller rolls back.
+ */
 export const useInviteLink = async (
   code: string,
   tx?: DbTransaction
@@ -159,7 +245,7 @@ export const useInviteLink = async (
   const [row] = await (tx ?? db)
     .update(inviteLink)
     .set({ usedAt: new Date() })
-    .where(and(eq(inviteLink.code, code), isNull(inviteLink.usedAt)))
+    .where(and(eq(inviteLink.code, code), isNull(inviteLink.usedAt), isNull(inviteLink.revokedAt)))
     .returning();
 
   return row;

--- a/src/services/groupUser/inviteNotifier.ts
+++ b/src/services/groupUser/inviteNotifier.ts
@@ -1,0 +1,53 @@
+import { config } from "../../config.js";
+import { logger } from "../../middleware/logger.js";
+import { emailSender } from "../email/index.js";
+
+/** Matches the invite's `expiresAt`; SES needs it as a human-readable string. */
+export const INVITE_EXPIRES_IN = "14 days";
+export const INVITE_TTL_DAYS = 14;
+
+export const inviteExpiryFrom = (now: Date): Date =>
+  new Date(now.getTime() + INVITE_TTL_DAYS * 24 * 60 * 60 * 1000);
+
+/** The plain sign-up page — deliberately carries no code or token. */
+export const buildSignUpUrl = (): string => new URL("/sign-up/", config.email.appUrl).toString();
+
+/** Where an account that already exists pastes the code. */
+export const buildJoinUrl = (): string => new URL("/groups/", config.email.appUrl).toString();
+
+/**
+ * Sends the invite email. Returns whether it went out rather than throwing:
+ * the invite row is already committed and the code is handed back to the
+ * admin, so a mail failure should downgrade to "share this code yourself"
+ * instead of failing a request that already did its work.
+ */
+export const notifyGroupInvited = async (input: {
+  email: string;
+  groupName: string;
+  inviterName: string;
+  code: string;
+}): Promise<boolean> => {
+  try {
+    await emailSender.sendTemplated({
+      to: input.email,
+      template: "group-invite",
+      data: {
+        groupName: input.groupName,
+        inviterName: input.inviterName,
+        inviteCode: input.code,
+        signUpUrl: buildSignUpUrl(),
+        joinUrl: buildJoinUrl(),
+        invitedEmail: input.email,
+        expiresIn: INVITE_EXPIRES_IN,
+      },
+    });
+    return true;
+  } catch (error) {
+    logger.error("Failed to send group invite email", {
+      email: input.email,
+      groupName: input.groupName,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+};

--- a/src/services/groupUser/types.ts
+++ b/src/services/groupUser/types.ts
@@ -37,7 +37,11 @@ export type InviteLink = {
   id: string;
   groupId: string;
   code: string;
+  /** Address the invite was issued to; null only on rows predating email invites. */
+  email: string | null;
+  invitedByUserId: string | null;
   usedAt: Date | null;
+  revokedAt: Date | null;
   expiresAt: Date;
   createdAt: Date;
   updatedAt: Date;
@@ -47,8 +51,21 @@ export type InviteLinkInsertType = {
   id: string;
   groupId: string;
   code: string;
+  email?: string | null;
+  invitedByUserId?: string | null;
   expiresAt: Date;
 };
+
+/** An invite plus who sent it, for the group's pending-invites list. */
+export type InviteLinkListItem = InviteLink & {
+  invitedByName: string | null;
+};
+
+export const validatePostGroupInvite = z.object({
+  email: z.email().transform((value) => value.toLowerCase()),
+});
+
+export type ValidatedPostGroupInviteType = z.infer<typeof validatePostGroupInvite>;
 
 export const validatePutGroupUserUpdate = z.object({
   groupId: z.uuid(),

--- a/src/services/user/userServices.ts
+++ b/src/services/user/userServices.ts
@@ -22,6 +22,24 @@ export const getUserById = async (
 };
 
 /**
+ * Looks a user up by email. `user.email` is uniquely indexed, so this matches
+ * at most one row. Callers must pass an already lower-cased address —
+ * better-auth stores emails lower-cased.
+ */
+export const getUserByEmail = async (
+  email: string,
+  tx?: DbTransaction
+): Promise<UserContact | undefined> => {
+  const [row] = await (tx ?? db)
+    .select({ id: user.id, name: user.name, email: user.email })
+    .from(user)
+    .where(eq(user.email, email))
+    .limit(1);
+
+  return row;
+};
+
+/**
  * Contact details for a set of users. Used by the notifier, which resolves
  * every recipient of a batch in one query.
  */

--- a/src/services/vacation/types.ts
+++ b/src/services/vacation/types.ts
@@ -42,6 +42,16 @@ export type VacationListItem = VacationType & {
 };
 
 /**
+ * A record as seen from one group's perspective. `mirroredFromGroupId` is null
+ * for the group's own records; when set, the record is only projected here from
+ * that group and is read-only — it is approved, counted and reported in its
+ * source group alone.
+ */
+export type GroupVacationListItem = VacationListItem & {
+  mirroredFromGroupId: string | null;
+};
+
+/**
  * A single request as shown on the detail view: the row, who it belongs to,
  * which group it was booked in, and who decided on it.
  */

--- a/src/services/vacation/vacationServices.ts
+++ b/src/services/vacation/vacationServices.ts
@@ -7,6 +7,7 @@ import {
   count,
   countDistinct,
   eq,
+  exists,
   gte,
   inArray,
   isNotNull,
@@ -17,6 +18,7 @@ import {
   sql,
 } from "drizzle-orm";
 import type {
+  GroupVacationListItem,
   VacationDetail,
   VacationInsertType,
   VacationListItem,
@@ -24,6 +26,8 @@ import type {
 } from "./types.js";
 import { user } from "../../db/schema/auth-schema.js";
 import { groups } from "../../db/schema/group-schema.js";
+import { groupUsers } from "../../db/schema/group-users-schema.js";
+import { groupMirrors } from "../../db/schema/group-mirror-schema.js";
 import { alias } from "drizzle-orm/pg-core";
 import { buildUserSummary, type UserSummary } from "../../utils/userPresentation.js";
 import { sumDaysWhere } from "./dayWeight.js";
@@ -65,18 +69,43 @@ const baseVacationSelection = {
 /**
  * Retrieves a list of vacations for a specific group within a given date range,
  * enriched with the requesting user's display summary. Optionally filters by user.
+ *
+ * Also returns records a member has mirrored into this group from another one
+ * they belong to (see `group_mirrors`). Those carry a non-null
+ * `mirroredFromGroupId` and stay owned by their source group: they are only
+ * projected here for visibility, are never approvable in this group — the
+ * approval queries key on `vacation.groupId` — and never count against this
+ * group's quotas or reports.
  */
 export const getVacationsForGroup = async (
   groupId: string,
   startDate: string,
   endDate: string,
   userId: string | null = null
-): Promise<VacationListItem[]> => {
+): Promise<GroupVacationListItem[]> => {
+  // A mirror only projects records of someone who still belongs to the target
+  // group; without this a member who left would keep leaking time off into it.
+  const stillAMember = exists(
+    db
+      .select({ one: sql`1` })
+      .from(groupUsers)
+      .where(
+        and(
+          eq(groupUsers.userId, vacation.userId),
+          eq(groupUsers.groupId, groupId),
+          isNull(groupUsers.deletedAt)
+        )
+      )
+  );
+
+  const inThisGroup = eq(vacation.groupId, groupId);
+  const mirroredIntoThisGroup = and(isNotNull(groupMirrors.id), stillAMember);
+
   const base = [
-    eq(vacation.groupId, groupId),
     isNull(vacation.deletedAt),
     gte(vacation.requestedDay, startDate),
     lt(vacation.requestedDay, endDate),
+    or(inThisGroup, mirroredIntoThisGroup),
   ] as const;
   const where = userId !== null ? and(...base, eq(vacation.userId, userId)) : and(...base);
 
@@ -84,10 +113,24 @@ export const getVacationsForGroup = async (
     .select(baseVacationSelection)
     .from(vacation)
     .innerJoin(user, eq(vacation.userId, user.id))
+    // At most one row can match: `group_mirrors_user_source_target_uniq` makes
+    // (user, source, target) unique among active mirrors, so this cannot fan out.
+    .leftJoin(
+      groupMirrors,
+      and(
+        eq(groupMirrors.userId, vacation.userId),
+        eq(groupMirrors.sourceGroupId, vacation.groupId),
+        eq(groupMirrors.targetGroupId, groupId),
+        isNull(groupMirrors.deletedAt)
+      )
+    )
     .where(where)
     .orderBy(asc(vacation.requestedDay));
 
-  return rows.map(toListItem);
+  return rows.map((row) => ({
+    ...toListItem(row),
+    mirroredFromGroupId: row.groupId === groupId ? null : row.groupId,
+  }));
 };
 
 /**

--- a/src/tests/e2e/groupMirror.e2e.test.ts
+++ b/src/tests/e2e/groupMirror.e2e.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { and, eq } from "drizzle-orm";
+import { db } from "../../db/db.js";
+import { groupMirrors } from "../../db/schema/group-mirror-schema.js";
+import { groupUsers } from "../../db/schema/group-users-schema.js";
+import { vacation, vacationType } from "../../db/schema/vacation-schema.js";
+import { v4 as uuidv4 } from "uuid";
+import { getVacationsForGroup } from "../../services/vacation/vacationServices.js";
+import {
+  getMirrorsIntoGroupForUser,
+  setMirrorsIntoGroupForUser,
+} from "../../services/groupMirror/groupMirrorServices.js";
+import { getPendingApprovalsForApprover } from "../../services/vacation/vacationServices.js";
+import { createTestGroup, createTestUser, cleanupTestData } from "./helpers/testSetup.js";
+
+/**
+ * Mirroring lives almost entirely in one SQL query, so it is verified here
+ * against a real database rather than with mocks.
+ *
+ * Shape under test: Dana books her time off in "Team A" (where her manager
+ * approves it) and wants it visible in "All Engineering", the umbrella group
+ * she also belongs to.
+ */
+describe("group mirroring", () => {
+  let dana: { id: string };
+  let outsider: { id: string };
+  let manager: { id: string };
+  let teamA: { id: string };
+  let allEng: { id: string };
+
+  const MONTH_START = "2026-03-01";
+  const MONTH_END = "2026-04-01";
+
+  const addMember = (userId: string, groupId: string) =>
+    db.insert(groupUsers).values({
+      id: uuidv4(),
+      userId,
+      groupId,
+      viewAccess: true,
+      adminAccess: false,
+      controlledUser: true,
+    });
+
+  const removeMember = (userId: string, groupId: string) =>
+    db
+      .delete(groupUsers)
+      .where(and(eq(groupUsers.userId, userId), eq(groupUsers.groupId, groupId)));
+
+  const book = (userId: string, groupId: string, day: string, approved = true) =>
+    db.insert(vacation).values({
+      id: uuidv4(),
+      userId,
+      groupId,
+      requestedDay: day,
+      vacationType: vacationType.Vacation,
+      approvedAt: approved ? new Date() : null,
+      approvedBy: approved ? manager.id : null,
+    });
+
+  beforeAll(async () => {
+    await cleanupTestData();
+
+    manager = await createTestUser("mirror-manager@test.com", "Manager", "password123");
+    dana = await createTestUser("mirror-dana@test.com", "Dana Holt", "password123");
+    outsider = await createTestUser("mirror-outsider@test.com", "Outsider", "password123");
+
+    teamA = await createTestGroup("Team A", manager.id, manager.id);
+    allEng = await createTestGroup("All Engineering", manager.id, manager.id);
+
+    await addMember(dana.id, teamA.id);
+    await addMember(dana.id, allEng.id);
+    await addMember(outsider.id, teamA.id);
+  });
+
+  afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  beforeEach(async () => {
+    await db.delete(groupMirrors);
+    await db.delete(vacation);
+  });
+
+  it("hides records booked elsewhere until a mirror exists", async () => {
+    await book(dana.id, teamA.id, "2026-03-10");
+
+    const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it("shows a mirrored record in the target group, flagged with its source", async () => {
+    await book(dana.id, teamA.id, "2026-03-10");
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+
+    const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      userId: dana.id,
+      groupId: teamA.id,
+      requestedDay: "2026-03-10",
+      mirroredFromGroupId: teamA.id,
+    });
+  });
+
+  it("leaves the group's own records unflagged", async () => {
+    await book(dana.id, allEng.id, "2026-03-11");
+
+    const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.mirroredFromGroupId).toBeNull();
+  });
+
+  it("returns own and mirrored records together, without duplicating either", async () => {
+    await addMember(outsider.id, allEng.id);
+    await book(dana.id, teamA.id, "2026-03-10");
+    await book(outsider.id, allEng.id, "2026-03-12");
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+
+    const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.requestedDay)).toEqual(["2026-03-10", "2026-03-12"]);
+
+    await removeMember(outsider.id, allEng.id);
+  });
+
+  it("stops projecting a member's records once they leave the target group", async () => {
+    await book(dana.id, teamA.id, "2026-03-10");
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    expect(await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END)).toHaveLength(1);
+
+    // The mirror row survives, but someone who left must not keep leaking time
+    // off into a group they no longer belong to.
+    await removeMember(dana.id, allEng.id);
+
+    expect(await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END)).toHaveLength(0);
+
+    await addMember(dana.id, allEng.id);
+  });
+
+  it("does not mirror in the opposite direction", async () => {
+    await book(dana.id, allEng.id, "2026-03-13");
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+
+    const rows = await getVacationsForGroup(teamA.id, MONTH_START, MONTH_END);
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it("never makes a mirrored record approvable in the target group", async () => {
+    await book(dana.id, teamA.id, "2026-03-14", false);
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+
+    const pending = await getPendingApprovalsForApprover(manager.id);
+
+    // Visible in All Engineering, but the only decision to make is in Team A.
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.groupId).toBe(teamA.id);
+  });
+
+  it("mirrors pending records too, so the team sees planned absence", async () => {
+    await book(dana.id, teamA.id, "2026-03-15", false);
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+
+    const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.approvedAt).toBeNull();
+  });
+
+  it("stops mirroring when the source is removed", async () => {
+    await book(dana.id, teamA.id, "2026-03-10");
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, []);
+
+    const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
+
+    expect(rows).toHaveLength(0);
+    expect(await getMirrorsIntoGroupForUser(dana.id, allEng.id)).toHaveLength(0);
+  });
+
+  it("only mirrors the user who opted in, not everyone in the source group", async () => {
+    await book(dana.id, teamA.id, "2026-03-10");
+    await book(outsider.id, teamA.id, "2026-03-16");
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+
+    const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.userId).toBe(dana.id);
+  });
+
+  it("keeps the date-range filter", async () => {
+    await book(dana.id, teamA.id, "2026-02-20");
+    await book(dana.id, teamA.id, "2026-03-10");
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+
+    const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.requestedDay).toBe("2026-03-10");
+  });
+
+  it("honours the per-user filter", async () => {
+    await book(dana.id, teamA.id, "2026-03-10");
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+
+    expect(await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END, dana.id)).toHaveLength(1);
+    expect(await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END, outsider.id)).toHaveLength(
+      0
+    );
+  });
+
+  it("is idempotent and does not duplicate rows when set twice", async () => {
+    await book(dana.id, teamA.id, "2026-03-10");
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+
+    expect(await getMirrorsIntoGroupForUser(dana.id, allEng.id)).toHaveLength(1);
+    expect(await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END)).toHaveLength(1);
+  });
+
+  it("names the source group for the settings screen", async () => {
+    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+
+    const mirrors = await getMirrorsIntoGroupForUser(dana.id, allEng.id);
+
+    expect(mirrors[0]).toMatchObject({ sourceGroupId: teamA.id, sourceGroupName: "Team A" });
+  });
+});

--- a/src/tests/utils/inviteCode.test.ts
+++ b/src/tests/utils/inviteCode.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { generateInviteCode, normalizeInviteCode } from "../../utils/inviteCode.js";
+
+describe("generateInviteCode", () => {
+  it("produces a XXXX-XXXX-XXXX code", () => {
+    expect(generateInviteCode()).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{4}-[A-Z2-9]{4}$/);
+  });
+
+  it("never emits the characters that are ambiguous when read aloud", () => {
+    const codes = Array.from({ length: 200 }, () => generateInviteCode()).join("");
+    for (const ambiguous of ["I", "L", "O", "U", "0", "1"]) {
+      expect(codes).not.toContain(ambiguous);
+    }
+  });
+
+  it("does not repeat itself across a large batch", () => {
+    const codes = Array.from({ length: 1000 }, () => generateInviteCode());
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it("round-trips through normalizeInviteCode unchanged", () => {
+    const code = generateInviteCode();
+    expect(normalizeInviteCode(code)).toBe(code);
+  });
+});
+
+describe("normalizeInviteCode", () => {
+  it("accepts the canonical form", () => {
+    expect(normalizeInviteCode("ABCD-EFGH-JKMN")).toBe("ABCD-EFGH-JKMN");
+  });
+
+  it("accepts lower case", () => {
+    expect(normalizeInviteCode("abcd-efgh-jkmn")).toBe("ABCD-EFGH-JKMN");
+  });
+
+  it("accepts a code with no dashes", () => {
+    expect(normalizeInviteCode("ABCDEFGHJKMN")).toBe("ABCD-EFGH-JKMN");
+  });
+
+  it("accepts stray whitespace from a copy-paste", () => {
+    expect(normalizeInviteCode("  ABCD EFGH JKMN ")).toBe("ABCD-EFGH-JKMN");
+  });
+
+  it("rejects a code of the wrong length", () => {
+    expect(normalizeInviteCode("ABCD-EFGH")).toBeNull();
+    expect(normalizeInviteCode("ABCD-EFGH-JKMN-PQRS")).toBeNull();
+  });
+
+  it("rejects characters outside the alphabet", () => {
+    // O and 0 are deliberately absent, so a typo cannot silently resolve to
+    // some other valid code.
+    expect(normalizeInviteCode("ABCD-EFGH-JKM0")).toBeNull();
+    expect(normalizeInviteCode("ABCD-EFGH-JKM!")).toBeNull();
+  });
+
+  it("rejects an empty string", () => {
+    expect(normalizeInviteCode("")).toBeNull();
+  });
+});

--- a/src/utils/inviteCode.ts
+++ b/src/utils/inviteCode.ts
@@ -1,0 +1,36 @@
+import crypto from "crypto";
+
+// Crockford-style alphabet: no I/L/O/U/0/1, so a code read off a screen and
+// typed into the join form cannot be ambiguous.
+const ALPHABET = "ABCDEFGHJKMNPQRSTVWXYZ23456789";
+const GROUP_SIZE = 4;
+const GROUPS = 3;
+
+/**
+ * A 12-character invite code formatted as `XXXX-XXXX-XXXX`. ~59 bits of
+ * entropy from `randomInt`, which rejection-samples and so stays uniform over
+ * the 30-character alphabet.
+ */
+export const generateInviteCode = (): string =>
+  Array.from({ length: GROUPS }, () =>
+    Array.from(
+      { length: GROUP_SIZE },
+      () => ALPHABET[crypto.randomInt(ALPHABET.length)] as string
+    ).join("")
+  ).join("-");
+
+/**
+ * Accepts what a human typed: case-insensitive, dashes and spaces optional.
+ * Returns the canonical stored form, or null when it isn't a plausible code.
+ */
+export const normalizeInviteCode = (raw: string): string | null => {
+  const stripped = raw.toUpperCase().replace(/[\s-]/g, "");
+  if (stripped.length !== GROUP_SIZE * GROUPS) return null;
+  if (![...stripped].every((char) => ALPHABET.includes(char))) return null;
+
+  const chunks: string[] = [];
+  for (let i = 0; i < stripped.length; i += GROUP_SIZE) {
+    chunks.push(stripped.slice(i, i + GROUP_SIZE));
+  }
+  return chunks.join("-");
+};


### PR DESCRIPTION
Reworks how groups are joined and presented. Part of a three-repo change — **merge and deploy this first**; the frontend PR calls endpoints that do not exist without it.

## 1. Sign-up no longer requires a group

`teamName` is now optional on `POST /api/auth/sign-up-with-team`; the response carries `group: null` when it is absent. Booking time off was already gated on the membership rather than on sign-up, so an account with no group simply cannot request leave until it creates or joins one.

## 2. Email invites

Previously nothing could generate the codes the join form accepted.

| Endpoint | |
|---|---|
| `POST /api/group-user/:groupId/invites` | issue a code and email it (admin) |
| `GET /api/group-user/:groupId/invites` | list outstanding invites (admin) |
| `DELETE /api/group-user/invites/:inviteId` | revoke (admin) |

- Codes are `XXXX-XXXX-XXXX` from an alphabet with no I/L/O/U/0/1, accepted case-insensitively with or without dashes.
- **Bound to the invited address** — `handlePostGroupUser` refuses a redeemer whose session email differs, so a forwarded code is useless to a stranger. Rows predating this change have a null email and stay unrestricted.
- Single-use is enforced by the `usedAt IS NULL` predicate in the redeeming `UPDATE`, so two concurrent redemptions cannot both win.
- The code is returned to the admin as well as emailed, so a failed send degrades to "share it yourself" (`emailDelivered: false`) instead of a dead end.

## 3. Mirroring

A user can show their records from one group inside another they belong to — a manager surfacing their own approved leave to their team, or several small teams feeding one umbrella group.

It is a **read-side projection only**: no vacation row is ever copied, so a mirrored record is still approved, counted against quotas and reported in its source group alone. Two invariants worth preserving:

- Mirrored records are never approvable in the target group. Nothing enforces this explicitly — the approval queries key on `vacation.groupId`, and that is *why* they must keep doing so.
- `getVacationsForGroup` re-checks active membership of the target group before projecting, so someone who leaves stops appearing there even though the mirror row survives.

Scoped to the data layer by design: `getVacationsForGroup` is mirror-aware but no new read endpoint was added, so nothing renders mirrored records yet.

## Migration

`0007_illegal_marauders.sql` — **must be run manually against production.** `cd.yml` only builds and pushes the image; the `db:migrate` step in `ci.yml` targets the CI throwaway database.

```bash
DATABASE='<prod-connection-string>' npm run db:migrate
```

Additive only: a new `group_mirrors` table, plus three **nullable** columns on `invite_link` (`email`, `invited_by_user_id`, `revoked_at`). No column is dropped, renamed, retyped or made `NOT NULL`; nothing is backfilled or deleted. Old code ignores the new columns, so migrate-then-deploy has no broken window.

Two notes:
- The new indexes are not `CONCURRENTLY`, so they briefly block writes on `invite_link` while building — irrelevant at that table's size.
- The partial unique index on `(group_id, email)` is safe against existing rows: every pre-existing invite has `email = NULL`, and Postgres treats NULLs as distinct in unique indexes, so open legacy invites in the same group will not collide.

## Testing

236 unit tests (+29) and 84 e2e (+14). Mirroring is almost entirely one SQL query, so it is covered by e2e against a real database rather than mocks — including that a mirrored pending record shows in the target group but appears in the approver's queue **only** under its source group.

Verified by hand in the running app: a second member was refused another's code, the invited member redeemed it typed lower-case without dashes, her leave then appeared in the umbrella group flagged as mirrored while the approval queue still attributed it solely to her own team, and a revoked code stopped working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signup can now create an account without creating a group.
  * Added group mirroring to display selected records across groups.
  * Added administrator tools to create, list, redeem, and revoke email invitations.
  * Added expiring, single-use invite codes and invitation emails.
* **Bug Fixes**
  * Improved invite validation, authorization, duplicate handling, revocation, and redemption conflict responses.
  * Group and membership creation now rolls back safely when persistence fails.
* **Documentation**
  * Updated API documentation for optional groups, mirroring, and invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->