### PR TITLE
fix: close 17 defects found in exploratory testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "eslint": "^10.8.0",
         "eslint-plugin-security": "^4.0.1",
         "globals": "^17.8.0",
-        "prettier": "^3.8.4",
+        "prettier": "3.9.6",
         "supertest": "^7.1.4",
         "ts-node-dev": "^2.0.0",
         "tsx": "^4.20.6",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint": "^10.8.0",
     "eslint-plugin-security": "^4.0.1",
     "globals": "^17.8.0",
-    "prettier": "^3.8.4",
+    "prettier": "3.9.6",
     "supertest": "^7.1.4",
     "ts-node-dev": "^2.0.0",
     "tsx": "^4.20.6",

--- a/src/controllers/auth/handleSignUpWithTeam.ts
+++ b/src/controllers/auth/handleSignUpWithTeam.ts
@@ -170,5 +170,17 @@ const createTeamForUser = async (userId: string, teamName: string) =>
       });
     }
 
+    await services.userYearQuotas.openQuotaFromGroupDefaults(
+      {
+        id: generateRandomUUID(),
+        userId,
+        groupId: newGroup.id,
+        relatedYear: new Date().getFullYear().toString(),
+        vacationDays: newGroup.defaultVacationDays,
+        homeOfficeDays: newGroup.defaultHomeOfficeDays,
+      },
+      tx
+    );
+
     return newGroup;
   });

--- a/src/controllers/auth/handleSignUpWithTeam.ts
+++ b/src/controllers/auth/handleSignUpWithTeam.ts
@@ -9,6 +9,7 @@ import { user, verification } from "../../db/schema/auth-schema.js";
 import { createDBServices } from "../../services/DBServices.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { logger } from "../../middleware/logger.js";
+import { currentYear } from "../../utils/dateFunc.js";
 
 const services = createDBServices();
 
@@ -175,7 +176,7 @@ const createTeamForUser = async (userId: string, teamName: string) =>
         id: generateRandomUUID(),
         userId,
         groupId: newGroup.id,
-        relatedYear: new Date().getFullYear().toString(),
+        relatedYear: currentYear().toString(),
         vacationDays: newGroup.defaultVacationDays,
         homeOfficeDays: newGroup.defaultHomeOfficeDays,
       },

