### PR TITLE
chore: skip liveness-probe requests in Sentry request logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ SERVICE_NAME=flexi-day-be
 FEED_BASE_URL=
 TRUSTED_ORIGINS=        # comma-separated allowed origins
 LOG_DIR=
+# Comma-separated paths whose request/response log lines are skipped entirely
+# (matched against the redacted path, so templated routes work too). Deployed
+# environments set this to the liveness probes, which would otherwise dominate.
+REQUEST_LOG_IGNORE_PATHS=
 
 # --- Year-end quota rollover job ---
 # Opens each member's allowance for the current year, carrying their unused

--- a/terraform/apprunner.tf
+++ b/terraform/apprunner.tf
@@ -46,6 +46,11 @@ resource "aws_apprunner_service" "main" {
             FEED_BASE_URL   = "https://${var.api_domain_name}"
             TRUSTED_ORIGINS = join(",", var.trusted_origins)
 
+            # Liveness probes only. App Runner hits /health every 10s (see
+            # health_check_configuration below), which would otherwise be the
+            # overwhelming majority of request logs reaching Sentry.
+            REQUEST_LOG_IGNORE_PATHS = "/health,/ping"
+
             # Transactional email (SESv2). Templates are stage-suffixed and
             # region-scoped; the instance role grants ses:SendEmail (see iam.tf).
             AWS_REGION            = var.aws_region


### PR DESCRIPTION
## Problem

Every request logs a `request` line up front and a `response` line on `finish`. App Runner health-checks `/health` every 10s (`terraform/apprunner.tf` `health_check_configuration`), so that one path alone produces ~17k log lines/day/instance in Sentry Logs — drowning out real traffic.

`requestContext` already supports `REQUEST_LOG_IGNORE_PATHS` (`src/middleware/requestContext.ts:9-14`), but nothing set it in any deployed environment, and it was undocumented.

## Change

- `terraform/apprunner.tf` — set `REQUEST_LOG_IGNORE_PATHS = "/health,/ping"` on the service. `/ping` is included because it shows up in Sentry as a 404 from an external prober (`requestContext` runs ahead of routing, so unmatched paths log too); no such route exists in this repo.
- `.env.example` — document the variable.

No application code changed.

## Notes

- `IGNORED_PATHS` is read once at module load, so this takes effect on the next deployment, not dynamically.
- This only affects the winston → Sentry Logs bridge. Health checks are still sampled into **traces** at `SENTRY_TRACES_SAMPLE_RATE` (0.2). If those turn out to be noisy too, the follow-up is a `tracesSampler` in `src/instrument.ts` returning 0 for these paths.

## Verification

- `terraform fmt -check` + `terraform validate` pass.
- `src/tests/middleware/requestContext.test.ts` — 15 tests pass; the existing `skips paths listed in REQUEST_LOG_IGNORE_PATHS` case already covers the behavior for both log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKd6QphRd4uc4Kwno5NWR5