### PR TITLE
feat: let the dashboard calendar show a whole group

### DIFF
--- a/src/controllers/users/handleGetMySettings.ts
+++ b/src/controllers/users/handleGetMySettings.ts
@@ -13,5 +13,7 @@ export const handleGetMySettings = async (req: Request, res: Response) => {
 
   return res.status(200).json({
     emailNotifications: settings?.emailNotifications ?? DEFAULT_USER_SETTINGS.emailNotifications,
+    dashboardScope: settings?.dashboardScope ?? DEFAULT_USER_SETTINGS.dashboardScope,
+    dashboardGroupId: settings?.dashboardGroupId ?? DEFAULT_USER_SETTINGS.dashboardGroupId,
   });
 };

--- a/src/controllers/users/handlePutMySettings.ts
+++ b/src/controllers/users/handlePutMySettings.ts
@@ -1,7 +1,13 @@
 import type { Request, Response } from "express";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
-import type { ValidatedPutUserSettingsType } from "../../services/userSettings/types.js";
+import {
+  DEFAULT_USER_SETTINGS,
+  type UserSettingsPatch,
+  type ValidatedPutUserSettingsType,
+} from "../../services/userSettings/types.js";
+import { dashboardScope } from "../../db/schema/user-settings-schema.js";
+import { canViewWholeGroup } from "../../services/report/reportScope.js";
 import AppError from "../../utils/appError.js";
 
 const services = createDBServices();
@@ -12,9 +18,43 @@ export const handlePutMySettings = async (req: Request, res: Response) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const data: ValidatedPutUserSettingsType = req.body;
 
-  const updated = await services.userSettings.upsertUserSettings(auth.userId, {
-    emailNotifications: data.emailNotifications,
-  });
+  const current = await services.userSettings.getUserSettings(auth.userId);
+
+  const patch: UserSettingsPatch = {};
+  if (data.emailNotifications !== undefined) patch.emailNotifications = data.emailNotifications;
+  if (data.dashboardScope !== undefined) patch.dashboardScope = data.dashboardScope;
+  if (data.dashboardGroupId !== undefined) patch.dashboardGroupId = data.dashboardGroupId;
+
+  // The patch is validated against the settings it produces, not against
+  // itself: switching to GROUP scope may rely on a group chosen earlier.
+  const nextScope =
+    patch.dashboardScope ?? current?.dashboardScope ?? DEFAULT_USER_SETTINGS.dashboardScope;
+  const nextGroupId =
+    patch.dashboardGroupId !== undefined
+      ? patch.dashboardGroupId
+      : current?.dashboardGroupId ?? DEFAULT_USER_SETTINGS.dashboardGroupId;
+
+  if (nextScope === dashboardScope.Group && !nextGroupId) {
+    throw new AppError({
+      code: 422,
+      message: "A group must be selected for group scope",
+      logging: false,
+    });
+  }
+
+  if (nextGroupId) {
+    const scope = await services.report.getScopeEntries(auth.userId);
+    if (!canViewWholeGroup(scope, nextGroupId)) {
+      throw new AppError({
+        code: 403,
+        message: "No access to view this group's records",
+        logging: true,
+        context: { userId: auth.userId, groupId: nextGroupId },
+      });
+    }
+  }
+
+  const updated = await services.userSettings.upsertUserSettings(auth.userId, patch);
 
   if (!updated) {
     throw new AppError({
@@ -25,5 +65,9 @@ export const handlePutMySettings = async (req: Request, res: Response) => {
     });
   }
 
-  return res.status(200).json({ emailNotifications: updated.emailNotifications });
+  return res.status(200).json({
+    emailNotifications: updated.emailNotifications,
+    dashboardScope: updated.dashboardScope,
+    dashboardGroupId: updated.dashboardGroupId,
+  });
 };

