### PR TITLE
fix(report): name departed members on the export summary sheet

### DIFF
--- a/src/controllers/report/handlePostReportExport.ts
+++ b/src/controllers/report/handlePostReportExport.ts
@@ -61,12 +61,22 @@ export const handlePostReportExport = async (req: Request, res: Response) => {
   const nameByUserId = new Map(members.map((member) => [member.id, member.name]));
   const groupNameById = new Map(scope.map((entry) => [entry.groupId, entry.groupName]));
 
-  const summary: SummaryRow[] = buildSummaryEntries(
+  const entries = buildSummaryEntries(
     quotas,
     usage,
     members.map((member) => ({ userId: member.id, groupId: member.groupId })),
     data.types
-  )
+  );
+
+  // Quota and usage rows outlive a membership, so someone who has left the
+  // group still earns a summary line — and is not in `members`. Resolve those
+  // names directly rather than printing a raw id in the Name column.
+  const unnamed = [...new Set(entries.map((e) => e.userId))].filter((id) => !nameByUserId.has(id));
+  for (const row of await services.user.getUsersByIds(unnamed)) {
+    nameByUserId.set(row.id, row.name);
+  }
+
+  const summary: SummaryRow[] = entries
     .map((entry) => ({
       userName: nameByUserId.get(entry.userId) ?? entry.userId,
       groupName: groupNameById.get(entry.groupId) ?? entry.groupId,

--- a/src/tests/e2e/helpers/reportFixtures.ts
+++ b/src/tests/e2e/helpers/reportFixtures.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
+import { and, eq } from "drizzle-orm";
 import { db } from "../../../db/db.js";
 import { user } from "../../../db/schema/auth-schema.js";
 import { groups } from "../../../db/schema/group-schema.js";
@@ -57,6 +58,14 @@ export async function addMember(
     createdAt: new Date(),
     updatedAt: new Date(),
   });
+}
+
+/** Soft-deletes a membership, as leaving a group does. */
+export async function removeMember(groupId: string, userId: string): Promise<void> {
+  await db
+    .update(groupUsers)
+    .set({ deletedAt: new Date(), updatedAt: new Date() })
+    .where(and(eq(groupUsers.groupId, groupId), eq(groupUsers.userId, userId)));
 }
 
 export async function addQuota(

--- a/src/tests/e2e/report.e2e.test.ts
+++ b/src/tests/e2e/report.e2e.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import request from "supertest";
+import ExcelJS from "exceljs";
 import type { Express } from "express";
 import { createServer } from "../../server.js";
 import { db } from "../../db/db.js";
@@ -17,6 +18,7 @@ import {
   dayIn,
   makeGroup,
   makeUser,
+  removeMember,
   resetReportData,
 } from "./helpers/reportFixtures.js";
 import { and, eq } from "drizzle-orm";
@@ -535,6 +537,42 @@ describe("Report API E2E", () => {
       );
       // Every xlsx is a zip archive, so the body must start with the PK magic.
       expect((res.body as Buffer).subarray(0, 2).toString()).toBe("PK");
+    });
+
+    it("names a member who has since left the group on the summary sheet", async () => {
+      const manager = await makeUser("Manager");
+      const leaver = await makeUser("Priya Leaver");
+      const groupId = await makeGroup("Engineering", manager.id);
+      await addMember(groupId, manager.id, { viewAccess: true });
+      await addMember(groupId, leaver.id);
+      await addQuota(groupId, leaver.id, FUTURE_YEAR, { vacationDays: 20 });
+      await addLeave(groupId, leaver.id, dayIn(FUTURE_YEAR, 3, 10));
+
+      // Their quota and bookings outlive the membership, so they still earn a
+      // summary line — one that used to print the raw user id.
+      await removeMember(groupId, leaver.id);
+
+      const res = await request(app)
+        .post("/api/reports/export")
+        .set("Cookie", await authCookieFor(manager.id))
+        .send({ year: FUTURE_YEAR })
+        .buffer(true)
+        .parse((response, callback) => {
+          const chunks: Buffer[] = [];
+          response.on("data", (chunk: Buffer) => chunks.push(chunk));
+          response.on("end", () => callback(null, Buffer.concat(chunks)));
+        })
+        .expect(200);
+
+      const workbook = new ExcelJS.Workbook();
+      await workbook.xlsx.load(res.body as ArrayBuffer);
+      const names = new Set<string>();
+      workbook.getWorksheet(`Summary ${FUTURE_YEAR.toString()}`)?.eachRow((row, index) => {
+        if (index > 1) names.add(String(row.getCell(1).value));
+      });
+
+      expect(names).toContain("Priya Leaver");
+      expect(names).not.toContain(leaver.id);
     });
 
     it("records who generated the export, for which year and with which filters", async () => {


### PR DESCRIPTION
## Problem

The Excel export's **Summary** sheet showed a raw user id in the Name column instead of a name. Reproduced locally: any member who has left the group (`group_users.deleted_at` set) renders as e.g. `5e16d490-e228-457d-b568-ea9230cf48e1`.

Their quota and usage rows outlive the membership, so `buildSummaryEntries` still produces a line for them — but `getScopeMembers` filters on `deleted_at IS NULL`, so they are absent from `members` and `handlePostReportExport` fell through to `?? entry.userId`.

The **Detail** sheet was never affected: it joins `user` directly, and showed the name all along.

## Fix

Resolve the names of any summary user ids not covered by `members` straight from the user table via `services.user.getUsersByIds`. The raw-id fallback stays as a last resort for a user row that no longer exists at all.

## Testing

- New e2e case in `report.e2e.test.ts` asserts a departed member is named on the summary sheet. Verified it fails without the controller change and passes with it.
- `npm test` (301 unit) and `npm run test:e2e` (89) both green.
- Exercised against the local dev seed: the departed member now reads "Carol Svoboda" rather than their id.

Paired with Daniel88dev/flexi-day#42 on the frontend (unrelated bugs from the same report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Report exports now show former members’ display names instead of raw user IDs when their quota or usage data remains.
  * Improved accuracy of report summary information after membership changes.

* **Tests**
  * Added coverage to verify former member names remain visible in exported report summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->