### PR TITLE
fix: let a cancelled or rejected day be requested again

### DIFF
--- a/src/db/schema/out/0009_true_dust.sql
+++ b/src/db/schema/out/0009_true_dust.sql
@@ -1,0 +1,2 @@
+DROP INDEX "uniq_vacation_user_day";--> statement-breakpoint
+CREATE UNIQUE INDEX "uniq_vacation_user_day" ON "vacation" USING btree ("user_id","requested_day") WHERE "vacation"."deleted_at" IS NULL AND "vacation"."rejected_at" IS NULL;

--- a/src/db/schema/out/meta/0009_snapshot.json
+++ b/src/db/schema/out/meta/0009_snapshot.json
@@ -1,0 +1,2293 @@
+{
+  "id": "fc674f26-f31d-42a4-94b7-2d582d810870",
+  "prevId": "96c59a55-0135-4de0-82fe-e51ec2ce21b0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_mirrors": {
+      "name": "group_mirrors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_group_id": {
+          "name": "target_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_mirrors_user_source_target_uniq": {
+          "name": "group_mirrors_user_source_target_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_mirrors\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_target_group_id": {
+          "name": "idx_group_mirrors_target_group_id",
+          "columns": [
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_user_id": {
+          "name": "idx_group_mirrors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_mirrors_user_id_user_id_fk": {
+          "name": "group_mirrors_user_id_user_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_source_group_id_groups_id_fk": {
+          "name": "group_mirrors_source_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_target_group_id_groups_id_fk": {
+          "name": "group_mirrors_target_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "target_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invite_link_group_id": {
+          "name": "idx_invite_link_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_group_email_open_uniq": {
+          "name": "invite_link_group_email_open_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_link\".\"used_at\" IS NULL AND \"invite_link\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invite_link_invited_by_user_id_user_id_fk": {
+          "name": "invite_link_invited_by_user_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_exports_user_id_idx": {
+          "name": "report_exports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_exports_created_at_idx": {
+          "name": "report_exports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_user_id_user_id_fk": {
+          "name": "report_exports_user_id_user_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboard_scope": {
+          "name": "dashboard_scope",
+          "type": "dashboard_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MINE'"
+        },
+        "dashboard_group_id": {
+          "name": "dashboard_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_settings_dashboard_group_id_groups_id_fk": {
+          "name": "user_settings_dashboard_group_id_groups_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "dashboard_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "carried_over_days": {
+          "name": "carried_over_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        },
+        "user_year_quotas_related_year_range_chk": {
+          "name": "user_year_quotas_related_year_range_chk",
+          "value": "\"user_year_quotas\".\"related_year\"::int BETWEEN 2025 AND 2100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "half_day": {
+          "name": "half_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vacation\".\"deleted_at\" IS NULL AND \"vacation\".\"rejected_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.dashboard_scope": {
+      "name": "dashboard_scope",
+      "schema": "public",
+      "values": [
+        "MINE",
+        "GROUP"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/_journal.json
+++ b/src/db/schema/out/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1785584203806,
       "tag": "0008_cold_talos",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1785685551546,
+      "tag": "0009_true_dust",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/vacation-schema.ts
+++ b/src/db/schema/vacation-schema.ts
@@ -9,6 +9,7 @@ import {
   pgEnum,
   boolean,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { user } from "./auth-schema.js";
 import { groups } from "./group-schema.js";
 import { enumToPgEnum } from "../../utils/enumToPgEnum.js";
@@ -64,6 +65,12 @@ export const vacation = pgTable(
   },
   (table) => [
     index("requested_day_idx").on(table.requestedDay),
-    uniqueIndex("uniq_vacation_user_day").on(table.userId, table.requestedDay),
+    // Partial on purpose: only a live row reserves the day. Cancelled
+    // (`deletedAt`) and rejected rows stay for history and must not stop the
+    // user from booking that day again. Every ON CONFLICT against this index
+    // has to repeat the predicate or Postgres cannot infer it.
+    uniqueIndex("uniq_vacation_user_day")
+      .on(table.userId, table.requestedDay)
+      .where(sql`${table.deletedAt} IS NULL AND ${table.rejectedAt} IS NULL`),
   ]
 );

--- a/src/services/report/reportServices.ts
+++ b/src/services/report/reportServices.ts
@@ -316,7 +316,11 @@ export const getBookingsForScope = async (
       asc(vacation.userId),
       asc(vacation.groupId),
       asc(vacation.vacationType),
-      asc(vacation.requestedDay)
+      asc(vacation.requestedDay),
+      // A rejected day and the live re-request of it both show up here, so the
+      // day alone is no longer a unique sort key. Live row first, so `limit`
+      // and the export can't return the two in a different order each run.
+      sql`${vacation.rejectedAt} IS NOT NULL`
     );
 
   const rows: BookingRow[] = await (limit === undefined ? query : query.limit(limit));

--- a/src/services/vacation/vacationServices.ts
+++ b/src/services/vacation/vacationServices.ts
@@ -165,6 +165,16 @@ export const getVacationsForUser = async (
 };
 
 /**
+ * Predicate of the partial `uniq_vacation_user_day` index. Only live rows
+ * reserve a day, so a cancelled or rejected one can be booked again — but
+ * Postgres can only infer a partial index when ON CONFLICT repeats its
+ * predicate, hence this fragment on every insert against it. Drizzle emits it
+ * from `onConflictDoNothing`'s `where`, which lands in the index-predicate
+ * position, not as an action filter.
+ */
+const liveRowConflictTarget = sql`${vacation.deletedAt} IS NULL AND ${vacation.rejectedAt} IS NULL`;
+
+/**
  * Inserts a single vacation row. Returns undefined on unique-constraint
  * collisions so callers can decide how to handle them.
  */
@@ -177,6 +187,7 @@ export const postVacation = async (
     .values(record)
     .onConflictDoNothing({
       target: [vacation.userId, vacation.requestedDay],
+      where: liveRowConflictTarget,
     })
     .returning();
   return row;
@@ -184,11 +195,12 @@ export const postVacation = async (
 
 /**
  * Inserts many per-day vacation rows in a single statement. All-or-nothing:
- * if any (userId, requestedDay) already exists, throws — and because the
- * caller wraps this in `db.transaction`, the partial inserts are rolled back.
- * That avoids the silent partial-commit case where a multi-day request that
- * overlaps one existing day would otherwise persist the remaining days and
- * still look like a success.
+ * if any (userId, requestedDay) is already held by a live row, throws — and
+ * because the caller wraps this in `db.transaction`, the partial inserts are
+ * rolled back. That avoids the silent partial-commit case where a multi-day
+ * request that overlaps one existing day would otherwise persist the remaining
+ * days and still look like a success. Days whose only rows are cancelled or
+ * rejected are free (see {@link liveRowConflictTarget}).
  */
 export const postVacationBulk = async (
   records: VacationInsertType[],
@@ -200,6 +212,7 @@ export const postVacationBulk = async (
     .values(records)
     .onConflictDoNothing({
       target: [vacation.userId, vacation.requestedDay],
+      where: liveRowConflictTarget,
     })
     .returning();
 
@@ -222,6 +235,38 @@ export const postVacationBulk = async (
   return inserted;
 };
 
+/**
+ * Approving un-rejects the row, which puts it back under the partial unique
+ * index — and the day may have been re-requested since the rejection. Postgres
+ * is the only place that can see that race, so translate its violation into the
+ * conflict the approver should be shown instead of a 500.
+ */
+const rethrowIfDayRetaken = (error: unknown, vacationIds: string[]): never => {
+  // Drizzle rethrows a "Failed query" Error and hangs the pg error, which is
+  // where `code`/`constraint` live, off `cause`.
+  let cursor: unknown = error;
+  let violated = false;
+  for (let depth = 0; cursor && depth < 5; depth++) {
+    const candidate = cursor as { code?: unknown; constraint?: unknown; cause?: unknown };
+    if (candidate.code === "23505" && candidate.constraint === "uniq_vacation_user_day") {
+      violated = true;
+      break;
+    }
+    cursor = candidate.cause;
+  }
+
+  if (violated) {
+    throw new AppError({
+      code: 409,
+      message:
+        "That day was requested again after the rejection — refresh and decide on the new request",
+      logging: true,
+      context: { vacationIds },
+    });
+  }
+  throw error;
+};
+
 export const approveVacation = async (
   vacationId: string,
   approvingPerson: string,
@@ -237,7 +282,8 @@ export const approveVacation = async (
       rejectionReason: null,
     })
     .where(and(eq(vacation.id, vacationId), isNull(vacation.deletedAt)))
-    .returning();
+    .returning()
+    .catch((error: unknown) => rethrowIfDayRetaken(error, [vacationId]));
 
   return row;
 };
@@ -263,7 +309,8 @@ export const approveVacationsBulk = async (
       rejectionReason: null,
     })
     .where(and(inArray(vacation.id, vacationIds), isNull(vacation.deletedAt)))
-    .returning();
+    .returning()
+    .catch((error: unknown) => rethrowIfDayRetaken(error, vacationIds));
 };
 
 /**
@@ -415,7 +462,9 @@ export const getVacationDetailById = async (
 
   const { groupName, approvedByName, rejectedByName, ...vacationRow } = row;
 
-  // Match the row's deletedAt state so a re-booked active day can't merge into a cancelled run.
+  // Match the row's deletedAt/rejectedAt state so a re-booked day can't merge
+  // into the cancelled or rejected run it replaced — both can sit on the same
+  // day as the live row now that uniqueness only covers live rows.
   const siblings = await (tx ?? db)
     .select({ id: vacation.id, requestedDay: vacation.requestedDay })
     .from(vacation)
@@ -424,7 +473,8 @@ export const getVacationDetailById = async (
         eq(vacation.userId, vacationRow.userId),
         eq(vacation.groupId, vacationRow.groupId),
         eq(vacation.vacationType, vacationRow.vacationType),
-        vacationRow.deletedAt ? isNotNull(vacation.deletedAt) : isNull(vacation.deletedAt)
+        vacationRow.deletedAt ? isNotNull(vacation.deletedAt) : isNull(vacation.deletedAt),
+        vacationRow.rejectedAt ? isNotNull(vacation.rejectedAt) : isNull(vacation.rejectedAt)
       )
     );
   const run = contiguousRunContaining(siblings, vacationRow.requestedDay);

--- a/src/tests/e2e/vacation.e2e.test.ts
+++ b/src/tests/e2e/vacation.e2e.test.ts
@@ -257,6 +257,101 @@ describe("Vacation API E2E Tests", () => {
     });
   });
 
+  // Uniqueness only covers live rows, so a day whose only rows are rejected or
+  // cancelled is free again. Before that was a partial index, the leftover row
+  // kept the day booked forever.
+  describe("POST /api/vacation/create-vacation — re-requesting a day", () => {
+    const bookDay = (cookie: string, day = "2025-12-24") =>
+      request(context.app)
+        .post("/api/vacation/create-vacation")
+        .set("Cookie", cookie)
+        .send({ groupId: context.group.id, from: day, to: day });
+
+    it("should return 409 while the day is still held by a live row", async () => {
+      await addToGroup(context.user1.id, context.group.id);
+      const cookie = await authCookieFor(context.user1.id);
+
+      await bookDay(cookie).expect(201);
+      const response = await bookDay(cookie).expect(409);
+
+      expect(response.body).toMatchObject({
+        errors: [{ context: { conflictingDays: ["2025-12-24"] } }],
+      });
+    });
+
+    it("should let the user book a day again after the request was rejected", async () => {
+      await addToGroup(context.user1.id, context.group.id);
+      const cookie = await authCookieFor(context.user1.id);
+      const approverCookie = await authCookieFor(context.approverUser.id);
+
+      const created = await bookDay(cookie).expect(201);
+      const rejectedId = (created.body as { id: string }[])[0]?.id;
+
+      await request(context.app)
+        .post(`/api/vacation/reject/${rejectedId ?? ""}`)
+        .set("Cookie", approverCookie)
+        .send({ reason: "not this week" })
+        .expect(200);
+
+      await bookDay(cookie).expect(201);
+
+      // The rejected row is kept for history alongside the new pending one.
+      const rows = await db.select().from(vacation).where(eq(vacation.userId, context.user1.id));
+      expect(rows).toHaveLength(2);
+      expect(rows.filter((row) => row.rejectedAt !== null)).toHaveLength(1);
+      expect(rows.filter((row) => row.rejectedAt === null && row.deletedAt === null)).toHaveLength(
+        1
+      );
+    });
+
+    it("should let the user book a day again after cancelling it", async () => {
+      await addToGroup(context.user1.id, context.group.id);
+      const cookie = await authCookieFor(context.user1.id);
+
+      const created = await bookDay(cookie).expect(201);
+      const cancelledId = (created.body as { id: string }[])[0]?.id;
+
+      await request(context.app)
+        .delete(`/api/vacation/${cancelledId ?? ""}`)
+        .set("Cookie", cookie)
+        .send({})
+        .expect(200);
+
+      await bookDay(cookie).expect(201);
+
+      const rows = await db.select().from(vacation).where(eq(vacation.userId, context.user1.id));
+      expect(rows).toHaveLength(2);
+      expect(rows.filter((row) => row.deletedAt !== null)).toHaveLength(1);
+    });
+
+    it("should return 409 when approving a rejected row whose day was booked again", async () => {
+      await addToGroup(context.user1.id, context.group.id);
+      const cookie = await authCookieFor(context.user1.id);
+      const approverCookie = await authCookieFor(context.approverUser.id);
+
+      const created = await bookDay(cookie).expect(201);
+      const rejectedId = (created.body as { id: string }[])[0]?.id ?? "";
+
+      await request(context.app)
+        .post(`/api/vacation/reject/${rejectedId}`)
+        .set("Cookie", approverCookie)
+        .send({ reason: "not this week" })
+        .expect(200);
+      await bookDay(cookie).expect(201);
+
+      // Stale approver queue: approving would un-reject the old row onto a day
+      // the live request now holds.
+      await request(context.app)
+        .post(`/api/vacation/approve/${rejectedId}`)
+        .set("Cookie", approverCookie)
+        .expect(409);
+
+      const rows = await db.select().from(vacation).where(eq(vacation.id, rejectedId));
+      expect(rows[0]?.rejectedAt).not.toBeNull();
+      expect(rows[0]?.approvedAt).toBeNull();
+    });
+  });
+
   describe("POST /api/vacation/approve/:id", () => {
     let vacationId: string;
 


### PR DESCRIPTION
## Problem

Requesting a day that was previously **rejected or cancelled** fails with:

> Some days in that range are already booked: 7 Aug. Please pick different dates.

`uniq_vacation_user_day` was an unconditional unique index on `(user_id, requested_day)`. Cancelling is a soft delete (`deleted_at`) and rejecting only stamps `rejected_at`, so both leave the row in the table holding the day forever. `postVacationBulk`'s `onConflictDoNothing` then swallows the insert and the inserted-count check raises the 409.

Reported from production via Sentry (`AppError: One or more days in the requested range are already booked`).

## Fix

Make the index **partial** — only a live row reserves a day:

```sql
CREATE UNIQUE INDEX uniq_vacation_user_day ON vacation (user_id, requested_day)
  WHERE deleted_at IS NULL AND rejected_at IS NULL;
```

The rejected/cancelled row stays in place, so reports (which show `rejected` status) and the request timeline keep their history, and the re-request is an ordinary new row.

Follow-on changes this forces:

- **Both inserts repeat the predicate** in `ON CONFLICT` — Postgres cannot infer a partial index otherwise. Note this is drizzle's `where` on `onConflictDoNothing`; `targetWhere` only exists on `onConflictDoUpdate`.
- **Approve path** — approving un-rejects a row, which can now collide with a live re-request of that day (stale approver queue). The `23505` is translated into a 409 instead of surfacing as a 500. Drizzle wraps pg errors, so the check walks the `cause` chain.
- **Detail view** — the contiguous-run lookup now matches `rejectedAt` state as well as `deletedAt`, so a rejected day and its re-request don't merge into one range.
- **Report bookings** — a tiebreaker on the duplicated day, so `limit` and the export can't return the two rows in a different order between runs. Deliberately *not* status-major ordering: that would group a member's records by status instead of chronologically, which is a worse report for the common case. The remaining artifact is cosmetic — a rejected day mid-range splits a contiguous run into two report lines.

No frontend change needed: the dashboard calendar filters rejected rows before grouping, and `groupVacationRequests` already keys on status.

## Deploying

Migration `0009` and this code are coupled in both directions — old code can't infer the partial index, new code can't match the old full index — so vacation creation fails in whatever window they disagree. Apply the migration at deploy time.

## Testing

- 4 new e2e cases: re-request after reject, re-request after cancel, genuine double-book still 409, stale approve → 409.
- Full suites green: 293 unit, 88 e2e. Lint clean apart from 3 pre-existing warnings.
- Index inference and the `23505` constraint name were also verified directly in psql.

🤖 Generated with [Claude Code](https://claude.com/claude-code)