--- a/src/controllers/users/tests/handleMySettings.test.ts
+++ b/src/controllers/users/tests/handleMySettings.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockGetUserSettings, mockUpsertUserSettings } = vi.hoisted(() => ({
+const { mockGetUserSettings, mockUpsertUserSettings, mockGetScopeEntries } = vi.hoisted(() => ({
   mockGetUserSettings: vi.fn(),
   mockUpsertUserSettings: vi.fn(),
+  mockGetScopeEntries: vi.fn(),
 }));
 
 vi.mock("../../../middleware/authSession.js", () => ({
@@ -15,6 +16,9 @@ vi.mock("../../../services/DBServices.js", () => ({
       getUserSettings: mockGetUserSettings,
       upsertUserSettings: mockUpsertUserSettings,
     },
+    report: {
+      getScopeEntries: mockGetScopeEntries,
+    },
   }),
 }));
 
@@ -22,34 +26,56 @@ import { handleGetMySettings } from "../handleGetMySettings.js";
 import { handlePutMySettings } from "../handlePutMySettings.js";
 import { getAuth } from "../../../middleware/authSession.js";
 import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
+import { dashboardScope } from "../../../db/schema/user-settings-schema.js";
+
+const DEFAULTS = {
+  emailNotifications: true,
+  dashboardScope: dashboardScope.Mine,
+  dashboardGroupId: null,
+};
+
+const scopeEntry = (access: "all" | "self") => ({
+  groupId: "group_1",
+  groupName: "Team A",
+  access,
+  canEditQuotas: false,
+});
 
 describe("user settings endpoints", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
+    mockGetUserSettings.mockResolvedValue(undefined);
   });
 
   it("defaults email notifications to on when the user has no stored settings", async () => {
     const { req, res } = makeReqRes();
-    mockGetUserSettings.mockResolvedValue(undefined);
 
     await handleGetMySettings(req, res);
 
-    expect(res.json).toHaveBeenCalledWith({ emailNotifications: true });
+    expect(res.json).toHaveBeenCalledWith(DEFAULTS);
   });
 
   it("returns the stored preference", async () => {
     const { req, res } = makeReqRes();
-    mockGetUserSettings.mockResolvedValue({ emailNotifications: false });
+    mockGetUserSettings.mockResolvedValue({
+      emailNotifications: false,
+      dashboardScope: dashboardScope.Group,
+      dashboardGroupId: "group_1",
+    });
 
     await handleGetMySettings(req, res);
 
-    expect(res.json).toHaveBeenCalledWith({ emailNotifications: false });
+    expect(res.json).toHaveBeenCalledWith({
+      emailNotifications: false,
+      dashboardScope: dashboardScope.Group,
+      dashboardGroupId: "group_1",
+    });
   });
 
   it("saves the preference for the authenticated user", async () => {
     const { req, res } = makeReqRes({ body: { emailNotifications: false } });
-    mockUpsertUserSettings.mockResolvedValue({ emailNotifications: false });
+    mockUpsertUserSettings.mockResolvedValue({ ...DEFAULTS, emailNotifications: false });
 
     await handlePutMySettings(req, res);
 
@@ -57,6 +83,69 @@ describe("user settings endpoints", () => {
       emailNotifications: false,
     });
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ emailNotifications: false });
+    expect(res.json).toHaveBeenCalledWith({ ...DEFAULTS, emailNotifications: false });
+  });
+
+  it("only sends the supplied fields to the store, leaving the rest untouched", async () => {
+    const { req, res } = makeReqRes({
+      body: { dashboardScope: dashboardScope.Group, dashboardGroupId: "group_1" },
+    });
+    mockGetScopeEntries.mockResolvedValue([scopeEntry("all")]);
+    mockUpsertUserSettings.mockResolvedValue({
+      ...DEFAULTS,
+      dashboardScope: dashboardScope.Group,
+      dashboardGroupId: "group_1",
+    });
+
+    await handlePutMySettings(req, res);
+
+    expect(mockUpsertUserSettings).toHaveBeenCalledWith(mockAuthData.userId, {
+      dashboardScope: dashboardScope.Group,
+      dashboardGroupId: "group_1",
+    });
+  });
+
+  it("accepts group scope when the group was already stored", async () => {
+    const { req, res } = makeReqRes({ body: { dashboardScope: dashboardScope.Group } });
+    mockGetUserSettings.mockResolvedValue({ ...DEFAULTS, dashboardGroupId: "group_1" });
+    mockGetScopeEntries.mockResolvedValue([scopeEntry("all")]);
+    mockUpsertUserSettings.mockResolvedValue({
+      ...DEFAULTS,
+      dashboardScope: dashboardScope.Group,
+      dashboardGroupId: "group_1",
+    });
+
+    await handlePutMySettings(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("rejects group scope without a group", async () => {
+    const { req, res } = makeReqRes({ body: { dashboardScope: dashboardScope.Group } });
+
+    await expect(handlePutMySettings(req, res)).rejects.toMatchObject({ code: 422 });
+    expect(mockUpsertUserSettings).not.toHaveBeenCalled();
+  });
+
+  it("rejects a group the caller may not view in full", async () => {
+    const { req, res } = makeReqRes({
+      body: { dashboardScope: dashboardScope.Group, dashboardGroupId: "group_1" },
+    });
+    mockGetScopeEntries.mockResolvedValue([scopeEntry("self")]);
+
+    await expect(handlePutMySettings(req, res)).rejects.toMatchObject({ code: 403 });
+    expect(mockUpsertUserSettings).not.toHaveBeenCalled();
+  });
+
+  it("clears the selected group without re-authorizing it", async () => {
+    const { req, res } = makeReqRes({
+      body: { dashboardScope: dashboardScope.Mine, dashboardGroupId: null },
+    });
+    mockUpsertUserSettings.mockResolvedValue(DEFAULTS);
+
+    await handlePutMySettings(req, res);
+
+    expect(mockGetScopeEntries).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
   });
 });

--- a/src/controllers/vacation/handleGetVacations.ts
+++ b/src/controllers/vacation/handleGetVacations.ts
@@ -3,6 +3,8 @@ import { getAuth } from "../../middleware/authSession.js";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
+import { canViewWholeGroup } from "../../services/report/reportScope.js";
+import AppError from "../../utils/appError.js";
 
 const services = createDBServices();
 
@@ -20,16 +22,43 @@ const validateMonth = z.coerce
   .max(12)
   .prefault(() => new Date().getMonth() + 1);
 
+const validateGroupId = z.string().min(1).optional();
+
 export const handleGetVacations = async (req: Request, res: Response) => {
   const auth = getAuth(req);
 
   const year = validateYear.parse(req.query.year);
   const month = validateMonth.parse(req.query.month);
+  const groupId = validateGroupId.parse(req.query.groupId);
 
   const range = formatStartAndEndDate(year, month);
 
-  const result = await services.vacation.getVacationsForUser(
-    auth.userId,
+  if (groupId === undefined) {
+    const result = await services.vacation.getVacationsForUser(
+      auth.userId,
+      range.startDate,
+      range.endDate
+    );
+    // Same shape either way, so the calendar does not branch on scope.
+    return res
+      .status(200)
+      .json(
+        result.map((row) => ({ ...row, mirroredFromGroupId: null, mirroredFromGroupName: null }))
+      );
+  }
+
+  const scope = await services.report.getScopeEntries(auth.userId);
+  if (!canViewWholeGroup(scope, groupId)) {
+    throw new AppError({
+      code: 403,
+      message: "No access to view this group's records",
+      logging: true,
+      context: { userId: auth.userId, groupId },
+    });
+  }
+
+  const result = await services.vacation.getVacationsForGroup(
+    groupId,
     range.startDate,
     range.endDate
   );

--- a/src/controllers/vacation/tests/handleGetVacations.test.ts
+++ b/src/controllers/vacation/tests/handleGetVacations.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Request, Response } from "express";
 
-const { mockGetVacationsForUser } = vi.hoisted(() => ({
-  mockGetVacationsForUser: vi.fn(),
-}));
+const { mockGetVacationsForUser, mockGetVacationsForGroup, mockGetScopeEntries } = vi.hoisted(
+  () => ({
+    mockGetVacationsForUser: vi.fn(),
+    mockGetVacationsForGroup: vi.fn(),
+    mockGetScopeEntries: vi.fn(),
+  })
+);
 
 vi.mock("../../../utils/dateFunc.js", () => ({
   formatStartAndEndDate: vi.fn(),
@@ -17,6 +21,10 @@ vi.mock("../../../services/DBServices.js", () => ({
   createDBServices: () => ({
     vacation: {
       getVacationsForUser: mockGetVacationsForUser,
+      getVacationsForGroup: mockGetVacationsForGroup,
+    },
+    report: {
+      getScopeEntries: mockGetScopeEntries,
     },
   }),
 }));
@@ -83,7 +91,11 @@ describe("handleGetVacations", () => {
     expect(formatStartAndEndDate).toHaveBeenCalledWith(2024, 3);
     expect(mockGetVacationsForUser).toHaveBeenCalledWith("user_123", "2024-01-01", "2024-01-31");
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(mockVacations);
+    // Own records carry the same mirror fields as group ones so the calendar
+    // never has to branch on which scope produced the row.
+    expect(res.json).toHaveBeenCalledWith(
+      mockVacations.map((v) => ({ ...v, mirroredFromGroupId: null, mirroredFromGroupName: null }))
+    );
   });
 
   it("should use default year (current year) when year query param is not provided", async () => {
@@ -206,6 +218,52 @@ describe("handleGetVacations", () => {
       "2024-01-01",
       "2024-01-31"
     );
+  });
+
+  describe("group scope", () => {
+    const scopeEntry = (access: "all" | "self") => ({
+      groupId: "group_1",
+      groupName: "Team A",
+      access,
+      canEditQuotas: false,
+    });
+
+    it("returns the group's records, mirrored ones included, when the caller may view it", async () => {
+      const { req, res } = makeReqRes({ year: "2024", month: "3", groupId: "group_1" });
+      const groupRows = [
+        { id: "v1", userId: "user_123", mirroredFromGroupId: null, mirroredFromGroupName: null },
+        {
+          id: "v2",
+          userId: "user_999",
+          mirroredFromGroupId: "group_2",
+          mirroredFromGroupName: "Team B",
+        },
+      ];
+      mockGetScopeEntries.mockResolvedValue([scopeEntry("all")]);
+      mockGetVacationsForGroup.mockResolvedValue(groupRows);
+
+      await handleGetVacations(req, res);
+
+      expect(mockGetVacationsForGroup).toHaveBeenCalledWith("group_1", "2024-01-01", "2024-01-31");
+      expect(mockGetVacationsForUser).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith(groupRows);
+    });
+
+    it("rejects a member without view access on the group", async () => {
+      const { req, res } = makeReqRes({ year: "2024", month: "3", groupId: "group_1" });
+      mockGetScopeEntries.mockResolvedValue([scopeEntry("self")]);
+
+      await expect(handleGetVacations(req, res)).rejects.toMatchObject({ code: 403 });
+      expect(mockGetVacationsForGroup).not.toHaveBeenCalled();
+    });
+
+    it("rejects a group the caller does not belong to", async () => {
+      const { req, res } = makeReqRes({ year: "2024", month: "3", groupId: "group_other" });
+      mockGetScopeEntries.mockResolvedValue([scopeEntry("all")]);
+
+      await expect(handleGetVacations(req, res)).rejects.toMatchObject({ code: 403 });
+      expect(mockGetVacationsForGroup).not.toHaveBeenCalled();
+    });
   });
 
   it("should pass correct date range from formatStartAndEndDate to service", async () => {

--- a/src/db/schema/out/0008_cold_talos.sql
+++ b/src/db/schema/out/0008_cold_talos.sql
@@ -1,0 +1,4 @@
+CREATE TYPE "public"."dashboard_scope" AS ENUM('MINE', 'GROUP');--> statement-breakpoint
+ALTER TABLE "user_settings" ADD COLUMN "dashboard_scope" "dashboard_scope" DEFAULT 'MINE' NOT NULL;--> statement-breakpoint
+ALTER TABLE "user_settings" ADD COLUMN "dashboard_group_id" text;--> statement-breakpoint
+ALTER TABLE "user_settings" ADD CONSTRAINT "user_settings_dashboard_group_id_groups_id_fk" FOREIGN KEY ("dashboard_group_id") REFERENCES "public"."groups"("id") ON DELETE set null ON UPDATE no action;

--- a/src/db/schema/out/meta/0008_snapshot.json
+++ b/src/db/schema/out/meta/0008_snapshot.json
@@ -1,0 +1,2292 @@
+{
+  "id": "96c59a55-0135-4de0-82fe-e51ec2ce21b0",
+  "prevId": "95dc126d-2c08-4825-869b-fa4ff5031eb2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_mirrors": {
+      "name": "group_mirrors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_group_id": {
+          "name": "target_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_mirrors_user_source_target_uniq": {
+          "name": "group_mirrors_user_source_target_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_mirrors\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_target_group_id": {
+          "name": "idx_group_mirrors_target_group_id",
+          "columns": [
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_user_id": {
+          "name": "idx_group_mirrors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_mirrors_user_id_user_id_fk": {
+          "name": "group_mirrors_user_id_user_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_source_group_id_groups_id_fk": {
+          "name": "group_mirrors_source_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_target_group_id_groups_id_fk": {
+          "name": "group_mirrors_target_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "target_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invite_link_group_id": {
+          "name": "idx_invite_link_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_group_email_open_uniq": {
+          "name": "invite_link_group_email_open_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_link\".\"used_at\" IS NULL AND \"invite_link\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invite_link_invited_by_user_id_user_id_fk": {
+          "name": "invite_link_invited_by_user_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_exports_user_id_idx": {
+          "name": "report_exports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_exports_created_at_idx": {
+          "name": "report_exports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_user_id_user_id_fk": {
+          "name": "report_exports_user_id_user_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboard_scope": {
+          "name": "dashboard_scope",
+          "type": "dashboard_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MINE'"
+        },
+        "dashboard_group_id": {
+          "name": "dashboard_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_settings_dashboard_group_id_groups_id_fk": {
+          "name": "user_settings_dashboard_group_id_groups_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "dashboard_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "carried_over_days": {
+          "name": "carried_over_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        },
+        "user_year_quotas_related_year_range_chk": {
+          "name": "user_year_quotas_related_year_range_chk",
+          "value": "\"user_year_quotas\".\"related_year\"::int BETWEEN 2025 AND 2100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "half_day": {
+          "name": "half_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.dashboard_scope": {
+      "name": "dashboard_scope",
+      "schema": "public",
+      "values": [
+        "MINE",
+        "GROUP"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/_journal.json
+++ b/src/db/schema/out/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1785571165719,
       "tag": "0007_illegal_marauders",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1785584203806,
+      "tag": "0008_cold_talos",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/user-settings-schema.ts
+++ b/src/db/schema/user-settings-schema.ts
@@ -1,5 +1,15 @@
-import { boolean, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { boolean, pgEnum, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { user } from "./auth-schema.js";
+import { groups } from "./group-schema.js";
+import { enumToPgEnum } from "../../utils/enumToPgEnum.js";
+
+/** Whose leave the dashboard calendar shows by default. */
+export enum dashboardScope {
+  Mine = "MINE",
+  Group = "GROUP",
+}
+
+export const dashboardScopeEnum = pgEnum("dashboard_scope", enumToPgEnum(dashboardScope));
 
 /**
  * Per-user preferences. Deliberately a separate table rather than columns on
@@ -16,6 +26,13 @@ export const userSettings = pgTable("user_settings", {
   // Workflow mail only (approval requests, decisions, cancellations).
   // Account mail such as email confirmation ignores this flag.
   emailNotifications: boolean("email_notifications").notNull().default(true),
+  dashboardScope: dashboardScopeEnum("dashboard_scope").notNull().default(dashboardScope.Mine),
+  // Which group `GROUP` scope shows. Kept nullable and cleared on group
+  // deletion; readers fall back to the personal calendar when it is null, so a
+  // deleted group degrades instead of erroring.
+  dashboardGroupId: text("dashboard_group_id").references(() => groups.id, {
+    onDelete: "set null",
+  }),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")
     .defaultNow()

--- a/src/routes/usersRouter.ts
+++ b/src/routes/usersRouter.ts
@@ -71,7 +71,7 @@ export const usersRouter = (): Router => {
    *     summary: The caller's preferences
    *     description: |
    *       Users without a stored row are on the defaults
-   *       (`emailNotifications: true`).
+   *       (`emailNotifications: true`, `dashboardScope: MINE`).
    *     security:
    *       - bearerAuth: []
    *     responses:
@@ -80,18 +80,23 @@ export const usersRouter = (): Router => {
    *         content:
    *           application/json:
    *             schema:
-   *               type: object
-   *               properties:
-   *                 emailNotifications:
-   *                   type: boolean
+   *               $ref: '#/components/schemas/UserSettings'
    *   put:
    *     tags:
    *       - Users
    *     summary: Update the caller's preferences
    *     description: |
+   *       A partial update — the screen saves one card at a time, so any subset
+   *       of the fields may be sent and the rest keep their stored value.
+   *
    *       Turning `emailNotifications` off suppresses workflow mail (approval
    *       requests, decisions, cancellations). Account mail such as email
    *       confirmation is unaffected.
+   *
+   *       `dashboardScope: GROUP` makes the dashboard calendar show
+   *       `dashboardGroupId`'s records instead of only the caller's own. That
+   *       group must already be selected or supplied in the same request, and
+   *       the caller must have view access on it.
    *     security:
    *       - bearerAuth: []
    *     requestBody:
@@ -99,15 +104,28 @@ export const usersRouter = (): Router => {
    *       content:
    *         application/json:
    *           schema:
-   *             type: object
-   *             required:
-   *               - emailNotifications
-   *             properties:
-   *               emailNotifications:
-   *                 type: boolean
+   *             $ref: '#/components/schemas/UserSettings'
    *     responses:
    *       '200':
    *         description: The stored preferences
+   *       '403':
+   *         description: No access to view the selected group's records
+   *       '422':
+   *         description: Group scope requested without a group
+   * components:
+   *   schemas:
+   *     UserSettings:
+   *       type: object
+   *       properties:
+   *         emailNotifications:
+   *           type: boolean
+   *         dashboardScope:
+   *           type: string
+   *           enum: [MINE, GROUP]
+   *         dashboardGroupId:
+   *           type: string
+   *           format: uuid
+   *           nullable: true
    */
   app.get("/me/settings", tryCatch(handleGetMySettings));
   app.put(

--- a/src/routes/vacationRouter.ts
+++ b/src/routes/vacationRouter.ts
@@ -31,9 +31,15 @@ export const vacationRouter = (): Router => {
    *   get:
    *     tags:
    *       - Vacations
-   *     summary: Retrieve vacations for the authenticated user
+   *     summary: Retrieve vacations for the authenticated user or one of their groups
    *     description: |
-   *       Returns vacation records for the authenticated user for a given year and month.
+   *       Returns vacation records for a given year and month. Without `groupId`
+   *       the caller's own records are returned. With `groupId` the whole
+   *       group's records are returned instead — including records mirrored into
+   *       it from another group, which carry a non-null `mirroredFromGroupId`.
+   *
+   *       Group scope requires view access on that group (view access, admin
+   *       access, or being its manager); a plain member gets a 403.
    *       Each row includes a denormalized `user` summary used by the calendar UI.
    *     operationId: handleGetVacations
    *     security:
@@ -53,6 +59,13 @@ export const vacationRouter = (): Router => {
    *           type: integer
    *           minimum: 1
    *           maximum: 12
+   *       - name: groupId
+   *         in: query
+   *         required: false
+   *         description: Return this group's records instead of the caller's own.
+   *         schema:
+   *           type: string
+   *           format: uuid
    *     responses:
    *       '200':
    *         description: Array of vacations matching the query
@@ -64,6 +77,8 @@ export const vacationRouter = (): Router => {
    *                 $ref: '#/components/schemas/VacationListItem'
    *       '401':
    *         description: Unauthorized
+   *       '403':
+   *         description: No access to view this group's records
    *       '500':
    *         description: Internal Server Error
    * components:
@@ -87,6 +102,14 @@ export const vacationRouter = (): Router => {
    *           properties:
    *             user:
    *               $ref: '#/components/schemas/UserSummary'
+   *             mirroredFromGroupId:
+   *               type: string
+   *               format: uuid
+   *               nullable: true
+   *               description: Set when the record belongs to another group and is only projected here.
+   *             mirroredFromGroupName:
+   *               type: string
+   *               nullable: true
    */
   app.get("/", tryCatch(handleGetVacations));
 

--- a/src/services/report/reportScope.ts
+++ b/src/services/report/reportScope.ts
@@ -48,6 +48,14 @@ export const buildScopePredicate = (
   return and(accessPredicate, inArray(cols.userId, filters.userIds)) as SQL;
 };
 
+/**
+ * True when the caller may see every member's records in the group, not just
+ * their own. Also gates the dashboard's group calendar, so a plain member
+ * without view access never sees who else is off.
+ */
+export const canViewWholeGroup = (scope: ReportScopeEntry[], groupId: string): boolean =>
+  scope.some((entry) => entry.groupId === groupId && entry.access === "all");
+
 /** True when the caller may edit quotas in the group — group admin or manager. */
 export const canEditQuotasIn = (scope: ReportScopeEntry[], groupId: string): boolean =>
   scope.some((entry) => entry.groupId === groupId && entry.canEditQuotas);

--- a/src/services/userSettings/types.ts
+++ b/src/services/userSettings/types.ts
@@ -1,8 +1,11 @@
 import { z } from "zod";
+import { dashboardScope } from "../../db/schema/user-settings-schema.js";
 
 export type UserSettingsRecord = {
   userId: string;
   emailNotifications: boolean;
+  dashboardScope: dashboardScope;
+  dashboardGroupId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -10,14 +13,34 @@ export type UserSettingsRecord = {
 /** What the settings endpoints expose — defaults applied, no timestamps. */
 export type UserSettingsResponse = {
   emailNotifications: boolean;
+  dashboardScope: dashboardScope;
+  dashboardGroupId: string | null;
 };
 
 export const DEFAULT_USER_SETTINGS: UserSettingsResponse = {
   emailNotifications: true,
+  dashboardScope: dashboardScope.Mine,
+  dashboardGroupId: null,
 };
 
-export const validatePutUserSettings = z.object({
-  emailNotifications: z.boolean(),
-});
+/**
+ * Every field is optional: the settings screen saves one card at a time, and
+ * the handler merges the patch onto whatever is stored.
+ */
+export const validatePutUserSettings = z
+  .object({
+    emailNotifications: z.boolean().optional(),
+    dashboardScope: z.enum(dashboardScope).optional(),
+    dashboardGroupId: z.string().nullable().optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "At least one setting must be supplied",
+  });
 
 export type ValidatedPutUserSettingsType = z.infer<typeof validatePutUserSettings>;
+
+export type UserSettingsPatch = {
+  emailNotifications?: boolean;
+  dashboardScope?: dashboardScope;
+  dashboardGroupId?: string | null;
+};

--- a/src/services/userSettings/userSettingsServices.ts
+++ b/src/services/userSettings/userSettingsServices.ts
@@ -1,7 +1,7 @@
 import { db, type DbTransaction } from "../../db/db.js";
 import { userSettings } from "../../db/schema/user-settings-schema.js";
 import { eq, inArray } from "drizzle-orm";
-import type { UserSettingsRecord } from "./types.js";
+import { DEFAULT_USER_SETTINGS, type UserSettingsPatch, type UserSettingsRecord } from "./types.js";
 
 export const getUserSettings = async (
   userId: string,
@@ -18,19 +18,21 @@ export const getUserSettings = async (
 
 /**
  * Stores the user's preferences, creating the row on first change. Users
- * without a row are on the defaults, so this is always an upsert.
+ * without a row are on the defaults, so this is always an upsert. `patch` may
+ * carry any subset of the settings — the screen saves one card at a time, and
+ * unmentioned fields keep their stored value (or take the default on insert).
  */
 export const upsertUserSettings = async (
   userId: string,
-  values: { emailNotifications: boolean },
+  patch: UserSettingsPatch,
   tx?: DbTransaction
 ): Promise<UserSettingsRecord | undefined> => {
   const [row] = await (tx ?? db)
     .insert(userSettings)
-    .values({ userId, ...values })
+    .values({ ...DEFAULT_USER_SETTINGS, ...patch, userId })
     .onConflictDoUpdate({
       target: userSettings.userId,
-      set: values,
+      set: patch,
     })
     .returning();
 

--- a/src/services/vacation/types.ts
+++ b/src/services/vacation/types.ts
@@ -49,6 +49,7 @@ export type VacationListItem = VacationType & {
  */
 export type GroupVacationListItem = VacationListItem & {
   mirroredFromGroupId: string | null;
+  mirroredFromGroupName: string | null;
 };
 
 /**

--- a/src/services/vacation/vacationServices.ts
+++ b/src/services/vacation/vacationServices.ts
@@ -110,9 +110,10 @@ export const getVacationsForGroup = async (
   const where = userId !== null ? and(...base, eq(vacation.userId, userId)) : and(...base);
 
   const rows = await db
-    .select(baseVacationSelection)
+    .select({ ...baseVacationSelection, sourceGroupName: groups.groupName })
     .from(vacation)
     .innerJoin(user, eq(vacation.userId, user.id))
+    .innerJoin(groups, eq(vacation.groupId, groups.id))
     // At most one row can match: `group_mirrors_user_source_target_uniq` makes
     // (user, source, target) unique among active mirrors, so this cannot fan out.
     .leftJoin(
@@ -127,10 +128,14 @@ export const getVacationsForGroup = async (
     .where(where)
     .orderBy(asc(vacation.requestedDay));
 
-  return rows.map((row) => ({
-    ...toListItem(row),
-    mirroredFromGroupId: row.groupId === groupId ? null : row.groupId,
-  }));
+  return rows.map(({ sourceGroupName, ...row }) => {
+    const mirrored = row.groupId !== groupId;
+    return {
+      ...toListItem(row),
+      mirroredFromGroupId: mirrored ? row.groupId : null,
+      mirroredFromGroupName: mirrored ? sourceGroupName : null,
+    };
+  });
 };
 
 /**

--- a/src/tests/e2e/groupMirror.e2e.test.ts
+++ b/src/tests/e2e/groupMirror.e2e.test.ts
@@ -101,6 +101,7 @@ describe("group mirroring", () => {
       groupId: teamA.id,
       requestedDay: "2026-03-10",
       mirroredFromGroupId: teamA.id,
+      mirroredFromGroupName: "Team A",
     });
   });
 
@@ -111,6 +112,7 @@ describe("group mirroring", () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0]?.mirroredFromGroupId).toBeNull();
+    expect(rows[0]?.mirroredFromGroupName).toBeNull();
   });
 
   it("returns own and mirrored records together, without duplicating either", async () => {


### PR DESCRIPTION
Backend half of the dashboard group-scope feature. The frontend PR is https://github.com/Daniel88dev/flexi-day/pull/23 and depends on this.

## What this adds

A member can now see their group's time off on the dashboard instead of only their own — including records **mirrored in from another group**.

- **Schema** — `user_settings` gains `dashboard_scope` (`MINE`/`GROUP`, default `MINE`) and a nullable `dashboard_group_id` referencing `groups` with `ON DELETE SET NULL`, so a deleted group degrades to the personal calendar instead of erroring. Migration `0008_cold_talos.sql`.
- **`PUT /api/users/me/settings` is now a partial update.** The settings screen saves one card at a time, so any subset of fields may be sent and the rest keep their stored value. Existing callers are unaffected.
- **`GET /api/vacation?groupId=`** returns the whole group instead of the caller's own rows, routed through the existing `getVacationsForGroup` — so mirroring works for free. Rows gain `mirroredFromGroupName` (new `groups` join) so the UI can label them; own-scope responses carry the same fields as `null` so clients never branch on scope.

## Authorization

Visibility follows the **report** model, not bare membership: `viewAccess || adminAccess || manager` opens the group, everyone else sees only themselves. Extracted as `canViewWholeGroup` in `services/report/reportScope.ts` and applied at both call sites.

Validation on the settings write checks the *resulting* settings rather than the patch, so switching to `GROUP` can rely on a group chosen earlier:
- `GROUP` scope with no group, stored or supplied → **422**
- a group the caller cannot view in full → **403**

## Worth a reviewer's attention

`calendar_sync` team feeds gate on **membership alone**, so a plain member still cannot see teammates on the dashboard but can build an .ics feed of their team. That inconsistency predates this PR and is left as-is deliberately; worth aligning separately.

## Testing

- Unit: new cases for the group-scope branch (member without view access → 403, non-member group → 403) and for the settings validation/authorization paths, including that clearing the group does not re-authorize it.
- E2E: `groupMirror.e2e.test.ts` extended for the source-group-name join.
- `npm test` — 244 passing. `tsc --noEmit` clean. Lint clean apart from a pre-existing `vitest.e2e.config.ts` parser error.
- Exercised end to end against a local stack: group calendar renders mirrored vs. own records distinctly, and revoking `view_access` turns both the listing and the settings write into 403s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dashboard settings for personal or group-based views, including optional group selection.
  - Added partial updates for notification and dashboard preferences.
  - Added group-scoped vacation retrieval with access controls.
  - Vacation results now identify the source group for mirrored records.

- **Bug Fixes**
  - Improved settings validation and preservation of unspecified values.
  - Added clear authorization errors for inaccessible groups.

- **Documentation**
  - Updated API documentation for dashboard settings and group-filtered vacation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->