--- a/src/controllers/auth/tests/handleSignUpWithTeam.test.ts
+++ b/src/controllers/auth/tests/handleSignUpWithTeam.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockSignUpEmail, mockCreateGroup, mockCreateGroupUser, mockDelete } = vi.hoisted(() => ({
+const {
+  mockSignUpEmail,
+  mockCreateGroup,
+  mockCreateGroupUser,
+  mockDelete,
+  mockOpenQuotaFromGroupDefaults,
+} = vi.hoisted(() => ({
   mockSignUpEmail: vi.fn(),
   mockCreateGroup: vi.fn(),
   mockCreateGroupUser: vi.fn(),
   mockDelete: vi.fn(),
+  mockOpenQuotaFromGroupDefaults: vi.fn(),
 }));
 
 vi.mock("../../../utils/auth.js", () => ({
@@ -24,6 +31,7 @@ vi.mock("../../../services/DBServices.js", () => ({
   createDBServices: () => ({
     group: { createGroup: mockCreateGroup },
     groupUser: { createGroupUser: mockCreateGroupUser },
+    userYearQuotas: { openQuotaFromGroupDefaults: mockOpenQuotaFromGroupDefaults },
   }),
 }));
 

--- a/src/controllers/group/handlePostGroup.ts
+++ b/src/controllers/group/handlePostGroup.ts
@@ -5,13 +5,12 @@ import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { z } from "zod";
 import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";
+import { currentYear } from "../../utils/dateFunc.js";
 
 const services = createDBServices();
 
 const validatePostGroup = z.object({
   groupName: z.string().trim().min(1).max(120),
-  // `.int()` matters: the columns are `integer`, so a fractional value used to
-  // pass validation and then fail in the driver as a 500.
   defaultVacation: z.number().int().min(0).max(99).optional(),
   defaultHomeOffice: z.number().int().min(0).max(99).optional(),
   // better-auth user ids are opaque non-UUID strings.
@@ -23,6 +22,16 @@ export const handlePostGroup = async (req: Request, res: Response) => {
 
   const data = validatePostGroup.parse(req.body);
 
+  // The creator is the only member yet, so nobody else can be a valid approver.
+  if (data.mainApprovalUser !== undefined && data.mainApprovalUser !== auth.userId) {
+    throw new AppError({
+      message: "An approver must be a member of the group",
+      logging: true,
+      code: 422,
+      context: { userId: auth.userId, mainApprovalUser: data.mainApprovalUser },
+    });
+  }
+
   const result = await db.transaction(async (tx) => {
     const record = await services.group.createGroup(
       {
@@ -31,9 +40,6 @@ export const handlePostGroup = async (req: Request, res: Response) => {
         managerUserId: auth.userId,
         defaultVacationDays: data.defaultVacation,
         defaultHomeOfficeDays: data.defaultHomeOffice,
-        // Without an approver nobody can ever decide on this group's requests
-        // and there is no route to set one later, so the creator takes the role
-        // by default — the same thing sign-up-with-team does.
         mainApprovalUser: data.mainApprovalUser ?? auth.userId,
       },
       tx
@@ -60,8 +66,6 @@ export const handlePostGroup = async (req: Request, res: Response) => {
         groupId: record.id,
         viewAccess: true,
         adminAccess: true,
-        // Booking is gated on `controlledUser`, so without this the creator
-        // could not take leave in the group they just made.
         controlledUser: true,
       },
       tx
@@ -85,7 +89,7 @@ export const handlePostGroup = async (req: Request, res: Response) => {
         id: generateRandomUUID(),
         userId: auth.userId,
         groupId: record.id,
-        relatedYear: new Date().getFullYear().toString(),
+        relatedYear: currentYear().toString(),
         vacationDays: record.defaultVacationDays,
         homeOfficeDays: record.defaultHomeOfficeDays,
       },

--- a/src/controllers/group/handlePostGroup.ts
+++ b/src/controllers/group/handlePostGroup.ts
@@ -9,10 +9,13 @@ import { db } from "../../db/db.js";
 const services = createDBServices();
 
 const validatePostGroup = z.object({
-  groupName: z.string().min(1),
-  defaultVacation: z.number().min(0).max(99).optional(),
-  defaultHomeOffice: z.number().min(0).max(99).optional(),
-  mainApprovalUser: z.uuid().optional(),
+  groupName: z.string().trim().min(1).max(120),
+  // `.int()` matters: the columns are `integer`, so a fractional value used to
+  // pass validation and then fail in the driver as a 500.
+  defaultVacation: z.number().int().min(0).max(99).optional(),
+  defaultHomeOffice: z.number().int().min(0).max(99).optional(),
+  // better-auth user ids are opaque non-UUID strings.
+  mainApprovalUser: z.string().min(1).optional(),
 });
 
 export const handlePostGroup = async (req: Request, res: Response) => {
@@ -28,7 +31,10 @@ export const handlePostGroup = async (req: Request, res: Response) => {
         managerUserId: auth.userId,
         defaultVacationDays: data.defaultVacation,
         defaultHomeOfficeDays: data.defaultHomeOffice,
-        mainApprovalUser: data.mainApprovalUser,
+        // Without an approver nobody can ever decide on this group's requests
+        // and there is no route to set one later, so the creator takes the role
+        // by default — the same thing sign-up-with-team does.
+        mainApprovalUser: data.mainApprovalUser ?? auth.userId,
       },
       tx
     );
@@ -54,6 +60,9 @@ export const handlePostGroup = async (req: Request, res: Response) => {
         groupId: record.id,
         viewAccess: true,
         adminAccess: true,
+        // Booking is gated on `controlledUser`, so without this the creator
+        // could not take leave in the group they just made.
+        controlledUser: true,
       },
       tx
     );
@@ -70,6 +79,18 @@ export const handlePostGroup = async (req: Request, res: Response) => {
         },
       });
     }
+
+    await services.userYearQuotas.openQuotaFromGroupDefaults(
+      {
+        id: generateRandomUUID(),
+        userId: auth.userId,
+        groupId: record.id,
+        relatedYear: new Date().getFullYear().toString(),
+        vacationDays: record.defaultVacationDays,
+        homeOfficeDays: record.defaultHomeOfficeDays,
+      },
+      tx
+    );
 
     return record;
   });

--- a/src/controllers/group/handlePutGroupApprovers.ts
+++ b/src/controllers/group/handlePutGroupApprovers.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
-import type { ValidatedPutGroupQuotasType } from "../../services/group/types.js";
+import type { ValidatedPutGroupApproversType } from "../../services/group/types.js";
 import AppError from "../../utils/appError.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { changesType } from "../../db/schema/changes-schema.js";
@@ -10,18 +10,20 @@ import { changesType } from "../../db/schema/changes-schema.js";
 const services = createDBServices();
 
 /**
- * Updates the group-wide default allowances. These are the values a member's
- * allowance is opened from when they join (see `openQuotaFromGroupDefaults`)
- * and what the year rollover falls back to; existing per-year quotas are
- * untouched (they are edited through `/api/quotas/:groupId`).
+ * Sets who may decide on the group's leave requests. Without this a group whose
+ * approver was never set had no way to ever approve anything — the columns were
+ * only ever written at creation time.
+ *
+ * Both approvers must be members of the group: naming an outsider would produce
+ * a group whose queue nobody with access can see.
  */
-export const handlePutGroupQuotas = async (req: Request, res: Response) => {
+export const handlePutGroupApprovers = async (req: Request, res: Response) => {
   const auth = getAuth(req);
 
   const groupId = z.uuid().parse(req.params.groupId);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const data: ValidatedPutGroupQuotasType = req.body;
+  const data: ValidatedPutGroupApproversType = req.body;
 
   const access = await services.groupUser.getGroupUser(auth.userId, groupId);
 
@@ -34,10 +36,25 @@ export const handlePutGroupQuotas = async (req: Request, res: Response) => {
     });
   }
 
-  const updated = await services.group.updateGroupQuotas(
+  const candidates = [data.mainApprovalUser, data.tempApprovalUser].filter(
+    (id): id is string => id !== null
+  );
+  for (const candidate of candidates) {
+    const membership = await services.groupUser.getGroupUser(candidate, groupId);
+    if (!membership) {
+      throw new AppError({
+        message: "An approver must be a member of the group",
+        logging: true,
+        code: 422,
+        context: { url: req.url, user: auth.userId, groupId, candidate },
+      });
+    }
+  }
+
+  const updated = await services.group.updateGroupApprovalUsers(
     groupId,
-    data.defaultVacationDays,
-    data.defaultHomeOfficeDays
+    data.mainApprovalUser,
+    data.tempApprovalUser
   );
 
   if (!updated) {
@@ -55,7 +72,9 @@ export const handlePutGroupQuotas = async (req: Request, res: Response) => {
     groupId,
     changeType: changesType.Group,
     changingUserId: auth.userId,
-    changeDetail: `Group defaults set to ${data.defaultVacationDays.toString()} vacation / ${data.defaultHomeOfficeDays.toString()} home office days`,
+    changeDetail: `Approvers updated (main: ${data.mainApprovalUser}, temp: ${
+      data.tempApprovalUser ?? "none"
+    })`,
   });
 
   return res.status(200).json(updated);

--- a/src/controllers/group/handlePutGroupApprovers.ts
+++ b/src/controllers/group/handlePutGroupApprovers.ts
@@ -6,17 +6,10 @@ import type { ValidatedPutGroupApproversType } from "../../services/group/types.
 import AppError from "../../utils/appError.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { changesType } from "../../db/schema/changes-schema.js";
+import { db } from "../../db/db.js";
 
 const services = createDBServices();
 
-/**
- * Sets who may decide on the group's leave requests. Without this a group whose
- * approver was never set had no way to ever approve anything — the columns were
- * only ever written at creation time.
- *
- * Both approvers must be members of the group: naming an outsider would produce
- * a group whose queue nobody with access can see.
- */
 export const handlePutGroupApprovers = async (req: Request, res: Response) => {
   const auth = getAuth(req);
 
@@ -51,30 +44,38 @@ export const handlePutGroupApprovers = async (req: Request, res: Response) => {
     }
   }
 
-  const updated = await services.group.updateGroupApprovalUsers(
-    groupId,
-    data.mainApprovalUser,
-    data.tempApprovalUser
-  );
+  const updated = await db.transaction(async (tx) => {
+    const row = await services.group.updateGroupApprovalUsers(
+      groupId,
+      data.mainApprovalUser,
+      data.tempApprovalUser,
+      tx
+    );
 
-  if (!updated) {
-    throw new AppError({
-      message: "Group not found",
-      logging: true,
-      code: 404,
-      context: { url: req.url, user: auth.userId, groupId },
-    });
-  }
+    if (!row) {
+      throw new AppError({
+        message: "Group not found",
+        logging: true,
+        code: 404,
+        context: { url: req.url, user: auth.userId, groupId },
+      });
+    }
 
-  await services.changes.postChanges({
-    id: generateRandomUUID(),
-    userId: auth.userId,
-    groupId,
-    changeType: changesType.Group,
-    changingUserId: auth.userId,
-    changeDetail: `Approvers updated (main: ${data.mainApprovalUser}, temp: ${
-      data.tempApprovalUser ?? "none"
-    })`,
+    await services.changes.postChanges(
+      {
+        id: generateRandomUUID(),
+        userId: auth.userId,
+        groupId,
+        changeType: changesType.Group,
+        changingUserId: auth.userId,
+        changeDetail: `Approvers updated (main: ${data.mainApprovalUser}, temp: ${
+          data.tempApprovalUser ?? "none"
+        })`,
+      },
+      tx
+    );
+
+    return row;
   });
 
   return res.status(200).json(updated);

--- a/src/controllers/group/handlePutGroupQuotas.ts
+++ b/src/controllers/group/handlePutGroupQuotas.ts
@@ -10,10 +10,9 @@ import { changesType } from "../../db/schema/changes-schema.js";
 const services = createDBServices();
 
 /**
- * Updates the group-wide default allowances. These are the values a member's
- * allowance is opened from when they join (see `openQuotaFromGroupDefaults`)
- * and what the year rollover falls back to; existing per-year quotas are
- * untouched (they are edited through `/api/quotas/:groupId`).
+ * Updates the group-wide default allowances. A member's allowance is opened
+ * from these when they join (`openQuotaFromGroupDefaults`); existing per-year
+ * quotas are untouched (they are edited through `/api/quotas/:groupId`).
  */
 export const handlePutGroupQuotas = async (req: Request, res: Response) => {
   const auth = getAuth(req);

--- a/src/controllers/groupUser/handlePostGroupUser.ts
+++ b/src/controllers/groupUser/handlePostGroupUser.ts
@@ -6,6 +6,7 @@ import { db } from "../../db/db.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { normalizeInviteCode } from "../../utils/inviteCode.js";
 import AppError from "../../utils/appError.js";
+import { currentYear } from "../../utils/dateFunc.js";
 
 const services = createDBServices();
 
@@ -57,9 +58,8 @@ export const handlePostGroupUser = async (req: Request, res: Response) => {
         message: "This invite was issued for a different email address",
         logging: true,
         code: 403,
-        // The invited address stays in `context` (logs only). Echoing it back
-        // would let anyone holding a forwarded or guessed code learn whose
-        // address it was issued to.
+        // Kept out of `publicContext`: echoing it back would tell a stranger
+        // holding the code whose address it was issued to.
         context: {
           url: req.url,
           userId: auth.userId,
@@ -109,16 +109,13 @@ export const handlePostGroupUser = async (req: Request, res: Response) => {
       });
     }
 
-    // The group's default allowance is what a new member starts from; without
-    // a row here their allowance is zero and every figure shown to them is
-    // wrong from the moment they join.
     const group = await services.group.getGroup(validateLink.groupId);
     await services.userYearQuotas.openQuotaFromGroupDefaults(
       {
         id: generateRandomUUID(),
         userId: auth.userId,
         groupId: validateLink.groupId,
-        relatedYear: new Date().getFullYear().toString(),
+        relatedYear: currentYear().toString(),
         vacationDays: group?.defaultVacationDays ?? 0,
         homeOfficeDays: group?.defaultHomeOfficeDays ?? 0,
       },

--- a/src/controllers/groupUser/handlePostGroupUser.ts
+++ b/src/controllers/groupUser/handlePostGroupUser.ts
@@ -57,12 +57,14 @@ export const handlePostGroupUser = async (req: Request, res: Response) => {
         message: "This invite was issued for a different email address",
         logging: true,
         code: 403,
+        // The invited address stays in `context` (logs only). Echoing it back
+        // would let anyone holding a forwarded or guessed code learn whose
+        // address it was issued to.
         context: {
           url: req.url,
           userId: auth.userId,
           invitedEmail: validateLink.email,
         },
-        publicContext: { invitedEmail: validateLink.email },
       });
     }
 
@@ -106,6 +108,22 @@ export const handlePostGroupUser = async (req: Request, res: Response) => {
         },
       });
     }
+
+    // The group's default allowance is what a new member starts from; without
+    // a row here their allowance is zero and every figure shown to them is
+    // wrong from the moment they join.
+    const group = await services.group.getGroup(validateLink.groupId);
+    await services.userYearQuotas.openQuotaFromGroupDefaults(
+      {
+        id: generateRandomUUID(),
+        userId: auth.userId,
+        groupId: validateLink.groupId,
+        relatedYear: new Date().getFullYear().toString(),
+        vacationDays: group?.defaultVacationDays ?? 0,
+        homeOfficeDays: group?.defaultHomeOfficeDays ?? 0,
+      },
+      tx
+    );
 
     // `usedAt IS NULL` in the update is what makes the code single-use: a
     // concurrent second redemption matches no row and rolls this back.

--- a/src/controllers/groupUser/tests/handlePostGroupInvite.test.ts
+++ b/src/controllers/groupUser/tests/handlePostGroupInvite.test.ts
@@ -41,9 +41,8 @@ vi.mock("../../../services/DBServices.js", () => ({
 }));
 
 vi.mock("../../../services/groupUser/inviteNotifier.js", async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import("../../../services/groupUser/inviteNotifier.js")
-  >();
+  const actual =
+    await importOriginal<typeof import("../../../services/groupUser/inviteNotifier.js")>();
   return { ...actual, notifyGroupInvited: mockNotifyGroupInvited };
 });
 

--- a/src/controllers/groupUser/tests/handlePostGroupUser.test.ts
+++ b/src/controllers/groupUser/tests/handlePostGroupUser.test.ts
@@ -1,12 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockGetInviteLinkByCode, mockUseInviteLink, mockCreateGroupUser, mockGetGroupUser } =
-  vi.hoisted(() => ({
-    mockGetInviteLinkByCode: vi.fn(),
-    mockUseInviteLink: vi.fn(),
-    mockCreateGroupUser: vi.fn(),
-    mockGetGroupUser: vi.fn(),
-  }));
+const {
+  mockGetInviteLinkByCode,
+  mockUseInviteLink,
+  mockCreateGroupUser,
+  mockGetGroupUser,
+  mockGetGroup,
+  mockOpenQuotaFromGroupDefaults,
+} = vi.hoisted(() => ({
+  mockGetInviteLinkByCode: vi.fn(),
+  mockUseInviteLink: vi.fn(),
+  mockCreateGroupUser: vi.fn(),
+  mockGetGroupUser: vi.fn(),
+  mockGetGroup: vi.fn(),
+  mockOpenQuotaFromGroupDefaults: vi.fn(),
+}));
 
 vi.mock("../../../middleware/authSession.js", () => ({ getAuth: vi.fn() }));
 
@@ -21,6 +29,8 @@ vi.mock("../../../services/DBServices.js", () => ({
       getInviteLinkByCode: mockGetInviteLinkByCode,
       useInviteLink: mockUseInviteLink,
     },
+    group: { getGroup: mockGetGroup },
+    userYearQuotas: { openQuotaFromGroupDefaults: mockOpenQuotaFromGroupDefaults },
   }),
 }));
 
@@ -53,6 +63,12 @@ describe("handlePostGroupUser", () => {
     mockGetGroupUser.mockResolvedValue(undefined);
     mockCreateGroupUser.mockResolvedValue({ id: "membership-1", groupId: GROUP_ID });
     mockUseInviteLink.mockResolvedValue(openInvite({ usedAt: new Date() }));
+    mockGetGroup.mockResolvedValue({
+      id: GROUP_ID,
+      defaultVacationDays: 20,
+      defaultHomeOfficeDays: 5,
+    });
+    mockOpenQuotaFromGroupDefaults.mockResolvedValue({ id: "quota-1" });
   });
 
   const redeem = (code = CODE) => makeReqRes({ params: { validationCode: code } });

--- a/src/controllers/users/handleGetMyBalances.ts
+++ b/src/controllers/users/handleGetMyBalances.ts
@@ -46,9 +46,7 @@ export const handleGetMyBalances = async (req: Request, res: Response) => {
     return bucket;
   };
 
-  // Carry-over belongs to the vacation allowance only, and it is part of what
-  // the member may actually take — the report already counts it, so leaving it
-  // out here told people they had fewer days than HR says they do.
+  // Carry-over belongs to the vacation allowance only.
   ensure(vacationType.Vacation).allocated = quotaSums.vacationDays + quotaSums.carriedOverDays;
   ensure(vacationType.HomeOffice).allocated = quotaSums.homeOfficeDays;
 

--- a/src/controllers/users/handleGetMyBalances.ts
+++ b/src/controllers/users/handleGetMyBalances.ts
@@ -46,7 +46,10 @@ export const handleGetMyBalances = async (req: Request, res: Response) => {
     return bucket;
   };
 
-  ensure(vacationType.Vacation).allocated = quotaSums.vacationDays;
+  // Carry-over belongs to the vacation allowance only, and it is part of what
+  // the member may actually take — the report already counts it, so leaving it
+  // out here told people they had fewer days than HR says they do.
+  ensure(vacationType.Vacation).allocated = quotaSums.vacationDays + quotaSums.carriedOverDays;
   ensure(vacationType.HomeOffice).allocated = quotaSums.homeOfficeDays;
 
   for (const row of usage) {

--- a/src/controllers/users/handlePutMySettings.ts
+++ b/src/controllers/users/handlePutMySettings.ts
@@ -32,7 +32,7 @@ export const handlePutMySettings = async (req: Request, res: Response) => {
   const nextGroupId =
     patch.dashboardGroupId !== undefined
       ? patch.dashboardGroupId
-      : current?.dashboardGroupId ?? DEFAULT_USER_SETTINGS.dashboardGroupId;
+      : (current?.dashboardGroupId ?? DEFAULT_USER_SETTINGS.dashboardGroupId);
 
   if (nextScope === dashboardScope.Group && !nextGroupId) {
     throw new AppError({

--- a/src/controllers/vacation/decisionGuards.ts
+++ b/src/controllers/vacation/decisionGuards.ts
@@ -1,0 +1,73 @@
+import AppError from "../../utils/appError.js";
+import type { DbTransaction } from "../../db/db.js";
+import { createDBServices } from "../../services/DBServices.js";
+import type { VacationType } from "../../services/vacation/types.js";
+
+const services = createDBServices();
+
+type Decision = "approve" | "reject";
+
+/**
+ * The single predicate for "may this person decide on these requests".
+ *
+ * Both the per-record and the bulk endpoints route through here so the same
+ * user acting on the same request cannot be refused by one button and obeyed by
+ * another — previously the bulk path accepted the group manager while the
+ * single path accepted only the named approvers, and sending a one-element
+ * array bypassed the stricter of the two.
+ *
+ * Separation of duties is part of the predicate: an approver's own request is
+ * for the group's other approver to decide, never for themselves.
+ */
+export const assertMayDecide = async (
+  actorUserId: string,
+  rows: Pick<VacationType, "id" | "userId" | "groupId">[],
+  decision: Decision,
+  tx?: DbTransaction
+): Promise<void> => {
+  const distinctGroupIds = Array.from(new Set(rows.map((row) => row.groupId)));
+  const allowedGroupIds = new Set(
+    await services.group.getGroupsWhereUserCanApprove(distinctGroupIds, actorUserId, tx)
+  );
+
+  const unauthorizedGroups = distinctGroupIds.filter((id) => !allowedGroupIds.has(id));
+  if (unauthorizedGroups.length > 0) {
+    throw new AppError({
+      code: 403,
+      message: `You are not allowed to ${decision} one or more of these requests`,
+      logging: true,
+      context: { actorUserId, unauthorizedGroups },
+    });
+  }
+
+  if (rows.some((row) => row.userId === actorUserId)) {
+    throw new AppError({
+      code: 403,
+      message: "You cannot decide on your own leave request",
+      logging: true,
+      context: { actorUserId, vacationIds: rows.map((row) => row.id) },
+    });
+  }
+};
+
+/**
+ * A decision is only meaningful on an open request. Checked here so the caller
+ * gets a 409 explaining what happened rather than the update silently matching
+ * no rows — or, before the update predicate was tightened, silently overturning
+ * the earlier decision.
+ */
+export const assertStillPending = (
+  rows: Pick<VacationType, "id" | "approvedAt" | "rejectedAt" | "deletedAt">[]
+): void => {
+  const decided = rows.filter(
+    (row) => row.approvedAt !== null || row.rejectedAt !== null || row.deletedAt !== null
+  );
+  if (decided.length > 0) {
+    throw new AppError({
+      code: 409,
+      message: "This request has already been decided",
+      logging: true,
+      context: { vacationIds: decided.map((row) => row.id) },
+    });
+  }
+};

--- a/src/controllers/vacation/decisionGuards.ts
+++ b/src/controllers/vacation/decisionGuards.ts
@@ -8,16 +8,9 @@ const services = createDBServices();
 type Decision = "approve" | "reject";
 
 /**
- * The single predicate for "may this person decide on these requests".
- *
- * Both the per-record and the bulk endpoints route through here so the same
- * user acting on the same request cannot be refused by one button and obeyed by
- * another — previously the bulk path accepted the group manager while the
- * single path accepted only the named approvers, and sending a one-element
- * array bypassed the stricter of the two.
- *
- * Separation of duties is part of the predicate: an approver's own request is
- * for the group's other approver to decide, never for themselves.
+ * The single predicate for "may this person decide on these requests", shared by
+ * the per-record and bulk endpoints so they cannot drift apart. Separation of
+ * duties is part of it: an approver's own request is for the other approver.
  */
 export const assertMayDecide = async (
   actorUserId: string,
@@ -50,12 +43,7 @@ export const assertMayDecide = async (
   }
 };
 
-/**
- * A decision is only meaningful on an open request. Checked here so the caller
- * gets a 409 explaining what happened rather than the update silently matching
- * no rows — or, before the update predicate was tightened, silently overturning
- * the earlier decision.
- */
+/** Fails fast with an explanation; the update predicate is the real guarantee. */
 export const assertStillPending = (
   rows: Pick<VacationType, "id" | "approvedAt" | "rejectedAt" | "deletedAt">[]
 ): void => {

--- a/src/controllers/vacation/handleBulkApproveVacation.ts
+++ b/src/controllers/vacation/handleBulkApproveVacation.ts
@@ -7,6 +7,8 @@ import type { ValidatedBulkApproveVacationType } from "../../services/vacation/t
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
+import { assertApprovalWithinQuota } from "../../services/vacation/quotaGuard.js";
+import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
 
 const services = createDBServices();
 
@@ -34,19 +36,9 @@ export const handleBulkApproveVacation = async (req: Request, res: Response) => 
       });
     }
 
-    const distinctGroupIds = Array.from(new Set(rows.map((r) => r.groupId)));
-    const allowedGroupIds = new Set(
-      await services.group.getGroupsWhereUserCanApprove(distinctGroupIds, auth.userId, tx)
-    );
-
-    const unauthorizedGroups = distinctGroupIds.filter((id) => !allowedGroupIds.has(id));
-    if (unauthorizedGroups.length > 0) {
-      throw new AppError({
-        code: 403,
-        message: "You are not allowed to approve one or more of these vacations",
-        context: { auth, unauthorizedGroups },
-      });
-    }
+    await assertMayDecide(auth.userId, rows, "approve", tx);
+    assertStillPending(rows);
+    await assertApprovalWithinQuota(rows, tx);
 
     const updated = await services.vacation.approveVacationsBulk(uniqueIds, auth.userId, tx);
 

--- a/src/controllers/vacation/handleBulkApproveVacation.ts
+++ b/src/controllers/vacation/handleBulkApproveVacation.ts
@@ -42,6 +42,16 @@ export const handleBulkApproveVacation = async (req: Request, res: Response) => 
 
     const updated = await services.vacation.approveVacationsBulk(uniqueIds, auth.userId, tx);
 
+    // A short update means a concurrent decision took part of the batch.
+    if (updated.length !== uniqueIds.length) {
+      throw new AppError({
+        code: 409,
+        message: "One or more of these requests has already been decided",
+        logging: true,
+        context: { auth, requested: uniqueIds, updated: updated.map((row) => row.id) },
+      });
+    }
+
     await services.vacationEvent.createVacationEvents(
       updated.map((row) => ({
         id: generateRandomUUID(),

--- a/src/controllers/vacation/handleBulkRejectVacation.ts
+++ b/src/controllers/vacation/handleBulkRejectVacation.ts
@@ -39,6 +39,16 @@ export const handleBulkRejectVacation = async (req: Request, res: Response) => {
       tx
     );
 
+    // A short update means a concurrent decision took part of the batch.
+    if (updated.length !== uniqueIds.length) {
+      throw new AppError({
+        code: 409,
+        message: "One or more of these requests has already been decided",
+        logging: true,
+        context: { auth, requested: uniqueIds, updated: updated.map((row) => row.id) },
+      });
+    }
+
     await services.vacationEvent.createVacationEvents(
       updated.map((row) => ({
         id: generateRandomUUID(),

--- a/src/controllers/vacation/handleBulkRejectVacation.ts
+++ b/src/controllers/vacation/handleBulkRejectVacation.ts
@@ -7,6 +7,7 @@ import type { ValidatedBulkRejectVacationType } from "../../services/vacation/ty
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
+import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
 
 const services = createDBServices();
 
@@ -28,19 +29,8 @@ export const handleBulkRejectVacation = async (req: Request, res: Response) => {
       });
     }
 
-    const distinctGroupIds = Array.from(new Set(rows.map((r) => r.groupId)));
-    const allowedGroupIds = new Set(
-      await services.group.getGroupsWhereUserCanApprove(distinctGroupIds, auth.userId, tx)
-    );
-
-    const unauthorizedGroups = distinctGroupIds.filter((id) => !allowedGroupIds.has(id));
-    if (unauthorizedGroups.length > 0) {
-      throw new AppError({
-        code: 403,
-        message: "You are not allowed to reject one or more of these vacations",
-        context: { auth, unauthorizedGroups },
-      });
-    }
+    await assertMayDecide(auth.userId, rows, "reject", tx);
+    assertStillPending(rows);
 
     const updated = await services.vacation.rejectVacationsBulk(
       uniqueIds,

--- a/src/controllers/vacation/handlePostVacation.ts
+++ b/src/controllers/vacation/handlePostVacation.ts
@@ -20,10 +20,8 @@ const services = createDBServices();
 // can't allocate tens of thousands of rows or stall a bulk insert.
 const MAX_VACATION_RANGE_DAYS = 366;
 
-// Where the range may sit on the calendar. Retroactive entries are legitimate
-// (sick leave is usually reported after the fact) but only within the current
-// year, and nothing may be booked past next year — a typo'd year would
-// otherwise draw down an allowance nobody will ever review.
+// Retroactive entries are legitimate (sick leave is reported after the fact)
+// but only back to the start of this year.
 const earliestBookableDay = (today: Date): string => `${today.getUTCFullYear().toString()}-01-01`;
 const latestBookableDay = (today: Date): string =>
   `${(today.getUTCFullYear() + 1).toString()}-12-31`;
@@ -130,8 +128,6 @@ export const handlePostVacation = async (req: Request, res: Response) => {
   }));
 
   const created = await db.transaction(async (tx) => {
-    // Inside the transaction so two concurrent requests cannot both read a
-    // balance that only one of them fits into.
     await assertRequestWithinQuota(records, tx);
 
     const rows = await services.vacation.postVacationBulk(records, tx);

--- a/src/controllers/vacation/handlePostVacation.ts
+++ b/src/controllers/vacation/handlePostVacation.ts
@@ -12,12 +12,21 @@ import { createDBServices } from "../../services/DBServices.js";
 import { db } from "../../db/db.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationRequested } from "../../services/vacation/vacationNotifier.js";
+import { assertRequestWithinQuota } from "../../services/vacation/quotaGuard.js";
 
 const services = createDBServices();
 
 // One full year. Caps the per-day fan-out so a pathological `from`/`to` pair
 // can't allocate tens of thousands of rows or stall a bulk insert.
 const MAX_VACATION_RANGE_DAYS = 366;
+
+// Where the range may sit on the calendar. Retroactive entries are legitimate
+// (sick leave is usually reported after the fact) but only within the current
+// year, and nothing may be booked past next year — a typo'd year would
+// otherwise draw down an allowance nobody will ever review.
+const earliestBookableDay = (today: Date): string => `${today.getUTCFullYear().toString()}-01-01`;
+const latestBookableDay = (today: Date): string =>
+  `${(today.getUTCFullYear() + 1).toString()}-12-31`;
 
 export const handlePostVacation = async (req: Request, res: Response) => {
   const auth = getAuth(req);
@@ -45,6 +54,19 @@ export const handlePostVacation = async (req: Request, res: Response) => {
       logging: true,
       code: 422,
       context: { from: fromIso, to: toIso, rangeDays },
+    });
+  }
+
+  const today = new Date();
+  const earliest = earliestBookableDay(today);
+  const latest = latestBookableDay(today);
+  if (fromIso < earliest || toIso > latest) {
+    throw new AppError({
+      message: `Leave can only be booked between ${earliest} and ${latest}`,
+      logging: true,
+      code: 422,
+      context: { from: fromIso, to: toIso, earliest, latest },
+      publicContext: { earliest, latest },
     });
   }
 
@@ -108,6 +130,10 @@ export const handlePostVacation = async (req: Request, res: Response) => {
   }));
 
   const created = await db.transaction(async (tx) => {
+    // Inside the transaction so two concurrent requests cannot both read a
+    // balance that only one of them fits into.
+    await assertRequestWithinQuota(records, tx);
+
     const rows = await services.vacation.postVacationBulk(records, tx);
     await services.vacationEvent.createVacationEvents(
       rows.map((row) => ({

--- a/src/controllers/vacation/handlePostVacationApproval.ts
+++ b/src/controllers/vacation/handlePostVacationApproval.ts
@@ -39,6 +39,16 @@ export const handlePostVacationApproval = async (req: Request, res: Response) =>
 
     const row = await services.vacation.approveVacation(vacationId, auth.userId, tx);
 
+    // Lost race: decided between the read above and this update.
+    if (!row) {
+      throw new AppError({
+        code: 409,
+        message: "This request has already been decided",
+        logging: true,
+        context: { auth, vacationId },
+      });
+    }
+
     await services.vacationEvent.createVacationEvent(
       {
         id: generateRandomUUID(),

--- a/src/controllers/vacation/handlePostVacationApproval.ts
+++ b/src/controllers/vacation/handlePostVacationApproval.ts
@@ -8,6 +8,8 @@ import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
 import type { ValidatedApproveVacationType } from "../../services/vacation/types.js";
+import { assertApprovalWithinQuota } from "../../services/vacation/quotaGuard.js";
+import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
 
 const services = createDBServices();
 
@@ -31,26 +33,9 @@ export const handlePostVacationApproval = async (req: Request, res: Response) =>
       });
     }
 
-    const getApprovers = await services.group.getApprovalUsers(vacationData.groupId, tx);
-
-    if (!getApprovers) {
-      throw new AppError({
-        code: 404,
-        message: "Not able to verify approvers",
-        context: { auth, vacationId },
-      });
-    }
-
-    if (
-      auth.userId !== getApprovers.mainApprovalUserId &&
-      auth.userId !== getApprovers.tempApprovalUserId
-    ) {
-      throw new AppError({
-        code: 403,
-        message: "You are not allowed to approve this vacation",
-        context: { auth, vacationId },
-      });
-    }
+    await assertMayDecide(auth.userId, [vacationData], "approve", tx);
+    assertStillPending([vacationData]);
+    await assertApprovalWithinQuota([vacationData], tx);
 
     const row = await services.vacation.approveVacation(vacationId, auth.userId, tx);
 

--- a/src/controllers/vacation/handlePostVacationReject.ts
+++ b/src/controllers/vacation/handlePostVacationReject.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";
 import type { ValidatedRejectVacationType } from "../../services/vacation/types.js";
+import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
@@ -31,26 +32,8 @@ export const handlePostVacationReject = async (req: Request, res: Response) => {
       });
     }
 
-    const approvers = await services.group.getApprovalUsers(vacationData.groupId, tx);
-
-    if (!approvers) {
-      throw new AppError({
-        code: 404,
-        message: "Not able to verify approvers",
-        context: { auth, vacationId },
-      });
-    }
-
-    if (
-      auth.userId !== approvers.mainApprovalUserId &&
-      auth.userId !== approvers.tempApprovalUserId
-    ) {
-      throw new AppError({
-        code: 403,
-        message: "You are not allowed to reject this vacation",
-        context: { auth, vacationId },
-      });
-    }
+    await assertMayDecide(auth.userId, [vacationData], "reject", tx);
+    assertStillPending([vacationData]);
 
     const row = await services.vacation.rejectVacation(
       vacationId,

--- a/src/controllers/vacation/handlePostVacationReject.ts
+++ b/src/controllers/vacation/handlePostVacationReject.ts
@@ -42,6 +42,16 @@ export const handlePostVacationReject = async (req: Request, res: Response) => {
       tx
     );
 
+    // Lost race: decided between the read above and this update.
+    if (!row) {
+      throw new AppError({
+        code: 409,
+        message: "This request has already been decided",
+        logging: true,
+        context: { auth, vacationId },
+      });
+    }
+
     await services.vacationEvent.createVacationEvent(
       {
         id: generateRandomUUID(),

--- a/src/controllers/vacation/tests/handlePostVacation.test.ts
+++ b/src/controllers/vacation/tests/handlePostVacation.test.ts
@@ -8,6 +8,7 @@ const {
   mockTransaction,
   mockCreateVacationEvents,
   mockNotifyVacationRequested,
+  mockAssertRequestWithinQuota,
 } = vi.hoisted(() => ({
   mockPostVacationBulk: vi.fn(),
   mockGetGroupUser: vi.fn(),
@@ -16,6 +17,7 @@ const {
   mockTransaction: vi.fn(),
   mockCreateVacationEvents: vi.fn(),
   mockNotifyVacationRequested: vi.fn(),
+  mockAssertRequestWithinQuota: vi.fn(),
 }));
 
 vi.mock("../../../utils/generateUUID.js", () => ({
@@ -28,6 +30,10 @@ vi.mock("../../../middleware/authSession.js", () => ({
 
 vi.mock("../../../services/vacation/vacationNotifier.js", () => ({
   notifyVacationRequested: mockNotifyVacationRequested,
+}));
+
+vi.mock("../../../services/vacation/quotaGuard.js", () => ({
+  assertRequestWithinQuota: mockAssertRequestWithinQuota,
 }));
 
 vi.mock("../../../db/db.js", () => ({
@@ -73,7 +79,13 @@ const baseBody = (overrides: Record<string, unknown> = {}) => ({
 
 describe("handlePostVacation", () => {
   beforeEach(() => {
+    // The controller bounds how far a range may sit from today, so the March
+    // 2024 fixtures below (chosen for their weekdays) need a matching "today".
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2024-03-01T09:00:00Z"));
+
     vi.clearAllMocks();
+    mockAssertRequestWithinQuota.mockResolvedValue(undefined);
 
     (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
 
@@ -93,6 +105,7 @@ describe("handlePostVacation", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 

--- a/src/controllers/vacation/tests/handlePostVacationApproval.test.ts
+++ b/src/controllers/vacation/tests/handlePostVacationApproval.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const { mockGetVacationById, mockGetApprovalUsers, mockApproveVacation, mockCreateVacationEvent } =
-  vi.hoisted(() => ({
-    mockGetVacationById: vi.fn(),
-    mockGetApprovalUsers: vi.fn(),
-    mockApproveVacation: vi.fn(),
-    mockCreateVacationEvent: vi.fn(),
-  }));
+const {
+  mockGetVacationById,
+  mockGetGroupsWhereUserCanApprove,
+  mockApproveVacation,
+  mockCreateVacationEvent,
+  mockAssertApprovalWithinQuota,
+} = vi.hoisted(() => ({
+  mockGetVacationById: vi.fn(),
+  mockGetGroupsWhereUserCanApprove: vi.fn(),
+  mockApproveVacation: vi.fn(),
+  mockCreateVacationEvent: vi.fn(),
+  mockAssertApprovalWithinQuota: vi.fn(),
+}));
 
 vi.mock("../../../middleware/authSession.js", () => ({
   getAuth: vi.fn(),
@@ -25,7 +31,7 @@ vi.mock("../../../services/DBServices.js", () => ({
       approveVacation: mockApproveVacation,
     },
     group: {
-      getApprovalUsers: mockGetApprovalUsers,
+      getGroupsWhereUserCanApprove: mockGetGroupsWhereUserCanApprove,
     },
     vacationEvent: {
       createVacationEvent: mockCreateVacationEvent,
@@ -33,115 +39,67 @@ vi.mock("../../../services/DBServices.js", () => ({
   }),
 }));
 
+vi.mock("../../../services/vacation/quotaGuard.js", () => ({
+  assertApprovalWithinQuota: mockAssertApprovalWithinQuota,
+}));
+
 import { handlePostVacationApproval } from "../handlePostVacationApproval.js";
 import { getAuth } from "../../../middleware/authSession.js";
 import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
+
+const VACATION_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+const pendingVacation = (over: Record<string, unknown> = {}) => ({
+  id: VACATION_ID,
+  userId: "vacation_user_123",
+  groupId: "group_123",
+  requestedDay: "2024-03-15",
+  startTime: "09:00",
+  endTime: "17:00",
+  vacationType: "VACATION",
+  halfDay: false,
+  approvedAt: null,
+  rejectedAt: null,
+  deletedAt: null,
+  ...over,
+});
 
 describe("handlePostVacationApproval", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
     (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
+    mockGetGroupsWhereUserCanApprove.mockResolvedValue(["group_123"]);
+    mockAssertApprovalWithinQuota.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("should approve vacation successfully when user is main approver", async () => {
-    const { req, res } = makeReqRes({
-      params: { id: "550e8400-e29b-41d4-a716-446655440000" },
-    });
+  it("should approve vacation successfully when the caller may decide on it", async () => {
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
 
-    const mockVacationData = {
-      id: "550e8400-e29b-41d4-a716-446655440000",
-      userId: "vacation_user_123",
-      groupId: "group_123",
-      requestedDay: "2024-03-15",
-      startTime: "09:00",
-      endTime: "17:00",
-      vacationType: "Vacation",
-    };
-
-    mockGetVacationById.mockResolvedValue(mockVacationData);
-    mockGetApprovalUsers.mockResolvedValue({
-      mainApprovalUserId: "user_123",
-      tempApprovalUserId: "temp_user_456",
-    });
+    mockGetVacationById.mockResolvedValue(pendingVacation());
     mockApproveVacation.mockResolvedValue(undefined);
 
     await handlePostVacationApproval(req, res);
 
     expect(getAuth).toHaveBeenCalledWith(req);
-    expect(mockGetVacationById).toHaveBeenCalledWith("550e8400-e29b-41d4-a716-446655440000", {});
-    expect(mockGetApprovalUsers).toHaveBeenCalledWith("group_123", {});
-    expect(mockApproveVacation).toHaveBeenCalledWith(
-      "550e8400-e29b-41d4-a716-446655440000",
-      "user_123",
-      {}
-    );
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ message: "Vacation approved" });
-  });
-
-  it("should approve vacation successfully when user is temp approver", async () => {
-    const { req, res } = makeReqRes({
-      params: { id: "550e8400-e29b-41d4-a716-446655440000" },
-    });
-
-    const mockVacationData = {
-      id: "550e8400-e29b-41d4-a716-446655440000",
-      userId: "vacation_user_123",
-      groupId: "group_123",
-      requestedDay: "2024-03-15",
-      startTime: "09:00",
-      endTime: "17:00",
-      vacationType: "Vacation",
-    };
-
-    (getAuth as ReturnType<typeof vi.fn>).mockReturnValue({
-      userId: "temp_user_456",
-      sessionId: "session_456",
-      userName: "Temp Approver",
-      userEmail: "temp@example.com",
-      emailVerified: true,
-    });
-
-    mockGetVacationById.mockResolvedValue(mockVacationData);
-    mockGetApprovalUsers.mockResolvedValue({
-      mainApprovalUserId: "main_user_123",
-      tempApprovalUserId: "temp_user_456",
-    });
-    mockApproveVacation.mockResolvedValue(undefined);
-
-    await handlePostVacationApproval(req, res);
-
-    expect(mockApproveVacation).toHaveBeenCalledWith(
-      "550e8400-e29b-41d4-a716-446655440000",
-      "temp_user_456",
-      {}
-    );
+    expect(mockGetVacationById).toHaveBeenCalledWith(VACATION_ID, {});
+    expect(mockGetGroupsWhereUserCanApprove).toHaveBeenCalledWith(["group_123"], "user_123", {});
+    expect(mockApproveVacation).toHaveBeenCalledWith(VACATION_ID, "user_123", {});
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ message: "Vacation approved" });
   });
 
   it("stores the approver's note on the APPROVED event", async () => {
     const { req, res } = makeReqRes({
-      params: { id: "550e8400-e29b-41d4-a716-446655440000" },
+      params: { id: VACATION_ID },
       body: { reason: "Enjoy the break" },
     });
 
-    mockGetVacationById.mockResolvedValue({
-      id: "550e8400-e29b-41d4-a716-446655440000",
-      userId: "vacation_user_123",
-      groupId: "group_123",
-      requestedDay: "2024-03-15",
-      vacationType: "Vacation",
-    });
-    mockGetApprovalUsers.mockResolvedValue({
-      mainApprovalUserId: "user_123",
-      tempApprovalUserId: "temp_user_456",
-    });
+    mockGetVacationById.mockResolvedValue(pendingVacation());
     mockApproveVacation.mockResolvedValue(undefined);
 
     await handlePostVacationApproval(req, res);
@@ -153,84 +111,85 @@ describe("handlePostVacationApproval", () => {
   });
 
   it("should throw validation error for invalid UUID format", async () => {
-    const { req, res } = makeReqRes({
-      params: { id: "invalid-uuid" },
-    });
+    const { req, res } = makeReqRes({ params: { id: "invalid-uuid" } });
 
     await expect(handlePostVacationApproval(req, res)).rejects.toThrow();
     expect(mockGetVacationById).not.toHaveBeenCalled();
   });
 
   it("should throw 404 error when vacation is not found", async () => {
-    const { req, res } = makeReqRes({
-      params: { id: "550e8400-e29b-41d4-a716-446655440000" },
-    });
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
 
     mockGetVacationById.mockResolvedValue(null);
 
     await expect(handlePostVacationApproval(req, res)).rejects.toThrow("Vacation not found");
-    expect(mockGetApprovalUsers).not.toHaveBeenCalled();
+    expect(mockGetGroupsWhereUserCanApprove).not.toHaveBeenCalled();
     expect(mockApproveVacation).not.toHaveBeenCalled();
   });
 
-  it("should throw 404 error when approvers cannot be verified", async () => {
-    const { req, res } = makeReqRes({
-      params: { id: "550e8400-e29b-41d4-a716-446655440000" },
-    });
+  it("refuses a caller who is not an approver of the request's group", async () => {
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
 
-    const mockVacationData = {
-      id: "550e8400-e29b-41d4-a716-446655440000",
-      userId: "vacation_user_123",
-      groupId: "group_123",
-      requestedDay: "2024-03-15",
-      startTime: "09:00",
-      endTime: "17:00",
-      vacationType: "Vacation",
-    };
-
-    mockGetVacationById.mockResolvedValue(mockVacationData);
-    mockGetApprovalUsers.mockResolvedValue(null);
+    mockGetVacationById.mockResolvedValue(pendingVacation());
+    mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
 
     await expect(handlePostVacationApproval(req, res)).rejects.toThrow(
-      "Not able to verify approvers"
+      "You are not allowed to approve one or more of these requests"
     );
     expect(mockApproveVacation).not.toHaveBeenCalled();
   });
 
-  it("should throw 403 error when user is not an approver", async () => {
-    const { req, res } = makeReqRes({
-      params: { id: "550e8400-e29b-41d4-a716-446655440000" },
-    });
+  it("refuses an approver deciding on their own request", async () => {
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
 
-    const mockVacationData = {
-      id: "550e8400-e29b-41d4-a716-446655440000",
-      userId: "vacation_user_123",
-      groupId: "group_123",
-      requestedDay: "2024-03-15",
-      startTime: "09:00",
-      endTime: "17:00",
-      vacationType: "Vacation",
-    };
-
-    mockGetVacationById.mockResolvedValue(mockVacationData);
-    mockGetApprovalUsers.mockResolvedValue({
-      mainApprovalUserId: "main_user_999",
-      tempApprovalUserId: "temp_user_888",
-    });
+    mockGetVacationById.mockResolvedValue(pendingVacation({ userId: "user_123" }));
 
     await expect(handlePostVacationApproval(req, res)).rejects.toThrow(
-      "You are not allowed to approve this vacation"
+      "You cannot decide on your own leave request"
+    );
+    expect(mockApproveVacation).not.toHaveBeenCalled();
+  });
+
+  it("refuses to overturn a request that has already been rejected", async () => {
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
+
+    mockGetVacationById.mockResolvedValue(pendingVacation({ rejectedAt: new Date() }));
+
+    await expect(handlePostVacationApproval(req, res)).rejects.toThrow(
+      "This request has already been decided"
+    );
+    expect(mockApproveVacation).not.toHaveBeenCalled();
+  });
+
+  it("refuses to re-approve a request that is already approved", async () => {
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
+
+    mockGetVacationById.mockResolvedValue(pendingVacation({ approvedAt: new Date() }));
+
+    await expect(handlePostVacationApproval(req, res)).rejects.toThrow(
+      "This request has already been decided"
+    );
+    expect(mockApproveVacation).not.toHaveBeenCalled();
+  });
+
+  it("does not approve days the requester has no allowance left for", async () => {
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
+
+    mockGetVacationById.mockResolvedValue(pendingVacation());
+    mockAssertApprovalWithinQuota.mockRejectedValue(
+      new Error("This would exceed the allowance for that leave type")
+    );
+
+    await expect(handlePostVacationApproval(req, res)).rejects.toThrow(
+      "This would exceed the allowance for that leave type"
     );
     expect(mockApproveVacation).not.toHaveBeenCalled();
   });
 
   it("should handle database service errors from getVacationById", async () => {
-    const { req, res } = makeReqRes({
-      params: { id: "550e8400-e29b-41d4-a716-446655440000" },
-    });
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
 
-    const dbError = new Error("Database connection failed");
-    mockGetVacationById.mockRejectedValue(dbError);
+    mockGetVacationById.mockRejectedValue(new Error("Database connection failed"));
 
     await expect(handlePostVacationApproval(req, res)).rejects.toThrow(
       "Database connection failed"
@@ -239,56 +198,27 @@ describe("handlePostVacationApproval", () => {
   });
 
   it("should handle database service errors from approveVacation", async () => {
-    const { req, res } = makeReqRes({
-      params: { id: "550e8400-e29b-41d4-a716-446655440000" },
-    });
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
 
-    const mockVacationData = {
-      id: "550e8400-e29b-41d4-a716-446655440000",
-      userId: "vacation_user_123",
-      groupId: "group_123",
-      requestedDay: "2024-03-15",
-      startTime: "09:00",
-      endTime: "17:00",
-      vacationType: "Vacation",
-    };
-
-    mockGetVacationById.mockResolvedValue(mockVacationData);
-    mockGetApprovalUsers.mockResolvedValue({
-      mainApprovalUserId: "user_123",
-      tempApprovalUserId: "temp_user_456",
-    });
-
-    const dbError = new Error("Failed to update vacation");
-    mockApproveVacation.mockRejectedValue(dbError);
+    mockGetVacationById.mockResolvedValue(pendingVacation());
+    mockApproveVacation.mockRejectedValue(new Error("Failed to update vacation"));
 
     await expect(handlePostVacationApproval(req, res)).rejects.toThrow("Failed to update vacation");
   });
 
-  it("should use groupId from vacation data to fetch approvers", async () => {
-    const { req, res } = makeReqRes({
-      params: { id: "550e8400-e29b-41d4-a716-446655440000" },
-    });
+  it("authorizes against the group the request belongs to", async () => {
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
 
-    const mockVacationData = {
-      id: "550e8400-e29b-41d4-a716-446655440000",
-      userId: "vacation_user_123",
-      groupId: "specific_group_789",
-      requestedDay: "2024-03-15",
-      startTime: "09:00",
-      endTime: "17:00",
-      vacationType: "Vacation",
-    };
-
-    mockGetVacationById.mockResolvedValue(mockVacationData);
-    mockGetApprovalUsers.mockResolvedValue({
-      mainApprovalUserId: "user_123",
-      tempApprovalUserId: "temp_user_456",
-    });
+    mockGetVacationById.mockResolvedValue(pendingVacation({ groupId: "specific_group_789" }));
+    mockGetGroupsWhereUserCanApprove.mockResolvedValue(["specific_group_789"]);
     mockApproveVacation.mockResolvedValue(undefined);
 
     await handlePostVacationApproval(req, res);
 
-    expect(mockGetApprovalUsers).toHaveBeenCalledWith("specific_group_789", {});
+    expect(mockGetGroupsWhereUserCanApprove).toHaveBeenCalledWith(
+      ["specific_group_789"],
+      "user_123",
+      {}
+    );
   });
 });

--- a/src/controllers/vacation/tests/handlePostVacationApproval.test.ts
+++ b/src/controllers/vacation/tests/handlePostVacationApproval.test.ts
@@ -81,7 +81,7 @@ describe("handlePostVacationApproval", () => {
     const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
 
     mockGetVacationById.mockResolvedValue(pendingVacation());
-    mockApproveVacation.mockResolvedValue(undefined);
+    mockApproveVacation.mockResolvedValue(pendingVacation({ approvedAt: new Date() }));
 
     await handlePostVacationApproval(req, res);
 
@@ -100,7 +100,7 @@ describe("handlePostVacationApproval", () => {
     });
 
     mockGetVacationById.mockResolvedValue(pendingVacation());
-    mockApproveVacation.mockResolvedValue(undefined);
+    mockApproveVacation.mockResolvedValue(pendingVacation({ approvedAt: new Date() }));
 
     await handlePostVacationApproval(req, res);
 
@@ -186,6 +186,19 @@ describe("handlePostVacationApproval", () => {
     expect(mockApproveVacation).not.toHaveBeenCalled();
   });
 
+  it("409s when the request was decided between the read and the update", async () => {
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
+
+    mockGetVacationById.mockResolvedValue(pendingVacation());
+    // The guards saw a pending row; the update predicate did not.
+    mockApproveVacation.mockResolvedValue(undefined);
+
+    await expect(handlePostVacationApproval(req, res)).rejects.toThrow(
+      "This request has already been decided"
+    );
+    expect(mockCreateVacationEvent).not.toHaveBeenCalled();
+  });
+
   it("should handle database service errors from getVacationById", async () => {
     const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
 
@@ -211,7 +224,7 @@ describe("handlePostVacationApproval", () => {
 
     mockGetVacationById.mockResolvedValue(pendingVacation({ groupId: "specific_group_789" }));
     mockGetGroupsWhereUserCanApprove.mockResolvedValue(["specific_group_789"]);
-    mockApproveVacation.mockResolvedValue(undefined);
+    mockApproveVacation.mockResolvedValue(pendingVacation({ approvedAt: new Date() }));
 
     await handlePostVacationApproval(req, res);
 

--- a/src/controllers/vacation/utils.ts
+++ b/src/controllers/vacation/utils.ts
@@ -20,7 +20,7 @@ export type VacationPermissions = {
  */
 export const resolveVacationPermissions = async (
   userId: string,
-  vacationRow: Pick<VacationType, "userId" | "groupId" | "deletedAt">,
+  vacationRow: Pick<VacationType, "userId" | "groupId" | "deletedAt" | "approvedAt" | "rejectedAt">,
   tx?: DbTransaction
 ): Promise<VacationPermissions> => {
   const isOwner = vacationRow.userId === userId;
@@ -34,13 +34,15 @@ export const resolveVacationPermissions = async (
   const isApprover = approvableGroups.includes(vacationRow.groupId);
   const isAdmin = membership?.adminAccess ?? false;
   const isCancelled = vacationRow.deletedAt !== null;
-  // Rejected requests can still be approved — approveVacation clears the
-  // rejection — so only a cancellation closes the decision for good.
-  const isDecidable = !isCancelled;
+  // A decision is final: re-deciding would overturn the first one and wipe its
+  // stamps, so only a request nobody has ruled on yet is decidable.
+  const isDecidable =
+    !isCancelled && vacationRow.approvedAt === null && vacationRow.rejectedAt === null;
 
   return {
     canView: isOwner || isApprover || (membership?.viewAccess ?? false),
-    canApprove: isApprover && isDecidable,
+    // Separation of duties: an approver's own request goes to the other approver.
+    canApprove: isApprover && !isOwner && isDecidable,
     canCancel: !isCancelled && (isOwner || isAdmin || isApprover),
   };
 };

--- a/src/controllers/vacation/utils.ts
+++ b/src/controllers/vacation/utils.ts
@@ -34,14 +34,12 @@ export const resolveVacationPermissions = async (
   const isApprover = approvableGroups.includes(vacationRow.groupId);
   const isAdmin = membership?.adminAccess ?? false;
   const isCancelled = vacationRow.deletedAt !== null;
-  // A decision is final: re-deciding would overturn the first one and wipe its
-  // stamps, so only a request nobody has ruled on yet is decidable.
+  // A decision is final; re-deciding would overturn it and wipe its stamps.
   const isDecidable =
     !isCancelled && vacationRow.approvedAt === null && vacationRow.rejectedAt === null;
 
   return {
     canView: isOwner || isApprover || (membership?.viewAccess ?? false),
-    // Separation of duties: an approver's own request goes to the other approver.
     canApprove: isApprover && !isOwner && isDecidable,
     canCancel: !isCancelled && (isOwner || isAdmin || isApprover),
   };

--- a/src/db/schema/auth-schema.ts
+++ b/src/db/schema/auth-schema.ts
@@ -6,8 +6,8 @@ export const user = pgTable("user", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").default(false).notNull(),
   image: text("image"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -15,10 +15,10 @@ export const user = pgTable("user", {
 
 export const session = pgTable("session", {
   id: text("id").primaryKey(),
-  expiresAt: timestamp("expires_at").notNull(),
+  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
   token: text("token").notNull().unique(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
   ipAddress: text("ip_address"),
@@ -38,12 +38,12 @@ export const account = pgTable("account", {
   accessToken: text("access_token"),
   refreshToken: text("refresh_token"),
   idToken: text("id_token"),
-  accessTokenExpiresAt: timestamp("access_token_expires_at"),
-  refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+  accessTokenExpiresAt: timestamp("access_token_expires_at", { withTimezone: true }),
+  refreshTokenExpiresAt: timestamp("refresh_token_expires_at", { withTimezone: true }),
   scope: text("scope"),
   password: text("password"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });
@@ -52,9 +52,9 @@ export const verification = pgTable("verification", {
   id: text("id").primaryKey(),
   identifier: text("identifier").notNull(),
   value: text("value").notNull(),
-  expiresAt: timestamp("expires_at").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),

--- a/src/db/schema/bank-holiday-schema.ts
+++ b/src/db/schema/bank-holiday-schema.ts
@@ -8,8 +8,8 @@ export const bankHolidays = pgTable(
     name: text("name").notNull(),
     country: text("country").notNull(),
     region: text("region"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/src/db/schema/calendar-sync-schema.ts
+++ b/src/db/schema/calendar-sync-schema.ts
@@ -35,10 +35,10 @@ export const calendarSync = pgTable(
     // `mineColor` so they stand out from the rest of the team's.
     distinguishMine: boolean("distinguish_mine").notNull().default(false),
     token: text("token").notNull(),
-    lastFetchedAt: timestamp("last_fetched_at"),
-    deletedAt: timestamp("deleted_at"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    lastFetchedAt: timestamp("last_fetched_at", { withTimezone: true }),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
@@ -68,7 +68,7 @@ export const calendarSyncTeams = pgTable(
     groupId: text("group_id")
       .notNull()
       .references(() => groups.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [
     uniqueIndex("calendar_sync_teams_config_group_uniq").on(table.calendarSyncId, table.groupId),
@@ -92,7 +92,7 @@ export const calendarSyncTypes = pgTable(
     // Swatch key from the shared palette (e.g. "violet"), not a raw color.
     color: text("color").notNull(),
     mineColor: text("mine_color"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [
     uniqueIndex("calendar_sync_types_config_type_uniq").on(

--- a/src/db/schema/changes-schema.ts
+++ b/src/db/schema/changes-schema.ts
@@ -26,8 +26,8 @@ export const changesSchema = pgTable("changes", {
   // person. The FK has no ON DELETE, so a real actor can never become NULL —
   // readers can treat NULL as "system" without ambiguity.
   changingUserId: text("changing_user_id").references(() => user.id),
-  createdAt: timestamp("created_at").notNull().defaultNow(),
-  updatedAt: timestamp("updated_at")
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
     .notNull()
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date()),

--- a/src/db/schema/group-mirror-schema.ts
+++ b/src/db/schema/group-mirror-schema.ts
@@ -23,9 +23,9 @@ export const groupMirrors = pgTable(
     targetGroupId: text("target_group_id")
       .notNull()
       .references(() => groups.id, { onDelete: "cascade" }),
-    deletedAt: timestamp("deleted_at"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/src/db/schema/group-schema.ts
+++ b/src/db/schema/group-schema.ts
@@ -16,9 +16,9 @@ export const groups = pgTable(
       .references(() => user.id),
     mainApprovalUser: text("main_approval_user").references(() => user.id),
     tempApprovalUser: text("temp_approval_user").references(() => user.id),
-    deletedAt: timestamp("deleted_at"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/src/db/schema/group-users-schema.ts
+++ b/src/db/schema/group-users-schema.ts
@@ -16,9 +16,9 @@ export const groupUsers = pgTable(
     viewAccess: boolean("view_access").notNull().default(false),
     adminAccess: boolean("admin_access").notNull().default(false),
     controlledUser: boolean("controlled_user").notNull().default(false),
-    deletedAt: timestamp("deleted_at"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/src/db/schema/invite-link-schema.ts
+++ b/src/db/schema/invite-link-schema.ts
@@ -9,18 +9,18 @@ export const inviteLink = pgTable(
     id: text("id").primaryKey(),
     groupId: text("group_id")
       .notNull()
-      .references(() => groups.id),
+      .references(() => groups.id, { onDelete: "cascade" }),
     code: text("code").unique().notNull(),
     // Lower-cased address the invite was issued to. Redeeming is restricted to
     // an account with this email, so a forwarded code is useless to a stranger.
     // Nullable only for rows predating email invites — those stay unrestricted.
     email: text("email"),
     invitedByUserId: text("invited_by_user_id").references(() => user.id, { onDelete: "set null" }),
-    usedAt: timestamp("used_at"),
-    revokedAt: timestamp("revoked_at"),
-    expiresAt: timestamp("expires_at").notNull(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    usedAt: timestamp("used_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/src/db/schema/notification-schema.ts
+++ b/src/db/schema/notification-schema.ts
@@ -23,9 +23,9 @@ export const notifications = pgTable(
     title: text("title").notNull(),
     body: text("body").notNull(),
     href: text("href"),
-    readAt: timestamp("read_at"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    readAt: timestamp("read_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/src/db/schema/out/0010_boring_rachel_grey.sql
+++ b/src/db/schema/out/0010_boring_rachel_grey.sql
@@ -1,0 +1,91 @@
+-- Stored values were naive `timestamp`. Everything the application wrote used
+-- UTC (and the API already serialises them with a `Z`), so the conversion
+-- states that explicitly rather than letting Postgres assume the session
+-- timezone. Values written by the `defaultNow()` column defaults were local
+-- wall clock and shift by the server's offset here — that skew is the defect
+-- being fixed, and it is corrected going forward.
+ALTER TABLE "invite_link" DROP CONSTRAINT "invite_link_group_id_groups_id_fk";
+--> statement-breakpoint
+ALTER TABLE "account" ALTER COLUMN "access_token_expires_at" SET DATA TYPE timestamp with time zone USING "access_token_expires_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "account" ALTER COLUMN "refresh_token_expires_at" SET DATA TYPE timestamp with time zone USING "refresh_token_expires_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "account" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "account" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "account" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "session" ALTER COLUMN "expires_at" SET DATA TYPE timestamp with time zone USING "expires_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "session" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "session" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "session" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "verification" ALTER COLUMN "expires_at" SET DATA TYPE timestamp with time zone USING "expires_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "verification" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "verification" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "verification" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "verification" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "bank_holidays" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "bank_holidays" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "bank_holidays" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "bank_holidays" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "calendar_sync" ALTER COLUMN "last_fetched_at" SET DATA TYPE timestamp with time zone USING "last_fetched_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "calendar_sync" ALTER COLUMN "deleted_at" SET DATA TYPE timestamp with time zone USING "deleted_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "calendar_sync" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "calendar_sync" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "calendar_sync" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "calendar_sync" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "calendar_sync_teams" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "calendar_sync_teams" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "calendar_sync_types" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "calendar_sync_types" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "changes" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "changes" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "changes" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "changes" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "group_mirrors" ALTER COLUMN "deleted_at" SET DATA TYPE timestamp with time zone USING "deleted_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "group_mirrors" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "group_mirrors" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "group_mirrors" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "group_mirrors" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "groups" ALTER COLUMN "deleted_at" SET DATA TYPE timestamp with time zone USING "deleted_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "groups" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "groups" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "groups" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "groups" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "group_users" ALTER COLUMN "deleted_at" SET DATA TYPE timestamp with time zone USING "deleted_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "group_users" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "group_users" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "group_users" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "group_users" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "invite_link" ALTER COLUMN "used_at" SET DATA TYPE timestamp with time zone USING "used_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "invite_link" ALTER COLUMN "revoked_at" SET DATA TYPE timestamp with time zone USING "revoked_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "invite_link" ALTER COLUMN "expires_at" SET DATA TYPE timestamp with time zone USING "expires_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "invite_link" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "invite_link" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "invite_link" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "invite_link" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "notifications" ALTER COLUMN "read_at" SET DATA TYPE timestamp with time zone USING "read_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "notifications" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "notifications" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "notifications" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "notifications" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "report_exports" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "report_exports" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "user_settings" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "user_settings" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "user_settings" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "user_settings" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "user_year_quotas" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "user_year_quotas" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "user_year_quotas" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "user_year_quotas" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "vacation_events" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "vacation_events" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "vacation" ALTER COLUMN "approved_at" SET DATA TYPE timestamp with time zone USING "approved_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "vacation" ALTER COLUMN "deleted_at" SET DATA TYPE timestamp with time zone USING "deleted_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "vacation" ALTER COLUMN "rejected_at" SET DATA TYPE timestamp with time zone USING "rejected_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "vacation" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "vacation" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "vacation" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "vacation" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "invite_link" ADD CONSTRAINT "invite_link_group_id_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;

--- a/src/db/schema/out/meta/0010_snapshot.json
+++ b/src/db/schema/out/meta/0010_snapshot.json
@@ -1,0 +1,2293 @@
+{
+  "id": "17a393e0-9d14-4549-b75e-ad8944071f6b",
+  "prevId": "fc674f26-f31d-42a4-94b7-2d582d810870",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_mirrors": {
+      "name": "group_mirrors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_group_id": {
+          "name": "target_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_mirrors_user_source_target_uniq": {
+          "name": "group_mirrors_user_source_target_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_mirrors\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_target_group_id": {
+          "name": "idx_group_mirrors_target_group_id",
+          "columns": [
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_user_id": {
+          "name": "idx_group_mirrors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_mirrors_user_id_user_id_fk": {
+          "name": "group_mirrors_user_id_user_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_source_group_id_groups_id_fk": {
+          "name": "group_mirrors_source_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_target_group_id_groups_id_fk": {
+          "name": "group_mirrors_target_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "target_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invite_link_group_id": {
+          "name": "idx_invite_link_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_group_email_open_uniq": {
+          "name": "invite_link_group_email_open_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_link\".\"used_at\" IS NULL AND \"invite_link\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_link_invited_by_user_id_user_id_fk": {
+          "name": "invite_link_invited_by_user_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_exports_user_id_idx": {
+          "name": "report_exports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_exports_created_at_idx": {
+          "name": "report_exports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_user_id_user_id_fk": {
+          "name": "report_exports_user_id_user_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboard_scope": {
+          "name": "dashboard_scope",
+          "type": "dashboard_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MINE'"
+        },
+        "dashboard_group_id": {
+          "name": "dashboard_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_settings_dashboard_group_id_groups_id_fk": {
+          "name": "user_settings_dashboard_group_id_groups_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "dashboard_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "carried_over_days": {
+          "name": "carried_over_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        },
+        "user_year_quotas_related_year_range_chk": {
+          "name": "user_year_quotas_related_year_range_chk",
+          "value": "\"user_year_quotas\".\"related_year\"::int BETWEEN 2025 AND 2100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "half_day": {
+          "name": "half_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vacation\".\"deleted_at\" IS NULL AND \"vacation\".\"rejected_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.dashboard_scope": {
+      "name": "dashboard_scope",
+      "schema": "public",
+      "values": [
+        "MINE",
+        "GROUP"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/_journal.json
+++ b/src/db/schema/out/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1785685551546,
       "tag": "0009_true_dust",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1785702279380,
+      "tag": "0010_boring_rachel_grey",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/report-export-schema.ts
+++ b/src/db/schema/report-export-schema.ts
@@ -16,7 +16,7 @@ export const reportExports = pgTable(
     relatedYear: varchar("related_year", { length: 4 }).notNull(),
     filters: jsonb("filters").notNull(),
     rowCount: integer("row_count").notNull(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [
     index("report_exports_user_id_idx").on(table.userId),

--- a/src/db/schema/user-settings-schema.ts
+++ b/src/db/schema/user-settings-schema.ts
@@ -33,8 +33,8 @@ export const userSettings = pgTable("user_settings", {
   dashboardGroupId: text("dashboard_group_id").references(() => groups.id, {
     onDelete: "set null",
   }),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),

--- a/src/db/schema/user-year-quotas-schema.ts
+++ b/src/db/schema/user-year-quotas-schema.ts
@@ -27,8 +27,8 @@ export const userYearQuotas = pgTable(
     // Unused allowance rolled forward from the previous year. Stored rather
     // than derived so a cap or expiry policy stays an explicit admin decision.
     carriedOverDays: integer("carried_over_days").notNull().default(0),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/src/db/schema/vacation-event-schema.ts
+++ b/src/db/schema/vacation-event-schema.ts
@@ -30,7 +30,7 @@ export const vacationEvents = pgTable(
     // Null when the actor's account is later removed; the event itself stays.
     actorUserId: text("actor_user_id").references(() => user.id, { onDelete: "set null" }),
     reason: text("reason"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [index("vacation_events_vacation_id_idx").on(table.vacationId, table.createdAt)]
 );

--- a/src/db/schema/vacation-schema.ts
+++ b/src/db/schema/vacation-schema.ts
@@ -46,19 +46,19 @@ export const vacation = pgTable(
     // allowance. `startTime`/`endTime` are presentation only and must never be
     // used to infer this — they are free-form and often set on full days too.
     halfDay: boolean("half_day").notNull().default(false),
-    approvedAt: timestamp("approved_at"),
+    approvedAt: timestamp("approved_at", { withTimezone: true }),
     approvedBy: text("approved_by").references(() => user.id, {
       onDelete: "set null",
     }),
-    deletedAt: timestamp("deleted_at"),
-    rejectedAt: timestamp("rejected_at"),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    rejectedAt: timestamp("rejected_at", { withTimezone: true }),
     rejectedBy: text("rejected_by").references(() => user.id, {
       onDelete: "set null",
     }),
     rejectionReason: text("rejection_reason"),
     note: text("note"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -5,7 +5,7 @@ import { config } from "../config.js";
 // better-auth uses for CSRF protection), e.g. the CloudFront frontend URLs.
 const allowedOrigins =
   config.api.env === "production"
-    ? config.auth?.trustedOrigins ?? []
+    ? (config.auth?.trustedOrigins ?? [])
     : [/^http:\/\/localhost:(\d{2,5})$/];
 
 export const serverCors = cors({

--- a/src/routes/groupRouter.ts
+++ b/src/routes/groupRouter.ts
@@ -5,7 +5,12 @@ import { handleGetGroups } from "../controllers/group/handleGetGroups.js";
 import { handlePutGroupQuotas } from "../controllers/group/handlePutGroupQuotas.js";
 import { handlePutGroupWorkingDays } from "../controllers/group/handlePutGroupWorkingDays.js";
 import { bodyValidationMiddleware } from "../middleware/validationMiddleware.js";
-import { validatePutGroupQuotas, validatePutGroupWorkingDays } from "../services/group/types.js";
+import {
+  validatePutGroupApprovers,
+  validatePutGroupQuotas,
+  validatePutGroupWorkingDays,
+} from "../services/group/types.js";
+import { handlePutGroupApprovers } from "../controllers/group/handlePutGroupApprovers.js";
 import { validatePutGroupMirrors } from "../services/groupMirror/types.js";
 import { handleGetGroupMirrors } from "../controllers/group/handleGetGroupMirrors.js";
 import { handlePutGroupMirrors } from "../controllers/group/handlePutGroupMirrors.js";
@@ -182,6 +187,56 @@ export const groupRouter = (): Router => {
    *       '422':
    *         description: A group cannot mirror itself
    */
+  /**
+   * @openapi
+   * /api/group/{groupId}/approvers:
+   *   put:
+   *     tags:
+   *       - Groups
+   *     summary: Set who decides on the group's leave requests
+   *     description: |
+   *       Names the main and optional stand-in approver. Both must already be
+   *       members of the group. A group always has a main approver — clearing it
+   *       would leave its requests undecidable. Requires admin access on the group.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: groupId
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - mainApprovalUser
+   *             properties:
+   *               mainApprovalUser:
+   *                 type: string
+   *               tempApprovalUser:
+   *                 type: string
+   *                 nullable: true
+   *     responses:
+   *       '200':
+   *         description: The updated group
+   *       '403':
+   *         description: No permission for related group
+   *       '404':
+   *         description: Group not found
+   *       '422':
+   *         description: A named approver does not belong to the group
+   */
+  app.put(
+    "/:groupId/approvers",
+    bodyValidationMiddleware(validatePutGroupApprovers),
+    tryCatch(handlePutGroupApprovers)
+  );
+
   app.get("/:groupId/mirrors", tryCatch(handleGetGroupMirrors));
   app.put(
     "/:groupId/mirrors",

--- a/src/services/DBServices.ts
+++ b/src/services/DBServices.ts
@@ -32,6 +32,7 @@ export type DBServices = Readonly<{
     countUsersOutOnDay: typeof vacationServices.countUsersOutOnDay;
     countApprovedVacationsInRange: typeof vacationServices.countApprovedVacationsInRange;
     aggregateUserUsageForYear: typeof vacationServices.aggregateUserUsageForYear;
+    sumCountedDaysForQuota: typeof vacationServices.sumCountedDaysForQuota;
   };
   vacationEvent: {
     createVacationEvent: typeof vacationEventServices.createVacationEvent;
@@ -80,6 +81,7 @@ export type DBServices = Readonly<{
     decreaseChangeForUserYearQuotas: typeof userYearQuotasServices.decreaseChangeForUserYearQuotas;
     updateUserYearQuotasById: typeof userYearQuotasServices.updateUserYearQuotasById;
     upsertUserYearQuota: typeof userYearQuotasServices.upsertUserYearQuota;
+    openQuotaFromGroupDefaults: typeof userYearQuotasServices.openQuotaFromGroupDefaults;
     sumUserQuotasForYear: typeof userYearQuotasServices.sumUserQuotasForYear;
   };
   changes: {
@@ -156,6 +158,7 @@ export const createDBServices = (): DBServices => {
       countUsersOutOnDay: vacationServices.countUsersOutOnDay,
       countApprovedVacationsInRange: vacationServices.countApprovedVacationsInRange,
       aggregateUserUsageForYear: vacationServices.aggregateUserUsageForYear,
+      sumCountedDaysForQuota: vacationServices.sumCountedDaysForQuota,
     },
     vacationEvent: {
       createVacationEvent: vacationEventServices.createVacationEvent,
@@ -204,6 +207,7 @@ export const createDBServices = (): DBServices => {
       decreaseChangeForUserYearQuotas: userYearQuotasServices.decreaseChangeForUserYearQuotas,
       updateUserYearQuotasById: userYearQuotasServices.updateUserYearQuotasById,
       upsertUserYearQuota: userYearQuotasServices.upsertUserYearQuota,
+      openQuotaFromGroupDefaults: userYearQuotasServices.openQuotaFromGroupDefaults,
       sumUserQuotasForYear: userYearQuotasServices.sumUserQuotasForYear,
     },
     changes: {

--- a/src/services/dev/devSeedServices.ts
+++ b/src/services/dev/devSeedServices.ts
@@ -261,8 +261,7 @@ export type ResetSummary = { users: number; groups: number };
  * Deletes only seeded data. Groups go first because `groups.manager_user_id`
  * and the approval columns reference `user` without a cascade, as do
  * `changes.changing_user_id`; everything else hangs off one of those two
- * deletes via ON DELETE CASCADE — which now includes `invite_link.group_id`,
- * added without one and so blocking the group delete outright.
+ * deletes via ON DELETE CASCADE.
  */
 export const resetDevData = async (): Promise<ResetSummary> => {
   const domain = devDomain();

--- a/src/services/dev/devSeedServices.ts
+++ b/src/services/dev/devSeedServices.ts
@@ -197,9 +197,9 @@ export const addVacation = async (input: {
       vacationType: input.type ?? vacationType.Vacation,
       note: input.note,
       approvedAt: input.state === "approved" ? now : null,
-      approvedBy: input.state === "approved" ? input.actorUserId ?? null : null,
+      approvedBy: input.state === "approved" ? (input.actorUserId ?? null) : null,
       rejectedAt: input.state === "rejected" ? now : null,
-      rejectedBy: input.state === "rejected" ? input.actorUserId ?? null : null,
+      rejectedBy: input.state === "rejected" ? (input.actorUserId ?? null) : null,
       rejectionReason: input.state === "rejected" ? "Team coverage on that day" : null,
       createdAt: now,
       updatedAt: now,
@@ -261,7 +261,8 @@ export type ResetSummary = { users: number; groups: number };
  * Deletes only seeded data. Groups go first because `groups.manager_user_id`
  * and the approval columns reference `user` without a cascade, as do
  * `changes.changing_user_id`; everything else hangs off one of those two
- * deletes via ON DELETE CASCADE.
+ * deletes via ON DELETE CASCADE — which now includes `invite_link.group_id`,
+ * added without one and so blocking the group delete outright.
  */
 export const resetDevData = async (): Promise<ResetSummary> => {
   const domain = devDomain();

--- a/src/services/group/groupServices.ts
+++ b/src/services/group/groupServices.ts
@@ -5,8 +5,11 @@ import { and, eq, inArray, isNull, or } from "drizzle-orm";
 import { user } from "../../db/schema/auth-schema.js";
 import { alias } from "drizzle-orm/pg-core";
 
-export const getGroup = async (groupId: string): Promise<GroupType | undefined> => {
-  const [row] = await db
+export const getGroup = async (
+  groupId: string,
+  tx?: DbTransaction
+): Promise<GroupType | undefined> => {
+  const [row] = await (tx ?? db)
     .select()
     .from(groups)
     .where(and(eq(groups.id, groupId), isNull(groups.deletedAt)));
@@ -47,9 +50,10 @@ export const updateGroupManager = async (
 export const updateGroupApprovalUsers = async (
   groupId: string,
   newMainApprovalUser: string | null,
-  newTempApprovalUser: string | null
+  newTempApprovalUser: string | null,
+  tx?: DbTransaction
 ): Promise<GroupType | undefined> => {
-  const [row] = await db
+  const [row] = await (tx ?? db)
     .update(groups)
     .set({
       mainApprovalUser: newMainApprovalUser,

--- a/src/services/group/types.ts
+++ b/src/services/group/types.ts
@@ -40,12 +40,8 @@ export const validatePutGroupWorkingDays = z.object({
 
 export type ValidatedPutGroupWorkingDaysType = z.infer<typeof validatePutGroupWorkingDays>;
 
-/**
- * Body of "set who decides on this group's requests". better-auth user ids are
- * opaque non-UUID strings, so they validate as non-empty strings. `null` clears
- * the slot; the main approver may not be cleared, because a group without one
- * has no way to ever decide on a request.
- */
+// better-auth user ids are opaque non-UUID strings. The main approver is
+// required: a group without one can never decide on a request.
 export const validatePutGroupApprovers = z.object({
   mainApprovalUser: z.string().min(1),
   tempApprovalUser: z.string().min(1).nullable().default(null),

--- a/src/services/group/types.ts
+++ b/src/services/group/types.ts
@@ -39,3 +39,16 @@ export const validatePutGroupWorkingDays = z.object({
 });
 
 export type ValidatedPutGroupWorkingDaysType = z.infer<typeof validatePutGroupWorkingDays>;
+
+/**
+ * Body of "set who decides on this group's requests". better-auth user ids are
+ * opaque non-UUID strings, so they validate as non-empty strings. `null` clears
+ * the slot; the main approver may not be cleared, because a group without one
+ * has no way to ever decide on a request.
+ */
+export const validatePutGroupApprovers = z.object({
+  mainApprovalUser: z.string().min(1),
+  tempApprovalUser: z.string().min(1).nullable().default(null),
+});
+
+export type ValidatedPutGroupApproversType = z.infer<typeof validatePutGroupApprovers>;

--- a/src/services/userYearQuotas/userYearQuotasServices.ts
+++ b/src/services/userYearQuotas/userYearQuotasServices.ts
@@ -20,6 +20,39 @@ export const getUserYearGroupQuotas = async (
   return (tx ?? db).select().from(userYearQuotas).where(where);
 };
 
+/**
+ * Opens a member's allowance for the current year from the group's defaults.
+ *
+ * Called whenever a membership is created — this is what the group's "default
+ * vacation / home office days" actually mean, and what the Quotas tab promises
+ * ("applies to members who have no allowance set for a year"). Without it a new
+ * member's allowance is zero until an admin sets one by hand, so every number
+ * the product shows them is wrong from the moment they join.
+ *
+ * `onConflictDoNothing` keeps it safe on a re-join: an existing allowance for
+ * that year, however it was set, wins.
+ */
+export const openQuotaFromGroupDefaults = async (
+  record: {
+    id: string;
+    userId: string;
+    groupId: string;
+    relatedYear: string;
+    vacationDays: number;
+    homeOfficeDays: number;
+  },
+  tx?: DbTransaction
+): Promise<UserYearQuotasType | undefined> => {
+  const [row] = await (tx ?? db)
+    .insert(userYearQuotas)
+    .values(record)
+    .onConflictDoNothing({
+      target: [userYearQuotas.userId, userYearQuotas.groupId, userYearQuotas.relatedYear],
+    })
+    .returning();
+  return row;
+};
+
 export const insertUserYearQuotas = async (
   records: UserYearQuotasInsertType[]
 ): Promise<UserYearQuotasType[]> => {
@@ -55,14 +88,15 @@ export const sumUserQuotasForYear = async (
   userId: string,
   groupIds: string[],
   relatedYear: string
-): Promise<{ vacationDays: number; homeOfficeDays: number }> => {
+): Promise<{ vacationDays: number; homeOfficeDays: number; carriedOverDays: number }> => {
   if (groupIds.length === 0) {
-    return { vacationDays: 0, homeOfficeDays: 0 };
+    return { vacationDays: 0, homeOfficeDays: 0, carriedOverDays: 0 };
   }
   const [row] = await db
     .select({
       vacationDays: sql<number>`COALESCE(SUM(${userYearQuotas.vacationDays}), 0)`,
       homeOfficeDays: sql<number>`COALESCE(SUM(${userYearQuotas.homeOfficeDays}), 0)`,
+      carriedOverDays: sql<number>`COALESCE(SUM(${userYearQuotas.carriedOverDays}), 0)`,
     })
     .from(userYearQuotas)
     .where(
@@ -75,6 +109,7 @@ export const sumUserQuotasForYear = async (
   return {
     vacationDays: Number(row?.vacationDays ?? 0),
     homeOfficeDays: Number(row?.homeOfficeDays ?? 0),
+    carriedOverDays: Number(row?.carriedOverDays ?? 0),
   };
 };
 

--- a/src/services/userYearQuotas/userYearQuotasServices.ts
+++ b/src/services/userYearQuotas/userYearQuotasServices.ts
@@ -21,16 +21,9 @@ export const getUserYearGroupQuotas = async (
 };
 
 /**
- * Opens a member's allowance for the current year from the group's defaults.
- *
- * Called whenever a membership is created — this is what the group's "default
- * vacation / home office days" actually mean, and what the Quotas tab promises
- * ("applies to members who have no allowance set for a year"). Without it a new
- * member's allowance is zero until an admin sets one by hand, so every number
- * the product shows them is wrong from the moment they join.
- *
- * `onConflictDoNothing` keeps it safe on a re-join: an existing allowance for
- * that year, however it was set, wins.
+ * Opens a member's allowance for the current year from the group's defaults;
+ * called wherever a membership is created. On a re-join an existing allowance
+ * for that year wins.
  */
 export const openQuotaFromGroupDefaults = async (
   record: {

--- a/src/services/vacation/quotaGuard.ts
+++ b/src/services/vacation/quotaGuard.ts
@@ -1,0 +1,183 @@
+import AppError from "../../utils/appError.js";
+import type { DbTransaction } from "../../db/db.js";
+import { vacationType } from "../../db/schema/vacation-schema.js";
+import { QUOTA_BEARING_TYPES } from "../report/buildSummary.js";
+import { createDBServices } from "../DBServices.js";
+import type { VacationType } from "./types.js";
+
+const services = createDBServices();
+
+const isQuotaBearing = (kind: vacationType): boolean =>
+  (QUOTA_BEARING_TYPES as readonly vacationType[]).includes(kind);
+
+/** Weight one row draws from an allowance — the SQL side of this is `dayWeight()`. */
+const weightOf = (row: { halfDay: boolean }): number => (row.halfDay ? 0.5 : 1);
+
+const yearOf = (isoDay: string): number => Number(isoDay.slice(0, 4));
+
+/**
+ * What a member may draw in one group and year. Falls back to the group's
+ * defaults when no quota row exists — memberships created before quotas were
+ * seeded on join would otherwise be capped at zero, which would block every
+ * booking rather than bound it.
+ */
+const allocationFor = async (
+  userId: string,
+  groupId: string,
+  year: number,
+  leaveType: vacationType,
+  tx?: DbTransaction
+): Promise<number> => {
+  const [quota] = await services.userYearQuotas.getUserYearGroupQuotas(
+    year.toString(),
+    groupId,
+    userId,
+    tx
+  );
+
+  if (quota) {
+    return leaveType === vacationType.Vacation
+      ? quota.vacationDays + quota.carriedOverDays
+      : quota.homeOfficeDays;
+  }
+
+  const group = await services.group.getGroup(groupId);
+  return leaveType === vacationType.Vacation
+    ? (group?.defaultVacationDays ?? 0)
+    : (group?.defaultHomeOfficeDays ?? 0);
+};
+
+type QuotaCheck = {
+  userId: string;
+  groupId: string;
+  year: number;
+  leaveType: vacationType;
+  /** Weighted days this operation adds on top of what is already counted. */
+  requestedDays: number;
+  /** Stored rows whose weight `requestedDays` already accounts for. */
+  excludeVacationIds: string[];
+};
+
+/**
+ * Enforces one member's allowance for one (group, year, leave type).
+ *
+ * `countPending` is what separates the two call sites: a new request competes
+ * with everything already booked, approved or not, so booking counts pending
+ * days. A decision only commits days that are actually granted, so approving
+ * compares against approved days alone — otherwise a queue of pending requests
+ * would block the approver from granting any of them.
+ */
+const assertOne = async (
+  check: QuotaCheck,
+  countPending: boolean,
+  tx?: DbTransaction
+): Promise<void> => {
+  if (!isQuotaBearing(check.leaveType)) return;
+
+  const [{ approved, pending }, allocated] = await Promise.all([
+    services.vacation.sumCountedDaysForQuota(
+      check.userId,
+      check.groupId,
+      check.year,
+      check.leaveType,
+      check.excludeVacationIds,
+      tx
+    ),
+    allocationFor(check.userId, check.groupId, check.year, check.leaveType, tx),
+  ]);
+
+  const alreadyCounted = countPending ? approved + pending : approved;
+  const total = Number((alreadyCounted + check.requestedDays).toFixed(2));
+
+  if (total > allocated) {
+    throw new AppError({
+      code: 422,
+      message: "This would exceed the allowance for that leave type",
+      logging: true,
+      context: { ...check, approved, pending, allocated, total },
+      publicContext: {
+        vacationType: check.leaveType,
+        year: check.year,
+        allocated,
+        alreadyCounted,
+        requestedDays: check.requestedDays,
+        exceededBy: Number((total - allocated).toFixed(2)),
+      },
+    });
+  }
+};
+
+/**
+ * Guards a new request against the requester's allowance. `rows` are the
+ * per-day records about to be inserted, so nothing is excluded from the
+ * existing totals.
+ */
+export const assertRequestWithinQuota = async (
+  rows: {
+    userId: string;
+    groupId: string;
+    requestedDay: string;
+    vacationType: vacationType;
+    halfDay: boolean;
+  }[],
+  tx?: DbTransaction
+): Promise<void> => {
+  await assertGrouped(rows, [], true, tx);
+};
+
+/**
+ * Guards an approval against the requester's allowance. The rows are already
+ * stored and counted as pending, so they are excluded from the running totals
+ * and added back as the days the decision is about to grant.
+ */
+export const assertApprovalWithinQuota = async (
+  rows: Pick<
+    VacationType,
+    "id" | "userId" | "groupId" | "requestedDay" | "vacationType" | "halfDay"
+  >[],
+  tx?: DbTransaction
+): Promise<void> => {
+  await assertGrouped(
+    rows,
+    rows.map((row) => row.id),
+    false,
+    tx
+  );
+};
+
+const assertGrouped = async (
+  rows: {
+    userId: string;
+    groupId: string;
+    requestedDay: string;
+    vacationType: vacationType;
+    halfDay: boolean;
+  }[],
+  excludeVacationIds: string[],
+  countPending: boolean,
+  tx?: DbTransaction
+): Promise<void> => {
+  // One allowance per (user, group, year, type) — a range can straddle a year
+  // boundary and a bulk decision can span several people at once.
+  const buckets = new Map<string, QuotaCheck>();
+
+  for (const row of rows) {
+    if (!isQuotaBearing(row.vacationType)) continue;
+    const year = yearOf(row.requestedDay);
+    const key = `${row.userId}::${row.groupId}::${year.toString()}::${row.vacationType}`;
+    const bucket = buckets.get(key) ?? {
+      userId: row.userId,
+      groupId: row.groupId,
+      year,
+      leaveType: row.vacationType,
+      requestedDays: 0,
+      excludeVacationIds,
+    };
+    bucket.requestedDays = Number((bucket.requestedDays + weightOf(row)).toFixed(2));
+    buckets.set(key, bucket);
+  }
+
+  for (const bucket of buckets.values()) {
+    await assertOne(bucket, countPending, tx);
+  }
+};

--- a/src/services/vacation/quotaGuard.ts
+++ b/src/services/vacation/quotaGuard.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import AppError from "../../utils/appError.js";
 import type { DbTransaction } from "../../db/db.js";
 import { vacationType } from "../../db/schema/vacation-schema.js";
@@ -7,44 +8,12 @@ import type { VacationType } from "./types.js";
 
 const services = createDBServices();
 
-const isQuotaBearing = (kind: vacationType): boolean =>
-  (QUOTA_BEARING_TYPES as readonly vacationType[]).includes(kind);
-
-/** Weight one row draws from an allowance — the SQL side of this is `dayWeight()`. */
-const weightOf = (row: { halfDay: boolean }): number => (row.halfDay ? 0.5 : 1);
-
-const yearOf = (isoDay: string): number => Number(isoDay.slice(0, 4));
-
-/**
- * What a member may draw in one group and year. Falls back to the group's
- * defaults when no quota row exists — memberships created before quotas were
- * seeded on join would otherwise be capped at zero, which would block every
- * booking rather than bound it.
- */
-const allocationFor = async (
-  userId: string,
-  groupId: string,
-  year: number,
-  leaveType: vacationType,
-  tx?: DbTransaction
-): Promise<number> => {
-  const [quota] = await services.userYearQuotas.getUserYearGroupQuotas(
-    year.toString(),
-    groupId,
-    userId,
-    tx
-  );
-
-  if (quota) {
-    return leaveType === vacationType.Vacation
-      ? quota.vacationDays + quota.carriedOverDays
-      : quota.homeOfficeDays;
-  }
-
-  const group = await services.group.getGroup(groupId);
-  return leaveType === vacationType.Vacation
-    ? (group?.defaultVacationDays ?? 0)
-    : (group?.defaultHomeOfficeDays ?? 0);
+type QuotaRow = {
+  userId: string;
+  groupId: string;
+  requestedDay: string;
+  vacationType: vacationType;
+  halfDay: boolean;
 };
 
 type QuotaCheck = {
@@ -52,39 +21,68 @@ type QuotaCheck = {
   groupId: string;
   year: number;
   leaveType: vacationType;
-  /** Weighted days this operation adds on top of what is already counted. */
   requestedDays: number;
-  /** Stored rows whose weight `requestedDays` already accounts for. */
   excludeVacationIds: string[];
 };
 
+const isQuotaBearing = (kind: vacationType): boolean =>
+  (QUOTA_BEARING_TYPES as readonly vacationType[]).includes(kind);
+
+const weightOf = (row: { halfDay: boolean }): number => (row.halfDay ? 0.5 : 1);
+
+const yearOf = (isoDay: string): number => Number(isoDay.slice(0, 4));
+
 /**
- * Enforces one member's allowance for one (group, year, leave type).
- *
- * `countPending` is what separates the two call sites: a new request competes
- * with everything already booked, approved or not, so booking counts pending
- * days. A decision only commits days that are actually granted, so approving
- * compares against approved days alone — otherwise a queue of pending requests
- * would block the approver from granting any of them.
+ * Serializes everyone competing for the same allowance. Without it, under READ
+ * COMMITTED, concurrent requests all read the pre-insert totals and all pass.
+ */
+const lockAllowance = async (check: QuotaCheck, tx: DbTransaction): Promise<void> => {
+  const key = `${check.userId}::${check.groupId}::${check.year.toString()}::${check.leaveType}`;
+  await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${key}, 0))`);
+};
+
+/** Falls back to the group defaults so a membership with no quota row yet is bounded, not blocked. */
+const allocationFor = async (check: QuotaCheck, tx: DbTransaction): Promise<number> => {
+  const [quota] = await services.userYearQuotas.getUserYearGroupQuotas(
+    check.year.toString(),
+    check.groupId,
+    check.userId,
+    tx
+  );
+
+  if (quota) {
+    return check.leaveType === vacationType.Vacation
+      ? quota.vacationDays + quota.carriedOverDays
+      : quota.homeOfficeDays;
+  }
+
+  const group = await services.group.getGroup(check.groupId, tx);
+  return check.leaveType === vacationType.Vacation
+    ? (group?.defaultVacationDays ?? 0)
+    : (group?.defaultHomeOfficeDays ?? 0);
+};
+
+/**
+ * `countPending` separates the call sites: booking competes with everything
+ * already booked, while approving counts approved days alone — otherwise a
+ * queue of pending requests would block the approver from granting any.
  */
 const assertOne = async (
   check: QuotaCheck,
   countPending: boolean,
-  tx?: DbTransaction
+  tx: DbTransaction
 ): Promise<void> => {
-  if (!isQuotaBearing(check.leaveType)) return;
+  await lockAllowance(check, tx);
 
-  const [{ approved, pending }, allocated] = await Promise.all([
-    services.vacation.sumCountedDaysForQuota(
-      check.userId,
-      check.groupId,
-      check.year,
-      check.leaveType,
-      check.excludeVacationIds,
-      tx
-    ),
-    allocationFor(check.userId, check.groupId, check.year, check.leaveType, tx),
-  ]);
+  const { approved, pending } = await services.vacation.sumCountedDaysForQuota(
+    check.userId,
+    check.groupId,
+    check.year,
+    check.leaveType,
+    check.excludeVacationIds,
+    tx
+  );
+  const allocated = await allocationFor(check, tx);
 
   const alreadyCounted = countPending ? approved + pending : approved;
   const total = Number((alreadyCounted + check.requestedDays).toFixed(2));
@@ -107,58 +105,13 @@ const assertOne = async (
   }
 };
 
-/**
- * Guards a new request against the requester's allowance. `rows` are the
- * per-day records about to be inserted, so nothing is excluded from the
- * existing totals.
- */
-export const assertRequestWithinQuota = async (
-  rows: {
-    userId: string;
-    groupId: string;
-    requestedDay: string;
-    vacationType: vacationType;
-    halfDay: boolean;
-  }[],
-  tx?: DbTransaction
-): Promise<void> => {
-  await assertGrouped(rows, [], true, tx);
-};
-
-/**
- * Guards an approval against the requester's allowance. The rows are already
- * stored and counted as pending, so they are excluded from the running totals
- * and added back as the days the decision is about to grant.
- */
-export const assertApprovalWithinQuota = async (
-  rows: Pick<
-    VacationType,
-    "id" | "userId" | "groupId" | "requestedDay" | "vacationType" | "halfDay"
-  >[],
-  tx?: DbTransaction
-): Promise<void> => {
-  await assertGrouped(
-    rows,
-    rows.map((row) => row.id),
-    false,
-    tx
-  );
-};
-
 const assertGrouped = async (
-  rows: {
-    userId: string;
-    groupId: string;
-    requestedDay: string;
-    vacationType: vacationType;
-    halfDay: boolean;
-  }[],
+  rows: QuotaRow[],
   excludeVacationIds: string[],
   countPending: boolean,
-  tx?: DbTransaction
+  tx: DbTransaction
 ): Promise<void> => {
-  // One allowance per (user, group, year, type) — a range can straddle a year
-  // boundary and a bulk decision can span several people at once.
+  // A range can straddle a year boundary and a bulk decision several people.
   const buckets = new Map<string, QuotaCheck>();
 
   for (const row of rows) {
@@ -177,7 +130,36 @@ const assertGrouped = async (
     buckets.set(key, bucket);
   }
 
-  for (const bucket of buckets.values()) {
+  // Ordered so overlapping batches take their locks alike and cannot deadlock.
+  const ordered = Array.from(buckets.entries())
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([, bucket]) => bucket);
+
+  for (const bucket of ordered) {
     await assertOne(bucket, countPending, tx);
   }
+};
+
+/** Guards a new request. The rows are not stored yet, so nothing is excluded. */
+export const assertRequestWithinQuota = async (
+  rows: QuotaRow[],
+  tx: DbTransaction
+): Promise<void> => {
+  await assertGrouped(rows, [], true, tx);
+};
+
+/** Rows already count as pending, so they are excluded and added back as granted days. */
+export const assertApprovalWithinQuota = async (
+  rows: Pick<
+    VacationType,
+    "id" | "userId" | "groupId" | "requestedDay" | "vacationType" | "halfDay"
+  >[],
+  tx: DbTransaction
+): Promise<void> => {
+  await assertGrouped(
+    rows,
+    rows.map((row) => row.id),
+    false,
+    tx
+  );
 };

--- a/src/services/vacation/types.ts
+++ b/src/services/vacation/types.ts
@@ -77,11 +77,9 @@ export const validateCancelVacation = z
 export type ValidatedCancelVacationType = z.infer<typeof validateCancelVacation>;
 
 /**
- * Leave kinds a person may request for themselves. `BANK_HOLIDAY` is
- * deliberately absent: it describes a company-wide closure, is owned by the
- * admin-only `bankHolidayRouter`, draws down no allowance, and renders to the
- * whole team as an unattributed holiday — so a member must not be able to
- * grant themselves one.
+ * `BANK_HOLIDAY` is deliberately absent: it is a company-wide closure owned by
+ * the admin `bankHolidayRouter`, costs no allowance, and shows to the whole team
+ * unattributed, so nobody may grant themselves one.
  */
 export const REQUESTABLE_VACATION_TYPES = Object.values(vacationType).filter(
   (kind) => kind !== vacationType.BankHoliday
@@ -106,8 +104,6 @@ export const validatePostVacation = z
     message: "`endTime` must be later than `startTime`",
     path: ["endTime"],
   })
-  // A half day is a property of one day. Stamping it across a range silently
-  // halved every day of it, which is never what the requester meant.
   .refine((data) => !data.halfDay || data.from.getTime() === data.to.getTime(), {
     message: "`halfDay` is only valid for a single-day request",
     path: ["halfDay"],

--- a/src/services/vacation/types.ts
+++ b/src/services/vacation/types.ts
@@ -76,20 +76,42 @@ export const validateCancelVacation = z
 
 export type ValidatedCancelVacationType = z.infer<typeof validateCancelVacation>;
 
-const vacationKindEnum = z.enum(Object.values(vacationType) as [vacationType, ...vacationType[]]);
+/**
+ * Leave kinds a person may request for themselves. `BANK_HOLIDAY` is
+ * deliberately absent: it describes a company-wide closure, is owned by the
+ * admin-only `bankHolidayRouter`, draws down no allowance, and renders to the
+ * whole team as an unattributed holiday — so a member must not be able to
+ * grant themselves one.
+ */
+export const REQUESTABLE_VACATION_TYPES = Object.values(vacationType).filter(
+  (kind) => kind !== vacationType.BankHoliday
+) as [vacationType, ...vacationType[]];
 
-export const validatePostVacation = z.object({
-  groupId: z.uuid(),
-  from: z.coerce.date(),
-  to: z.coerce.date(),
-  vacationType: vacationKindEnum.default(vacationType.Vacation),
-  startTime: z.iso.time().nullable().default(null),
-  endTime: z.iso.time().nullable().default(null),
-  // Drives quota accounting (0.5 vs 1 day). Deliberately explicit — the
-  // optional start/end times above are free-form and cannot stand in for it.
-  halfDay: z.boolean().default(false),
-  note: z.string().max(1000).nullable().default(null),
-});
+const requestableKindEnum = z.enum(REQUESTABLE_VACATION_TYPES);
+
+export const validatePostVacation = z
+  .object({
+    groupId: z.uuid(),
+    from: z.coerce.date(),
+    to: z.coerce.date(),
+    vacationType: requestableKindEnum.default(vacationType.Vacation),
+    startTime: z.iso.time().nullable().default(null),
+    endTime: z.iso.time().nullable().default(null),
+    // Drives quota accounting (0.5 vs 1 day). Deliberately explicit — the
+    // optional start/end times above are free-form and cannot stand in for it.
+    halfDay: z.boolean().default(false),
+    note: z.string().max(1000).nullable().default(null),
+  })
+  .refine((data) => !(data.startTime && data.endTime) || data.endTime > data.startTime, {
+    message: "`endTime` must be later than `startTime`",
+    path: ["endTime"],
+  })
+  // A half day is a property of one day. Stamping it across a range silently
+  // halved every day of it, which is never what the requester meant.
+  .refine((data) => !data.halfDay || data.from.getTime() === data.to.getTime(), {
+    message: "`halfDay` is only valid for a single-day request",
+    path: ["halfDay"],
+  });
 
 export type ValidatedPostVacationType = z.infer<typeof validatePostVacation>;
 

--- a/src/services/vacation/vacationServices.ts
+++ b/src/services/vacation/vacationServices.ts
@@ -14,6 +14,8 @@ import {
   isNull,
   lt,
   lte,
+  ne,
+  notInArray,
   or,
   sql,
 } from "drizzle-orm";
@@ -236,10 +238,25 @@ export const postVacationBulk = async (
 };
 
 /**
- * Approving un-rejects the row, which puts it back under the partial unique
- * index — and the day may have been re-requested since the rejection. Postgres
- * is the only place that can see that race, so translate its violation into the
- * conflict the approver should be shown instead of a 500.
+ * A decision is only valid on a request that is still open. Making this the
+ * update predicate — rather than just `id = ?` — is what gives the workflow a
+ * state machine: a decided row matches nothing, the update returns no rows, and
+ * the controller turns that into a 409 instead of silently overturning an
+ * earlier decision and wiping its stamps.
+ *
+ * Cancellation deliberately does NOT use this: plans change, and an approved
+ * request must stay cancellable.
+ */
+const stillPending = [
+  isNull(vacation.deletedAt),
+  isNull(vacation.approvedAt),
+  isNull(vacation.rejectedAt),
+] as const;
+
+/**
+ * Defensive: a pending row already sits in the partial unique index, so a
+ * decision cannot collide with a re-booking of the same day. Kept so that any
+ * future widening of the predicate surfaces as a 409 rather than a 500.
  */
 const rethrowIfDayRetaken = (error: unknown, vacationIds: string[]): never => {
   // Drizzle rethrows a "Failed query" Error and hangs the pg error, which is
@@ -277,11 +294,8 @@ export const approveVacation = async (
     .set({
       approvedBy: approvingPerson,
       approvedAt: new Date(),
-      rejectedBy: null,
-      rejectedAt: null,
-      rejectionReason: null,
     })
-    .where(and(eq(vacation.id, vacationId), isNull(vacation.deletedAt)))
+    .where(and(eq(vacation.id, vacationId), ...stillPending))
     .returning()
     .catch((error: unknown) => rethrowIfDayRetaken(error, [vacationId]));
 
@@ -290,8 +304,9 @@ export const approveVacation = async (
 
 /**
  * Bulk-approves many vacation rows in a single statement. Returns the rows
- * that were actually updated — callers can compare against the input ids to
- * detect any that no longer matched (already approved/rejected/deleted).
+ * that were actually updated — callers compare against the input ids to detect
+ * any that were already approved, rejected or cancelled and reject the whole
+ * batch.
  */
 export const approveVacationsBulk = async (
   vacationIds: string[],
@@ -304,11 +319,8 @@ export const approveVacationsBulk = async (
     .set({
       approvedBy: approvingPerson,
       approvedAt: new Date(),
-      rejectedBy: null,
-      rejectedAt: null,
-      rejectionReason: null,
     })
-    .where(and(inArray(vacation.id, vacationIds), isNull(vacation.deletedAt)))
+    .where(and(inArray(vacation.id, vacationIds), ...stillPending))
     .returning()
     .catch((error: unknown) => rethrowIfDayRetaken(error, vacationIds));
 };
@@ -329,10 +341,8 @@ export const rejectVacationsBulk = async (
       rejectedAt: new Date(),
       rejectedBy: rejectingPerson,
       rejectionReason: reason,
-      approvedAt: null,
-      approvedBy: null,
     })
-    .where(and(inArray(vacation.id, vacationIds), isNull(vacation.deletedAt)))
+    .where(and(inArray(vacation.id, vacationIds), ...stillPending))
     .returning();
 };
 
@@ -378,10 +388,8 @@ export const rejectVacation = async (
       rejectedAt: new Date(),
       rejectedBy: rejectingPerson,
       rejectionReason: reason,
-      approvedAt: null,
-      approvedBy: null,
     })
-    .where(and(eq(vacation.id, vacationId), isNull(vacation.deletedAt)))
+    .where(and(eq(vacation.id, vacationId), ...stillPending))
     .returning();
 
   return row;
@@ -530,6 +538,10 @@ export type PendingApprovalRow = {
  * for groups where the caller is a manager / main approver / temp approver.
  * Rows are ordered by user/group/day so the caller can collapse contiguous
  * ranges into single approval entries.
+ *
+ * The approver's own requests are excluded: they are for the group's other
+ * approver to decide, and the decision endpoints refuse them, so showing them
+ * here would only offer a button that 403s.
  */
 export const getPendingApprovalsForApprover = async (
   approverUserId: string
@@ -555,6 +567,7 @@ export const getPendingApprovalsForApprover = async (
         isNull(vacation.approvedAt),
         isNull(vacation.rejectedAt),
         isNull(groups.deletedAt),
+        ne(vacation.userId, approverUserId),
         or(
           eq(groups.managerUserId, approverUserId),
           eq(groups.mainApprovalUser, approverUserId),
@@ -568,6 +581,49 @@ export const getPendingApprovalsForApprover = async (
       asc(vacation.vacationType),
       asc(vacation.requestedDay)
     );
+};
+
+/**
+ * Weighted day totals for one member's allowance in a single group and year,
+ * split by leave type. Unlike {@link aggregateUserUsageForYear} this is scoped
+ * to one group because an allowance is granted per (user, group, year) — the
+ * quota guard has to compare like with like.
+ *
+ * `excludeVacationIds` lets the caller leave the rows it is about to decide on
+ * out of the totals, so they can be added back at their post-decision weight
+ * instead of being double-counted.
+ */
+export const sumCountedDaysForQuota = async (
+  userId: string,
+  groupId: string,
+  year: number,
+  leaveType: vacationType,
+  excludeVacationIds: string[] = [],
+  tx?: DbTransaction
+): Promise<{ approved: number; pending: number }> => {
+  const yearStart = `${year.toString().padStart(4, "0")}-01-01`;
+  const yearEnd = `${(year + 1).toString().padStart(4, "0")}-01-01`;
+
+  const [row] = await (tx ?? db)
+    .select({
+      approved: sumDaysWhere(sql`${vacation.approvedAt} IS NOT NULL`),
+      pending: sumDaysWhere(sql`${vacation.approvedAt} IS NULL`),
+    })
+    .from(vacation)
+    .where(
+      and(
+        eq(vacation.userId, userId),
+        eq(vacation.groupId, groupId),
+        eq(vacation.vacationType, leaveType),
+        isNull(vacation.deletedAt),
+        isNull(vacation.rejectedAt),
+        gte(vacation.requestedDay, yearStart),
+        lt(vacation.requestedDay, yearEnd),
+        excludeVacationIds.length > 0 ? notInArray(vacation.id, excludeVacationIds) : undefined
+      )
+    );
+
+  return { approved: Number(row?.approved ?? 0), pending: Number(row?.pending ?? 0) };
 };
 
 /**

--- a/src/services/vacation/vacationServices.ts
+++ b/src/services/vacation/vacationServices.ts
@@ -238,14 +238,8 @@ export const postVacationBulk = async (
 };
 
 /**
- * A decision is only valid on a request that is still open. Making this the
- * update predicate — rather than just `id = ?` — is what gives the workflow a
- * state machine: a decided row matches nothing, the update returns no rows, and
- * the controller turns that into a 409 instead of silently overturning an
- * earlier decision and wiping its stamps.
- *
- * Cancellation deliberately does NOT use this: plans change, and an approved
- * request must stay cancellable.
+ * The workflow's state machine. Cancellation deliberately does NOT use it:
+ * plans change, and an approved request must stay cancellable.
  */
 const stillPending = [
   isNull(vacation.deletedAt),
@@ -253,11 +247,7 @@ const stillPending = [
   isNull(vacation.rejectedAt),
 ] as const;
 
-/**
- * Defensive: a pending row already sits in the partial unique index, so a
- * decision cannot collide with a re-booking of the same day. Kept so that any
- * future widening of the predicate surfaces as a 409 rather than a 500.
- */
+/** Unreachable while decisions are pending-only; kept so widening the predicate 409s, not 500s. */
 const rethrowIfDayRetaken = (error: unknown, vacationIds: string[]): never => {
   // Drizzle rethrows a "Failed query" Error and hangs the pg error, which is
   // where `code`/`constraint` live, off `cause`.
@@ -303,10 +293,9 @@ export const approveVacation = async (
 };
 
 /**
- * Bulk-approves many vacation rows in a single statement. Returns the rows
- * that were actually updated — callers compare against the input ids to detect
- * any that were already approved, rejected or cancelled and reject the whole
- * batch.
+ * Bulk-approves in one statement. Returns only the rows actually updated;
+ * callers compare against the input ids and reject the whole batch on a short
+ * result.
  */
 export const approveVacationsBulk = async (
   vacationIds: string[],
@@ -537,11 +526,8 @@ export type PendingApprovalRow = {
  * Returns pending (not yet approved, not rejected, not deleted) vacation rows
  * for groups where the caller is a manager / main approver / temp approver.
  * Rows are ordered by user/group/day so the caller can collapse contiguous
- * ranges into single approval entries.
- *
- * The approver's own requests are excluded: they are for the group's other
- * approver to decide, and the decision endpoints refuse them, so showing them
- * here would only offer a button that 403s.
+ * ranges into single approval entries. The approver's own requests are
+ * excluded — the decision endpoints refuse them.
  */
 export const getPendingApprovalsForApprover = async (
   approverUserId: string
@@ -584,14 +570,10 @@ export const getPendingApprovalsForApprover = async (
 };
 
 /**
- * Weighted day totals for one member's allowance in a single group and year,
- * split by leave type. Unlike {@link aggregateUserUsageForYear} this is scoped
- * to one group because an allowance is granted per (user, group, year) — the
- * quota guard has to compare like with like.
- *
- * `excludeVacationIds` lets the caller leave the rows it is about to decide on
- * out of the totals, so they can be added back at their post-decision weight
- * instead of being double-counted.
+ * Weighted day totals for one allowance. Scoped to a single group, unlike
+ * {@link aggregateUserUsageForYear}, because an allowance is granted per
+ * (user, group, year). `excludeVacationIds` leaves out rows the caller is about
+ * to decide on and will add back at their post-decision weight.
  */
 export const sumCountedDaysForQuota = async (
   userId: string,

--- a/src/tests/e2e/vacation.e2e.test.ts
+++ b/src/tests/e2e/vacation.e2e.test.ts
@@ -14,6 +14,28 @@ import { session } from "../../db/schema/auth-schema.js";
 import { v4 as uuidv4 } from "uuid";
 import { eq } from "drizzle-orm";
 
+// Booking is bounded to the current year through the end of the next, so these
+// anchor to a real Monday in the current year. Fixed calendar dates would book
+// fine today and fall out of the accepted window a year from now.
+const isoDay = (date: Date) => date.toISOString().slice(0, 10);
+const shift = (base: Date, days: number) => {
+  const next = new Date(base);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+};
+const firstMondayOfDecember = () => {
+  const day = new Date(Date.UTC(new Date().getUTCFullYear(), 11, 1));
+  while (day.getUTCDay() !== 1) day.setUTCDate(day.getUTCDate() + 1);
+  return day;
+};
+const MONDAY_OF_WEEK = firstMondayOfDecember();
+const MON = isoDay(MONDAY_OF_WEEK);
+const WED = isoDay(shift(MONDAY_OF_WEEK, 2));
+const FRI = isoDay(shift(MONDAY_OF_WEEK, 4));
+const SAT = isoDay(shift(MONDAY_OF_WEEK, 5));
+const SUN = isoDay(shift(MONDAY_OF_WEEK, 6));
+const NEXT_MON = isoDay(shift(MONDAY_OF_WEEK, 7));
+
 describe("Vacation API E2E Tests", () => {
   let context: TestContext;
 
@@ -126,7 +148,7 @@ describe("Vacation API E2E Tests", () => {
     it("should return 401 when not authenticated", async () => {
       const response = await request(context.app)
         .post("/api/vacation/create-vacation")
-        .send({ groupId: context.group.id, from: "2025-12-24", to: "2025-12-24" })
+        .send({ groupId: context.group.id, from: WED, to: WED })
         .expect(401);
 
       expect(response.body).toBeDefined();
@@ -146,18 +168,18 @@ describe("Vacation API E2E Tests", () => {
       await addToGroup(context.user1.id, context.group.id);
       const cookie = await authCookieFor(context.user1.id);
 
-      // 2025-12-24 is a Wednesday, inside the group's default Mon–Fri.
+      // A Wednesday, inside the group's default Mon–Fri working days.
       const response = await request(context.app)
         .post("/api/vacation/create-vacation")
         .set("Cookie", cookie)
-        .send({ groupId: context.group.id, from: "2025-12-24", to: "2025-12-24" })
+        .send({ groupId: context.group.id, from: WED, to: WED })
         .expect(201);
 
       expect(response.body).toHaveLength(1);
 
       const rows = await db.select().from(vacation).where(eq(vacation.userId, context.user1.id));
       expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({ requestedDay: "2025-12-24", halfDay: false });
+      expect(rows[0]).toMatchObject({ requestedDay: WED, halfDay: false });
     });
 
     it("should persist halfDay when the request asks for one", async () => {
@@ -167,7 +189,7 @@ describe("Vacation API E2E Tests", () => {
       await request(context.app)
         .post("/api/vacation/create-vacation")
         .set("Cookie", cookie)
-        .send({ groupId: context.group.id, from: "2025-12-24", to: "2025-12-24", halfDay: true })
+        .send({ groupId: context.group.id, from: WED, to: WED, halfDay: true })
         .expect(201);
 
       const rows = await db.select().from(vacation).where(eq(vacation.userId, context.user1.id));
@@ -182,7 +204,7 @@ describe("Vacation API E2E Tests", () => {
       await request(context.app)
         .post("/api/vacation/create-vacation")
         .set("Cookie", cookie)
-        .send({ groupId: context.group.id, from: "2025-12-24", to: "2025-12-24" })
+        .send({ groupId: context.group.id, from: WED, to: WED })
         .expect(201);
 
       const rows = await db.select().from(vacation).where(eq(vacation.userId, context.user1.id));
@@ -193,11 +215,11 @@ describe("Vacation API E2E Tests", () => {
       await addToGroup(context.user1.id, context.group.id);
       const cookie = await authCookieFor(context.user1.id);
 
-      // Mon 2025-12-22 → Fri 2025-12-26 spans five weekdays.
+      // Mon → Fri spans five weekdays.
       const response = await request(context.app)
         .post("/api/vacation/create-vacation")
         .set("Cookie", cookie)
-        .send({ groupId: context.group.id, from: "2025-12-22", to: "2025-12-26" })
+        .send({ groupId: context.group.id, from: MON, to: FRI })
         .expect(201);
 
       expect(response.body).toHaveLength(5);
@@ -207,30 +229,30 @@ describe("Vacation API E2E Tests", () => {
       await addToGroup(context.user1.id, context.group.id);
       const cookie = await authCookieFor(context.user1.id);
 
-      // Fri 2025-12-26 → Mon 2025-12-29 covers a weekend; only the two
+      // Fri → the following Mon covers a weekend; only the two
       // weekdays should be booked.
       const response = await request(context.app)
         .post("/api/vacation/create-vacation")
         .set("Cookie", cookie)
-        .send({ groupId: context.group.id, from: "2025-12-26", to: "2025-12-29" })
+        .send({ groupId: context.group.id, from: FRI, to: NEXT_MON })
         .expect(201);
 
       expect(response.body).toHaveLength(2);
       const days = (response.body as { requestedDay: string }[])
         .map((row) => row.requestedDay)
         .sort();
-      expect(days).toEqual(["2025-12-26", "2025-12-29"]);
+      expect(days).toEqual([FRI, NEXT_MON]);
     });
 
     it("should return 422 when the range contains no working day", async () => {
       await addToGroup(context.user1.id, context.group.id);
       const cookie = await authCookieFor(context.user1.id);
 
-      // Sat 2025-12-27 → Sun 2025-12-28.
+      // A full weekend.
       await request(context.app)
         .post("/api/vacation/create-vacation")
         .set("Cookie", cookie)
-        .send({ groupId: context.group.id, from: "2025-12-27", to: "2025-12-28" })
+        .send({ groupId: context.group.id, from: SAT, to: SUN })
         .expect(422);
     });
 
@@ -240,7 +262,7 @@ describe("Vacation API E2E Tests", () => {
       await request(context.app)
         .post("/api/vacation/create-vacation")
         .set("Cookie", cookie)
-        .send({ groupId: context.group.id, from: "2025-12-24", to: "2025-12-24" })
+        .send({ groupId: context.group.id, from: WED, to: WED })
         .expect(403);
     });
 
@@ -252,7 +274,7 @@ describe("Vacation API E2E Tests", () => {
       await request(context.app)
         .post("/api/vacation/create-vacation")
         .set("Cookie", cookie)
-        .send({ groupId: uuidv4(), from: "2025-12-24", to: "2025-12-24" })
+        .send({ groupId: uuidv4(), from: WED, to: WED })
         .expect(403);
     });
   });
@@ -261,7 +283,7 @@ describe("Vacation API E2E Tests", () => {
   // cancelled is free again. Before that was a partial index, the leftover row
   // kept the day booked forever.
   describe("POST /api/vacation/create-vacation — re-requesting a day", () => {
-    const bookDay = (cookie: string, day = "2025-12-24") =>
+    const bookDay = (cookie: string, day = WED) =>
       request(context.app)
         .post("/api/vacation/create-vacation")
         .set("Cookie", cookie)
@@ -275,7 +297,7 @@ describe("Vacation API E2E Tests", () => {
       const response = await bookDay(cookie).expect(409);
 
       expect(response.body).toMatchObject({
-        errors: [{ context: { conflictingDays: ["2025-12-24"] } }],
+        errors: [{ context: { conflictingDays: [WED] } }],
       });
     });
 
@@ -339,8 +361,8 @@ describe("Vacation API E2E Tests", () => {
         .expect(200);
       await bookDay(cookie).expect(201);
 
-      // Stale approver queue: approving would un-reject the old row onto a day
-      // the live request now holds.
+      // Stale approver queue. A decided row is no longer re-decidable at all,
+      // so this is refused before it can reach the day the live request holds.
       await request(context.app)
         .post(`/api/vacation/approve/${rejectedId}`)
         .set("Cookie", approverCookie)

--- a/src/tests/e2e/vacation.e2e.test.ts
+++ b/src/tests/e2e/vacation.e2e.test.ts
@@ -14,9 +14,8 @@ import { session } from "../../db/schema/auth-schema.js";
 import { v4 as uuidv4 } from "uuid";
 import { eq } from "drizzle-orm";
 
-// Booking is bounded to the current year through the end of the next, so these
-// anchor to a real Monday in the current year. Fixed calendar dates would book
-// fine today and fall out of the accepted window a year from now.
+// Booking is bounded to this year through the end of the next, so fixed dates
+// would fall out of range as time passes.
 const isoDay = (date: Date) => date.toISOString().slice(0, 10);
 const shift = (base: Date, days: number) => {
   const next = new Date(base);
@@ -361,8 +360,8 @@ describe("Vacation API E2E Tests", () => {
         .expect(200);
       await bookDay(cookie).expect(201);
 
-      // Stale approver queue. A decided row is no longer re-decidable at all,
-      // so this is refused before it can reach the day the live request holds.
+      // A decided row is not re-decidable, so this never reaches the day the
+      // live request now holds.
       await request(context.app)
         .post(`/api/vacation/approve/${rejectedId}`)
         .set("Cookie", approverCookie)

--- a/src/tests/middleware/devGuard.test.ts
+++ b/src/tests/middleware/devGuard.test.ts
@@ -24,7 +24,7 @@ const makeReq = (peer: string | undefined, token?: string): Request =>
     socket: { remoteAddress: peer },
     path: "/status",
     get: (name: string) => (name === "x-dev-token" ? token : undefined),
-  } as unknown as Request);
+  }) as unknown as Request;
 
 const run = (req: Request) => {
   const next = vi.fn() as unknown as NextFunction & { mock: { calls: unknown[][] } };

--- a/src/tests/middleware/requestContext.test.ts
+++ b/src/tests/middleware/requestContext.test.ts
@@ -274,9 +274,8 @@ describe("requestContext request logging", () => {
   it("skips paths listed in REQUEST_LOG_IGNORE_PATHS", async () => {
     vi.resetModules();
     process.env.REQUEST_LOG_IGNORE_PATHS = "/health";
-    const { requestContext: freshMiddleware } = await import(
-      "../../middleware/requestContext.js?ignore-paths"
-    );
+    const { requestContext: freshMiddleware } =
+      await import("../../middleware/requestContext.js?ignore-paths");
     const { logger: freshLogger } = await import("../../middleware/logger.js?ignore-paths");
     const infoSpy = vi.spyOn(freshLogger, "info").mockImplementation(() => freshLogger);
 

--- a/src/utils/dateFunc.ts
+++ b/src/utils/dateFunc.ts
@@ -16,6 +16,10 @@ export const formatDateToISOString = (date: Date): DateString => {
   return `${year}-${month}-${day}`;
 };
 
+// UTC everywhere, so opening a quota and validating a booking against it
+// cannot disagree about the year on a server that is not on UTC.
+export const currentYear = (): number => new Date().getUTCFullYear();
+
 // Returns true when the supplied UTC date is a working day (Mon-Fri).
 export const isBusinessDay = (date: Date): boolean => {
   const day = date.getUTCDay();


### PR DESCRIPTION
Closes 17 of the 20 defects from the exploratory test pass recorded in `BUGS-FOUND.md`. The frontend half is in [flexi-day#fix/exploratory-test-findings](https://github.com/Daniel88dev/flexi-day/pull/new/fix/exploratory-test-findings) — the two are independent deploys but the report and dashboard fixes only make sense alongside these.

## Why this is one PR

The defects cluster into two systems that were each broken end to end, and fixing one bug in isolation would have left the surrounding behaviour still wrong:

- **Quota tracking never held.** Allowances were never provisioned (BUG-020), nothing enforced them (BUG-003), and the balance endpoint omitted carry-over (BUG-005). For most real members the allowance the system compared against was zero and unused.
- **The approval workflow had no state machine and no separation of duties.** An approver could approve their own leave (BUG-002), a decision could be silently overturned (BUG-007), and the two approval endpoints disagreed about who was allowed to act (BUG-010).

## What changed

### Quotas — BUG-003, BUG-005, BUG-020

`services/vacation/quotaGuard.ts` enforces one member's allowance per `(group, year, leave type)`. It takes a transaction-scoped advisory lock on that key before summing — plain aggregate SELECTs inside a transaction are not enough under READ COMMITTED, where concurrent requests would all read the same pre-insert totals and all pass. Buckets are lock-ordered so overlapping batches cannot deadlock.

The two call sites deliberately count differently: **booking** counts pending days, because a new request competes with everything already booked; **approving** counts approved days only, or a queue of pending requests would block the approver from granting any of them. Ranges are bucketed by year and requester, so a range straddling New Year and a bulk decision spanning several people are both handled.

`openQuotaFromGroupDefaults` opens a member's allowance from the group defaults whenever a membership is created — all three paths (`handlePostGroup`, `handleSignUpWithTeam`, `handlePostGroupUser`). This is what the group's "default vacation / home office days" was always documented to mean; nothing implemented it. `onConflictDoNothing` keeps a re-join safe. For memberships that predate this, the guard falls back to the group defaults rather than capping them at zero, which would block every booking instead of bounding it.

### Approvals — BUG-002, BUG-007, BUG-010

`controllers/vacation/decisionGuards.ts` holds the single predicate for "may this person decide on these requests", used by all four decision endpoints. Previously the bulk path accepted the group manager while the single path accepted only the named approvers, so a one-element array bypassed the stricter check. The unified rule is the one `resolveVacationPermissions` already reported through `canApprove`, so the UI and API now agree.

The state machine lives in the update predicate (`stillPending`), not just the controller: a decided row matches nothing, the update returns no rows, and the controller returns 409. Cancellation deliberately keeps the looser predicate — plans change, and an approved request must stay cancellable.

`canApprove` is now false for your own request and for anything already decided, so the detail dialog stops offering a Decline button on an approved request.

### Timestamps — BUG-009

All 50 timestamp columns become `timestamptz`. Columns written by `defaultNow()` were storing local wall clock while the application wrote UTC, and the API serialised both with a `Z` — the same row could hold `approved_at` and its APPROVED event two hours apart, and the error was seasonal, so it looked intermittent.

**Migration note:** `0010` converts with an explicit `USING "col" AT TIME ZONE 'UTC'`. Everything the application wrote was UTC (and the API already claimed so), so this states it rather than letting Postgres assume the session zone. Rows written by the old `defaultNow()` defaults shift by the server's offset — that skew is the defect, and it is corrected going forward.

### Groups — BUG-011, BUG-012, BUG-013, BUG-014

A group created from the Groups page got `main_approval_user = NULL` and there was no route to set one, so its requests could never be approved by anyone, permanently. The creator now becomes the approver by default (matching what sign-up-with-team already did), and `PUT /api/group/:groupId/approvers` can change it afterwards — it requires admin access and refuses an approver who is not a member.

The creator's membership also gains `controlledUser: true`; without it they could not book leave in the group they had just created.

### Validation and privacy — BUG-015, BUG-016, BUG-017, BUG-018, BUG-019, BUG-001

`BANK_HOLIDAY` is dropped from the requestable kinds. It describes a company-wide closure, costs no allowance, and rendered to the whole team as an unattributed holiday — the frontend dropdown was the only thing preventing a member from granting themselves one. The other personal leave types stay available; only the company-wide one moves to the admin route.

Also: `endTime` must be later than `startTime`; `halfDay` is single-day only (it was being stamped onto every day of a range); leave is bounded to this calendar year through the end of next; a failed invite redemption no longer echoes back the invited address; `invite_link.group_id` gets `ON DELETE CASCADE`.

## Verification

Every fix was re-run against the original repro on a live stack. Highlights:

| | before | after |
|---|---|---|
| approve own request (single **and** bulk) | 200 | 403 `You cannot decide on your own leave request` |
| approve an already-rejected request | 200, rejection wiped | 409 `This request has already been decided` |
| non-approver, all four endpoints | 403 / **200** / 403 / **200** | 403 on all four, identical message |
| book past the allowance | 201 | 422 `exceededBy: 5` |
| new member's allowance after redeeming an invite | `0` | `20` from the group default |
| `defaultNow()` vs app-written timestamp, same row | 2h apart | identical to the millisecond |
| `dev:reset` with an invite present | 500 FK violation | succeeds |
| naive timestamp columns remaining | 32 | 0 |

`npm test` — 300 passed. `npm run test:e2e` — 88 passed against a fresh Postgres, which also confirms migration `0010` applies cleanly from an empty database. `npm run lint` — clean (3 pre-existing `any` warnings in `appError.ts`).

The e2e vacation fixtures booked December 2025 and the new window rejects it, so they are re-anchored to a real Monday in the current year (separate commit) — the weekday-sensitive cases keep their meaning and stop rotting with the calendar.

## ⚠️ Deployment note: this migration rewrites 19 tables

Every `ALTER COLUMN … SET DATA TYPE timestamptz` rewrites the table under an `ACCESS EXCLUSIVE` lock, and `0010` touches 19 of them including `vacation`, `changes` and `notifications`. On a populated production database this blocks reads and writes for the whole run — **run it in a maintenance window.**

I left it as one migration on purpose: `drizzle-kit migrate` does not wrap a file in a transaction (confirmed while developing this — a syntax error mid-file left the first statement committed and the rest unapplied), so adding a `lock_timeout` would risk stranding the schema half-converted. If the production tables are large enough that a single window is impractical, splitting the hot tables into separate migrations is the safer path — that is a call for you, not something I wanted to decide here.

## Notes for review

- Five files (`handlePutMySettings.ts`, `handlePostGroupInvite.test.ts`, `cors.ts`, `devGuard.test.ts`, `requestContext.test.ts`) were reformatted by the repo's own `npm run format` and are **not** in this commit — they are still dirty in my working tree. Worth a separate formatting commit.
- The unified approval predicate is the more permissive of the two that existed: the group manager can now approve where the single-record path used to refuse. That direction was chosen because it is what the UI already showed users. If the intent is that only named approvers decide, the change is one line in `getGroupsWhereUserCanApprove` — but then `resolveVacationPermissions` needs it too.
- Blocking self-approval means a single-approver team cannot approve the approver's own leave at all. That is the correct separation of duties, but it makes `temp_approval_user` load-bearing for small teams; the seeded dev scenario now leaves the owner's own requests pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
