### PR TITLE
feat: split approver out of admin access, make mirroring admin-managed

### DIFF
--- a/src/controllers/auth/handleSignUpWithTeam.ts
+++ b/src/controllers/auth/handleSignUpWithTeam.ts
@@ -157,6 +157,7 @@ const createTeamForUser = async (userId: string, teamName: string) =>
         groupId: newGroup.id,
         viewAccess: true,
         adminAccess: true,
+        approverAccess: true,
         controlledUser: true,
       },
       tx

--- a/src/controllers/dev/handlePostDevScenario.ts
+++ b/src/controllers/dev/handlePostDevScenario.ts
@@ -23,16 +23,17 @@ export const validatePostDevScenario = z.object({
 export type ValidatedPostDevScenarioType = z.infer<typeof validatePostDevScenario>;
 
 const MEMBERS = [
-  { local: "alice", name: "Alice Novak" },
+  { local: "alice", name: "Alice Novak", approverAccess: true },
   { local: "bob", name: "Bob Dvorak" },
   { local: "carol", name: "Carol Svoboda" },
 ];
 
 /**
  * Seeds a whole team the UI can actually be exercised against: an owner who is
- * also the approver, three members, current-year quotas, and vacations spread
- * across pending / approved / rejected so every dashboard widget and the
- * approvals queue have content. Re-running it is a no-op rather than an error.
+ * also an admin and approver, three members (Alice approves but administers
+ * nothing), current-year quotas, and vacations spread across pending /
+ * approved / rejected so every dashboard widget and the approvals queue have
+ * content. Re-running it is a no-op rather than an error.
  */
 export const handlePostDevScenario = async (req: Request, res: Response) => {
   const data = req.body as ValidatedPostDevScenarioType;
@@ -52,7 +53,7 @@ export const handlePostDevScenario = async (req: Request, res: Response) => {
   const team =
     (await findTeam(owner.id, teamName)) ?? (await seedTeam({ teamName, managerUserId: owner.id }));
 
-  await addMember({ userId: owner.id, groupId: team.id, adminAccess: true });
+  await addMember({ userId: owner.id, groupId: team.id, adminAccess: true, approverAccess: true });
   await setQuota({ userId: owner.id, groupId: team.id });
 
   const members: SeededUser[] = [];
@@ -62,7 +63,11 @@ export const handlePostDevScenario = async (req: Request, res: Response) => {
       name: member.name,
       password,
     });
-    await addMember({ userId: seeded.id, groupId: team.id });
+    await addMember({
+      userId: seeded.id,
+      groupId: team.id,
+      approverAccess: member.approverAccess ?? false,
+    });
     await setQuota({ userId: seeded.id, groupId: team.id });
     members.push(seeded);
   }

--- a/src/controllers/dev/handlePostDevUser.ts
+++ b/src/controllers/dev/handlePostDevUser.ts
@@ -34,7 +34,12 @@ export const handlePostDevUser = async (req: Request, res: Response) => {
         teamName: data.teamName,
         managerUserId: seeded.id,
       }));
-    await addMember({ userId: seeded.id, groupId: team.id, adminAccess: true });
+    await addMember({
+      userId: seeded.id,
+      groupId: team.id,
+      adminAccess: true,
+      approverAccess: true,
+    });
     await setQuota({ userId: seeded.id, groupId: team.id });
   }
 

--- a/src/controllers/group/handleGetGroupMirrors.ts
+++ b/src/controllers/group/handleGetGroupMirrors.ts
@@ -3,14 +3,14 @@ import { z } from "zod";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
 import AppError from "../../utils/appError.js";
-import type { MirrorCandidate } from "../../services/groupMirror/types.js";
+import { buildUserSummary } from "../../utils/userPresentation.js";
+import type { MirrorCandidate, MirrorMember } from "../../services/groupMirror/types.js";
 
 const services = createDBServices();
 
 /**
- * The caller's mirroring setup for one group: every other group they belong to,
- * and whether their records from it are currently shown here. Mirroring is a
- * per-user choice, so this is scoped to the caller — not the whole group.
+ * The mirroring setup for one group: for an admin, every member with the
+ * sources they may be given; for anyone else, their own mirrors read-only.
  */
 export const handleGetGroupMirrors = async (req: Request, res: Response) => {
   const auth = getAuth(req);
@@ -27,20 +27,75 @@ export const handleGetGroupMirrors = async (req: Request, res: Response) => {
     });
   }
 
-  const [memberships, mirrors] = await Promise.all([
-    services.groupUser.getAllGroupsForUser(auth.userId),
-    services.groupMirror.getMirrorsIntoGroupForUser(auth.userId, groupId),
+  if (!membership.adminAccess) {
+    const mirrors = await services.groupMirror.getMirrorsIntoGroupForUser(auth.userId, groupId);
+    const self: MirrorMember = {
+      userId: auth.userId,
+      user: buildUserSummary({ id: auth.userId, name: auth.userName }),
+      email: auth.userEmail,
+      candidates: mirrors.map((mirror) => ({
+        groupId: mirror.sourceGroupId,
+        groupName: mirror.sourceGroupName,
+        mirrored: true,
+        manageable: false,
+      })),
+    };
+    return res.status(200).json({ groupId, canManage: false, members: [self] });
+  }
+
+  const members = await services.groupUser.getGroupUsers(groupId);
+  const memberIds = members.map((member) => member.userId);
+
+  const adminGroupIds = (await services.groupUser.getAdminGroupIdsForUser(auth.userId)).filter(
+    (id) => id !== groupId
+  );
+
+  const [sourceGroups, membershipPairs, mirrorPairs] = await Promise.all([
+    services.group.getAllGroups(adminGroupIds),
+    services.groupUser.getMembershipPairs(memberIds, adminGroupIds),
+    services.groupMirror.getMirrorsIntoGroupForUsers(memberIds, groupId),
   ]);
 
-  const otherGroupIds = memberships.map((row) => row.groupId).filter((id) => id !== groupId);
-  const otherGroups = await services.group.getAllGroups(otherGroupIds);
-  const mirroredIds = new Set(mirrors.map((mirror) => mirror.sourceGroupId));
+  const manageableGroupNames = new Map(sourceGroups.map((group) => [group.id, group.groupName]));
 
-  const candidates: MirrorCandidate[] = otherGroups.map((group) => ({
-    groupId: group.id,
-    groupName: group.groupName,
-    mirrored: mirroredIds.has(group.id),
-  }));
+  const manageableFor = new Map<string, Set<string>>();
+  for (const pair of membershipPairs) {
+    if (!manageableGroupNames.has(pair.groupId)) continue;
+    const set = manageableFor.get(pair.userId) ?? new Set<string>();
+    set.add(pair.groupId);
+    manageableFor.set(pair.userId, set);
+  }
 
-  return res.status(200).json({ groupId, candidates });
+  const mirroredFor = new Map<string, Map<string, string>>();
+  for (const pair of mirrorPairs) {
+    const map = mirroredFor.get(pair.userId) ?? new Map<string, string>();
+    map.set(pair.sourceGroupId, pair.sourceGroupName);
+    mirroredFor.set(pair.userId, map);
+  }
+
+  const payload: MirrorMember[] = members.map((member) => {
+    const manageable = manageableFor.get(member.userId) ?? new Set<string>();
+    const active = mirroredFor.get(member.userId) ?? new Map<string, string>();
+
+    // Locked, but listed: a save is scoped to `manageable`, so omitting these
+    // would read as "no mirror" when there is one.
+    const candidateIds = new Set([...manageable, ...active.keys()]);
+    const candidates: MirrorCandidate[] = [...candidateIds].map((sourceGroupId) => ({
+      groupId: sourceGroupId,
+      groupName:
+        manageableGroupNames.get(sourceGroupId) ?? active.get(sourceGroupId) ?? sourceGroupId,
+      mirrored: active.has(sourceGroupId),
+      manageable: manageable.has(sourceGroupId),
+    }));
+    candidates.sort((a, b) => a.groupName.localeCompare(b.groupName));
+
+    return {
+      userId: member.userId,
+      user: member.user,
+      email: member.email,
+      candidates,
+    };
+  });
+
+  return res.status(200).json({ groupId, canManage: true, members: payload });
 };

--- a/src/controllers/group/handlePostGroup.ts
+++ b/src/controllers/group/handlePostGroup.ts
@@ -66,6 +66,7 @@ export const handlePostGroup = async (req: Request, res: Response) => {
         groupId: record.id,
         viewAccess: true,
         adminAccess: true,
+        approverAccess: true,
         controlledUser: true,
       },
       tx

--- a/src/controllers/group/handlePutGroupMirrors.ts
+++ b/src/controllers/group/handlePutGroupMirrors.ts
@@ -9,10 +9,9 @@ import type { ValidatedPutGroupMirrorsType } from "../../services/groupMirror/ty
 const services = createDBServices();
 
 /**
- * Replaces the caller's mirror sources for one group. Mirroring only ever
- * projects the caller's own records, so membership of the target and of every
- * source group is the whole authorization story — no admin rights are needed
- * and none are enough on someone else's behalf.
+ * Replaces one member's mirror sources for a group. Not self-service: the
+ * caller must administer the target group *and* every source group they touch,
+ * or projecting a group's records would need rights on the receiving side only.
  */
 export const handlePutGroupMirrors = async (req: Request, res: Response) => {
   const auth = getAuth(req);
@@ -31,24 +30,53 @@ export const handlePutGroupMirrors = async (req: Request, res: Response) => {
     });
   }
 
-  const memberships = await services.groupUser.getAllGroupsForUser(auth.userId);
-  const memberOf = new Set(memberships.map((row) => row.groupId));
-
-  if (!memberOf.has(targetGroupId)) {
+  const access = await services.groupUser.getGroupUser(auth.userId, targetGroupId);
+  if (!access?.adminAccess) {
     throw new AppError({
-      message: "No access for related group",
+      message: "No permission for related group",
       logging: true,
       code: 403,
       context: { url: req.url, userId: auth.userId, targetGroupId },
     });
   }
 
-  const notAMember = data.sourceGroupIds.filter((id) => !memberOf.has(id));
-  if (notAMember.length > 0) {
+  const targetMembership = await services.groupUser.getGroupUser(data.userId, targetGroupId);
+  if (!targetMembership) {
     throw new AppError({
-      message: "You can only mirror groups you belong to",
+      message: "Mirroring can only be set up for a member of this group",
+      logging: true,
+      code: 422,
+      context: { url: req.url, userId: auth.userId, targetGroupId, memberId: data.userId },
+    });
+  }
+
+  const adminGroupIds = (await services.groupUser.getAdminGroupIdsForUser(auth.userId)).filter(
+    (id) => id !== targetGroupId
+  );
+  const adminOf = new Set(adminGroupIds);
+
+  const notAdminOf = data.sourceGroupIds.filter((id) => !adminOf.has(id));
+  if (notAdminOf.length > 0) {
+    throw new AppError({
+      message: "You can only mirror from groups you administer",
       logging: true,
       code: 403,
+      context: { url: req.url, userId: auth.userId, targetGroupId, notAdminOf },
+      publicContext: { groupIds: notAdminOf },
+    });
+  }
+
+  const memberOfSources = new Set(
+    (await services.groupUser.getMembershipPairs([data.userId], data.sourceGroupIds)).map(
+      (pair) => pair.groupId
+    )
+  );
+  const notAMember = data.sourceGroupIds.filter((id) => !memberOfSources.has(id));
+  if (notAMember.length > 0) {
+    throw new AppError({
+      message: "A member can only be mirrored from groups they belong to",
+      logging: true,
+      code: 422,
       context: { url: req.url, userId: auth.userId, targetGroupId, notAMember },
       publicContext: { groupIds: notAMember },
     });
@@ -56,9 +84,10 @@ export const handlePutGroupMirrors = async (req: Request, res: Response) => {
 
   const mirrors = await db.transaction((tx) =>
     services.groupMirror.setMirrorsIntoGroupForUser(
-      auth.userId,
+      data.userId,
       targetGroupId,
       data.sourceGroupIds,
+      adminGroupIds,
       tx
     )
   );

--- a/src/controllers/group/tests/handleGroupMirrors.test.ts
+++ b/src/controllers/group/tests/handleGroupMirrors.test.ts
@@ -2,15 +2,21 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const {
   mockGetGroupUser,
-  mockGetAllGroupsForUser,
+  mockGetGroupUsers,
+  mockGetAdminGroupIdsForUser,
+  mockGetMembershipPairs,
   mockGetAllGroups,
   mockGetMirrorsIntoGroupForUser,
+  mockGetMirrorsIntoGroupForUsers,
   mockSetMirrorsIntoGroupForUser,
 } = vi.hoisted(() => ({
   mockGetGroupUser: vi.fn(),
-  mockGetAllGroupsForUser: vi.fn(),
+  mockGetGroupUsers: vi.fn(),
+  mockGetAdminGroupIdsForUser: vi.fn(),
+  mockGetMembershipPairs: vi.fn(),
   mockGetAllGroups: vi.fn(),
   mockGetMirrorsIntoGroupForUser: vi.fn(),
+  mockGetMirrorsIntoGroupForUsers: vi.fn(),
   mockSetMirrorsIntoGroupForUser: vi.fn(),
 }));
 
@@ -24,11 +30,14 @@ vi.mock("../../../services/DBServices.js", () => ({
   createDBServices: () => ({
     groupUser: {
       getGroupUser: mockGetGroupUser,
-      getAllGroupsForUser: mockGetAllGroupsForUser,
+      getGroupUsers: mockGetGroupUsers,
+      getAdminGroupIdsForUser: mockGetAdminGroupIdsForUser,
+      getMembershipPairs: mockGetMembershipPairs,
     },
     group: { getAllGroups: mockGetAllGroups },
     groupMirror: {
       getMirrorsIntoGroupForUser: mockGetMirrorsIntoGroupForUser,
+      getMirrorsIntoGroupForUsers: mockGetMirrorsIntoGroupForUsers,
       setMirrorsIntoGroupForUser: mockSetMirrorsIntoGroupForUser,
     },
   }),
@@ -42,26 +51,39 @@ import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
 const TARGET = "550e8400-e29b-41d4-a716-446655440000";
 const SOURCE_A = "550e8400-e29b-41d4-a716-446655440001";
 const SOURCE_B = "550e8400-e29b-41d4-a716-446655440002";
+const UNMANAGED = "550e8400-e29b-41d4-a716-446655440008";
 const OUTSIDER = "550e8400-e29b-41d4-a716-446655440009";
+
+const MEMBER = "member-1";
+
+const memberRow = (userId: string, name: string) => ({
+  userId,
+  user: { id: userId, name, initials: "XX", avatarColor: "hsl(1, 65%, 50%)" },
+  email: `${userId}@example.com`,
+});
 
 describe("handleGetGroupMirrors", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
-    mockGetGroupUser.mockResolvedValue({ viewAccess: true });
-    mockGetAllGroupsForUser.mockResolvedValue([
-      { groupId: TARGET },
-      { groupId: SOURCE_A },
-      { groupId: SOURCE_B },
+    mockGetGroupUser.mockResolvedValue({ viewAccess: true, adminAccess: true });
+    mockGetGroupUsers.mockResolvedValue([memberRow(MEMBER, "Ada Byron")]);
+    mockGetAdminGroupIdsForUser.mockResolvedValue([TARGET, SOURCE_A, SOURCE_B]);
+    mockGetMembershipPairs.mockResolvedValue([
+      { userId: MEMBER, groupId: SOURCE_A },
+      { userId: MEMBER, groupId: SOURCE_B },
     ]);
     mockGetAllGroups.mockResolvedValue([
       { id: SOURCE_A, groupName: "Team A" },
       { id: SOURCE_B, groupName: "Leadership" },
     ]);
-    mockGetMirrorsIntoGroupForUser.mockResolvedValue([{ sourceGroupId: SOURCE_A }]);
+    mockGetMirrorsIntoGroupForUsers.mockResolvedValue([
+      { userId: MEMBER, sourceGroupId: SOURCE_A, sourceGroupName: "Team A" },
+    ]);
+    mockGetMirrorsIntoGroupForUser.mockResolvedValue([]);
   });
 
-  it("lists the caller's other groups, flagging the mirrored ones", async () => {
+  it("lists every member with their candidate sources, flagging the mirrored ones", async () => {
     const { req, res } = makeReqRes({ params: { groupId: TARGET } });
 
     await handleGetGroupMirrors(req, res);
@@ -69,9 +91,15 @@ describe("handleGetGroupMirrors", () => {
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
       groupId: TARGET,
-      candidates: [
-        { groupId: SOURCE_A, groupName: "Team A", mirrored: true },
-        { groupId: SOURCE_B, groupName: "Leadership", mirrored: false },
+      canManage: true,
+      members: [
+        expect.objectContaining({
+          userId: MEMBER,
+          candidates: [
+            { groupId: SOURCE_B, groupName: "Leadership", mirrored: false, manageable: true },
+            { groupId: SOURCE_A, groupName: "Team A", mirrored: true, manageable: true },
+          ],
+        }),
       ],
     });
   });
@@ -82,6 +110,65 @@ describe("handleGetGroupMirrors", () => {
     await handleGetGroupMirrors(req, res);
 
     expect(mockGetAllGroups).toHaveBeenCalledWith([SOURCE_A, SOURCE_B]);
+  });
+
+  it("offers only sources the acting admin also administers", async () => {
+    mockGetAdminGroupIdsForUser.mockResolvedValue([TARGET, SOURCE_A]);
+    mockGetAllGroups.mockResolvedValue([{ id: SOURCE_A, groupName: "Team A" }]);
+    const { req, res } = makeReqRes({ params: { groupId: TARGET } });
+
+    await handleGetGroupMirrors(req, res);
+
+    const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+      members: { candidates: { groupId: string }[] }[];
+    };
+    expect(payload.members[0]?.candidates.map((c) => c.groupId)).toEqual([SOURCE_A]);
+  });
+
+  it("shows an active mirror from a group the admin does not administer, locked", async () => {
+    mockGetAdminGroupIdsForUser.mockResolvedValue([TARGET, SOURCE_A]);
+    mockGetAllGroups.mockResolvedValue([{ id: SOURCE_A, groupName: "Team A" }]);
+    mockGetMembershipPairs.mockResolvedValue([{ userId: MEMBER, groupId: SOURCE_A }]);
+    mockGetMirrorsIntoGroupForUsers.mockResolvedValue([
+      { userId: MEMBER, sourceGroupId: UNMANAGED, sourceGroupName: "Hidden Team" },
+    ]);
+    const { req, res } = makeReqRes({ params: { groupId: TARGET } });
+
+    await handleGetGroupMirrors(req, res);
+
+    const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+      members: { candidates: { groupId: string; mirrored: boolean; manageable: boolean }[] }[];
+    };
+    expect(payload.members[0]?.candidates).toContainEqual({
+      groupId: UNMANAGED,
+      groupName: "Hidden Team",
+      mirrored: true,
+      manageable: false,
+    });
+  });
+
+  it("gives a non-admin their own mirrors read-only", async () => {
+    mockGetGroupUser.mockResolvedValue({ viewAccess: true, adminAccess: false });
+    mockGetMirrorsIntoGroupForUser.mockResolvedValue([
+      { sourceGroupId: SOURCE_A, sourceGroupName: "Team A" },
+    ]);
+    const { req, res } = makeReqRes({ params: { groupId: TARGET } });
+
+    await handleGetGroupMirrors(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      groupId: TARGET,
+      canManage: false,
+      members: [
+        expect.objectContaining({
+          userId: mockAuthData.userId,
+          candidates: [
+            { groupId: SOURCE_A, groupName: "Team A", mirrored: true, manageable: false },
+          ],
+        }),
+      ],
+    });
+    expect(mockGetGroupUsers).not.toHaveBeenCalled();
   });
 
   it("403s for a caller who does not belong to the group", async () => {
@@ -96,56 +183,84 @@ describe("handlePutGroupMirrors", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
-    mockGetAllGroupsForUser.mockResolvedValue([
-      { groupId: TARGET },
-      { groupId: SOURCE_A },
-      { groupId: SOURCE_B },
-    ]);
+    mockGetGroupUser.mockResolvedValue({ adminAccess: true });
+    mockGetAdminGroupIdsForUser.mockResolvedValue([TARGET, SOURCE_A, SOURCE_B]);
+    mockGetMembershipPairs.mockImplementation((_userIds: string[], groupIds: string[]) =>
+      Promise.resolve(groupIds.map((groupId) => ({ userId: MEMBER, groupId })))
+    );
     mockSetMirrorsIntoGroupForUser.mockResolvedValue([]);
   });
 
-  const put = (sourceGroupIds: string[]) =>
-    makeReqRes({ params: { groupId: TARGET }, body: { sourceGroupIds } });
+  const put = (sourceGroupIds: string[], userId = MEMBER) =>
+    makeReqRes({ params: { groupId: TARGET }, body: { userId, sourceGroupIds } });
 
-  it("replaces the caller's mirror sources", async () => {
+  it("replaces the member's mirror sources within the admin's reach", async () => {
     const { req, res } = put([SOURCE_A, SOURCE_B]);
 
     await handlePutGroupMirrors(req, res);
 
     expect(mockSetMirrorsIntoGroupForUser).toHaveBeenCalledWith(
-      mockAuthData.userId,
+      MEMBER,
       TARGET,
+      [SOURCE_A, SOURCE_B],
       [SOURCE_A, SOURCE_B],
       expect.anything()
     );
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
-  it("turns mirroring off with an empty array", async () => {
+  it("turns the admin's manageable mirrors off with an empty array", async () => {
     const { req, res } = put([]);
 
     await handlePutGroupMirrors(req, res);
 
     expect(mockSetMirrorsIntoGroupForUser).toHaveBeenCalledWith(
-      mockAuthData.userId,
+      MEMBER,
       TARGET,
       [],
+      [SOURCE_A, SOURCE_B],
       expect.anything()
     );
   });
 
-  it("refuses a source group the caller does not belong to", async () => {
+  it("refuses a caller who is only a plain member of the target group", async () => {
+    mockGetGroupUser.mockResolvedValue({ adminAccess: false });
+    const { req, res } = put([SOURCE_A]);
+
+    await expect(handlePutGroupMirrors(req, res)).rejects.toMatchObject({ code: 403 });
+    expect(mockSetMirrorsIntoGroupForUser).not.toHaveBeenCalled();
+  });
+
+  it("refuses a caller who does not belong to the target group", async () => {
+    mockGetGroupUser.mockResolvedValue(undefined);
+    const { req, res } = put([SOURCE_A]);
+
+    await expect(handlePutGroupMirrors(req, res)).rejects.toMatchObject({ code: 403 });
+    expect(mockSetMirrorsIntoGroupForUser).not.toHaveBeenCalled();
+  });
+
+  it("refuses a source group the caller does not administer", async () => {
     const { req, res } = put([SOURCE_A, OUTSIDER]);
 
     await expect(handlePutGroupMirrors(req, res)).rejects.toMatchObject({ code: 403 });
     expect(mockSetMirrorsIntoGroupForUser).not.toHaveBeenCalled();
   });
 
-  it("refuses when the caller does not belong to the target group", async () => {
-    mockGetAllGroupsForUser.mockResolvedValue([{ groupId: SOURCE_A }]);
+  it("refuses a member who does not belong to the target group", async () => {
+    mockGetGroupUser.mockImplementation((userId: string) =>
+      Promise.resolve(userId === mockAuthData.userId ? { adminAccess: true } : undefined)
+    );
     const { req, res } = put([SOURCE_A]);
 
-    await expect(handlePutGroupMirrors(req, res)).rejects.toMatchObject({ code: 403 });
+    await expect(handlePutGroupMirrors(req, res)).rejects.toMatchObject({ code: 422 });
+    expect(mockSetMirrorsIntoGroupForUser).not.toHaveBeenCalled();
+  });
+
+  it("refuses a source group the member does not belong to", async () => {
+    mockGetMembershipPairs.mockResolvedValue([{ userId: MEMBER, groupId: SOURCE_A }]);
+    const { req, res } = put([SOURCE_A, SOURCE_B]);
+
+    await expect(handlePutGroupMirrors(req, res)).rejects.toMatchObject({ code: 422 });
     expect(mockSetMirrorsIntoGroupForUser).not.toHaveBeenCalled();
   });
 

--- a/src/controllers/groupUser/handlePostGroupUser.ts
+++ b/src/controllers/groupUser/handlePostGroupUser.ts
@@ -90,6 +90,7 @@ export const handlePostGroupUser = async (req: Request, res: Response) => {
         groupId: validateLink.groupId,
         viewAccess: true,
         adminAccess: false,
+        approverAccess: false,
         controlledUser: true,
       },
       tx

--- a/src/controllers/groupUser/handleUpdateGroupUsers.ts
+++ b/src/controllers/groupUser/handleUpdateGroupUsers.ts
@@ -33,6 +33,7 @@ export const handleUpdateGroupUsers = async (req: Request, res: Response) => {
         {
           viewAccess: userRecord.viewAccess,
           adminAccess: userRecord.adminAccess,
+          approverAccess: userRecord.approverAccess,
           controlledUser: userRecord.controlledUser,
         },
         tx

--- a/src/controllers/vacation/decisionGuards.ts
+++ b/src/controllers/vacation/decisionGuards.ts
@@ -8,9 +8,24 @@ const services = createDBServices();
 type Decision = "approve" | "reject";
 
 /**
+ * Whether the actor may decide on their *own* request in this group. Only the
+ * `approverAccess` flag lifts separation of duties, and not while the actor's
+ * records are mirrored in from another group — that leave is governed there.
+ */
+export const mayDecideOwn = async (
+  actorUserId: string,
+  groupId: string,
+  tx?: DbTransaction
+): Promise<boolean> => {
+  const membership = await services.groupUser.getGroupUser(actorUserId, groupId, tx);
+  if (!membership?.approverAccess) return false;
+
+  return !(await services.groupMirror.hasMirrorIntoGroup(actorUserId, groupId, tx));
+};
+
+/**
  * The single predicate for "may this person decide on these requests", shared by
- * the per-record and bulk endpoints so they cannot drift apart. Separation of
- * duties is part of it: an approver's own request is for the other approver.
+ * the per-record and bulk endpoints so they cannot drift apart.
  */
 export const assertMayDecide = async (
   actorUserId: string,
@@ -33,12 +48,22 @@ export const assertMayDecide = async (
     });
   }
 
-  if (rows.some((row) => row.userId === actorUserId)) {
+  const ownRows = rows.filter((row) => row.userId === actorUserId);
+  if (ownRows.length === 0) return;
+
+  const ownGroupIds = Array.from(new Set(ownRows.map((row) => row.groupId)));
+  const selfDecidable = new Set<string>();
+  for (const groupId of ownGroupIds) {
+    if (await mayDecideOwn(actorUserId, groupId, tx)) selfDecidable.add(groupId);
+  }
+
+  const blocked = ownRows.filter((row) => !selfDecidable.has(row.groupId));
+  if (blocked.length > 0) {
     throw new AppError({
       code: 403,
       message: "You cannot decide on your own leave request",
       logging: true,
-      context: { actorUserId, vacationIds: rows.map((row) => row.id) },
+      context: { actorUserId, vacationIds: blocked.map((row) => row.id) },
     });
   }
 };

--- a/src/controllers/vacation/handleGetVacations.ts
+++ b/src/controllers/vacation/handleGetVacations.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { canViewWholeGroup } from "../../services/report/reportScope.js";
 import AppError from "../../utils/appError.js";
+import { resolveCanApproveForList } from "./utils.js";
 
 const services = createDBServices();
 
@@ -39,12 +40,16 @@ export const handleGetVacations = async (req: Request, res: Response) => {
       range.startDate,
       range.endDate
     );
+    const canApprove = await resolveCanApproveForList(auth.userId, result);
     // Same shape either way, so the calendar does not branch on scope.
-    return res
-      .status(200)
-      .json(
-        result.map((row) => ({ ...row, mirroredFromGroupId: null, mirroredFromGroupName: null }))
-      );
+    return res.status(200).json(
+      result.map((row) => ({
+        ...row,
+        mirroredFromGroupId: null,
+        mirroredFromGroupName: null,
+        canApprove: canApprove(row),
+      }))
+    );
   }
 
   const scope = await services.report.getScopeEntries(auth.userId);
@@ -62,6 +67,7 @@ export const handleGetVacations = async (req: Request, res: Response) => {
     range.startDate,
     range.endDate
   );
+  const canApprove = await resolveCanApproveForList(auth.userId, result);
 
-  return res.status(200).json(result);
+  return res.status(200).json(result.map((row) => ({ ...row, canApprove: canApprove(row) })));
 };

--- a/src/controllers/vacation/tests/handleGetVacations.test.ts
+++ b/src/controllers/vacation/tests/handleGetVacations.test.ts
@@ -1,13 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Request, Response } from "express";
 
-const { mockGetVacationsForUser, mockGetVacationsForGroup, mockGetScopeEntries } = vi.hoisted(
-  () => ({
-    mockGetVacationsForUser: vi.fn(),
-    mockGetVacationsForGroup: vi.fn(),
-    mockGetScopeEntries: vi.fn(),
-  })
-);
+const {
+  mockGetVacationsForUser,
+  mockGetVacationsForGroup,
+  mockGetScopeEntries,
+  mockGetGroupsWhereUserCanApprove,
+  mockGetGroupUser,
+  mockHasMirrorIntoGroup,
+} = vi.hoisted(() => ({
+  mockGetVacationsForUser: vi.fn(),
+  mockGetVacationsForGroup: vi.fn(),
+  mockGetScopeEntries: vi.fn(),
+  mockGetGroupsWhereUserCanApprove: vi.fn(),
+  mockGetGroupUser: vi.fn(),
+  mockHasMirrorIntoGroup: vi.fn(),
+}));
 
 vi.mock("../../../utils/dateFunc.js", () => ({
   formatStartAndEndDate: vi.fn(),
@@ -25,6 +33,15 @@ vi.mock("../../../services/DBServices.js", () => ({
     },
     report: {
       getScopeEntries: mockGetScopeEntries,
+    },
+    group: {
+      getGroupsWhereUserCanApprove: mockGetGroupsWhereUserCanApprove,
+    },
+    groupUser: {
+      getGroupUser: mockGetGroupUser,
+    },
+    groupMirror: {
+      hasMirrorIntoGroup: mockHasMirrorIntoGroup,
     },
   }),
 }));
@@ -61,6 +78,10 @@ describe("handleGetVacations", () => {
       startDate: "2024-01-01",
       endDate: "2024-01-31",
     });
+
+    mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
+    mockGetGroupUser.mockResolvedValue(undefined);
+    mockHasMirrorIntoGroup.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -94,7 +115,12 @@ describe("handleGetVacations", () => {
     // Own records carry the same mirror fields as group ones so the calendar
     // never has to branch on which scope produced the row.
     expect(res.json).toHaveBeenCalledWith(
-      mockVacations.map((v) => ({ ...v, mirroredFromGroupId: null, mirroredFromGroupName: null }))
+      mockVacations.map((v) => ({
+        ...v,
+        mirroredFromGroupId: null,
+        mirroredFromGroupName: null,
+        canApprove: false,
+      }))
     );
   });
 
@@ -228,13 +254,23 @@ describe("handleGetVacations", () => {
       canEditQuotas: false,
     });
 
+    const pendingRow = (id: string, userId: string, groupId = "group_1") => ({
+      id,
+      userId,
+      groupId,
+      deletedAt: null,
+      approvedAt: null,
+      rejectedAt: null,
+      mirroredFromGroupId: null,
+      mirroredFromGroupName: null,
+    });
+
     it("returns the group's records, mirrored ones included, when the caller may view it", async () => {
       const { req, res } = makeReqRes({ year: "2024", month: "3", groupId: "group_1" });
       const groupRows = [
-        { id: "v1", userId: "user_123", mirroredFromGroupId: null, mirroredFromGroupName: null },
+        pendingRow("v1", "user_123"),
         {
-          id: "v2",
-          userId: "user_999",
+          ...pendingRow("v2", "user_999"),
           mirroredFromGroupId: "group_2",
           mirroredFromGroupName: "Team B",
         },
@@ -246,7 +282,52 @@ describe("handleGetVacations", () => {
 
       expect(mockGetVacationsForGroup).toHaveBeenCalledWith("group_1", "2024-01-01", "2024-01-31");
       expect(mockGetVacationsForUser).not.toHaveBeenCalled();
-      expect(res.json).toHaveBeenCalledWith(groupRows);
+      expect(res.json).toHaveBeenCalledWith(
+        groupRows.map((row) => ({ ...row, canApprove: false }))
+      );
+    });
+
+    it("marks someone else's pending request approvable for an approver", async () => {
+      const { req, res } = makeReqRes({ year: "2024", month: "3", groupId: "group_1" });
+      mockGetScopeEntries.mockResolvedValue([scopeEntry("all")]);
+      mockGetVacationsForGroup.mockResolvedValue([pendingRow("v1", "user_999")]);
+      mockGetGroupsWhereUserCanApprove.mockResolvedValue(["group_1"]);
+
+      await handleGetVacations(req, res);
+
+      expect(res.json).toHaveBeenCalledWith([expect.objectContaining({ canApprove: true })]);
+    });
+
+    it("marks an approver's own request approvable only when nothing mirrors into the group", async () => {
+      const { req, res } = makeReqRes({ year: "2024", month: "3", groupId: "group_1" });
+      mockGetScopeEntries.mockResolvedValue([scopeEntry("all")]);
+      mockGetVacationsForGroup.mockResolvedValue([pendingRow("v1", "user_123")]);
+      mockGetGroupsWhereUserCanApprove.mockResolvedValue(["group_1"]);
+      mockGetGroupUser.mockResolvedValue({ approverAccess: true });
+      mockHasMirrorIntoGroup.mockResolvedValue(true);
+
+      await handleGetVacations(req, res);
+
+      expect(res.json).toHaveBeenCalledWith([expect.objectContaining({ canApprove: false })]);
+
+      mockHasMirrorIntoGroup.mockResolvedValue(false);
+      const second = makeReqRes({ year: "2024", month: "3", groupId: "group_1" });
+      await handleGetVacations(second.req, second.res);
+
+      expect(second.res.json).toHaveBeenCalledWith([expect.objectContaining({ canApprove: true })]);
+    });
+
+    it("never marks a decided request approvable", async () => {
+      const { req, res } = makeReqRes({ year: "2024", month: "3", groupId: "group_1" });
+      mockGetScopeEntries.mockResolvedValue([scopeEntry("all")]);
+      mockGetVacationsForGroup.mockResolvedValue([
+        { ...pendingRow("v1", "user_999"), approvedAt: new Date() },
+      ]);
+      mockGetGroupsWhereUserCanApprove.mockResolvedValue(["group_1"]);
+
+      await handleGetVacations(req, res);
+
+      expect(res.json).toHaveBeenCalledWith([expect.objectContaining({ canApprove: false })]);
     });
 
     it("rejects a member without view access on the group", async () => {

--- a/src/controllers/vacation/tests/handlePostVacationApproval.test.ts
+++ b/src/controllers/vacation/tests/handlePostVacationApproval.test.ts
@@ -6,12 +6,16 @@ const {
   mockApproveVacation,
   mockCreateVacationEvent,
   mockAssertApprovalWithinQuota,
+  mockGetGroupUser,
+  mockHasMirrorIntoGroup,
 } = vi.hoisted(() => ({
   mockGetVacationById: vi.fn(),
   mockGetGroupsWhereUserCanApprove: vi.fn(),
   mockApproveVacation: vi.fn(),
   mockCreateVacationEvent: vi.fn(),
   mockAssertApprovalWithinQuota: vi.fn(),
+  mockGetGroupUser: vi.fn(),
+  mockHasMirrorIntoGroup: vi.fn(),
 }));
 
 vi.mock("../../../middleware/authSession.js", () => ({
@@ -35,6 +39,12 @@ vi.mock("../../../services/DBServices.js", () => ({
     },
     vacationEvent: {
       createVacationEvent: mockCreateVacationEvent,
+    },
+    groupUser: {
+      getGroupUser: mockGetGroupUser,
+    },
+    groupMirror: {
+      hasMirrorIntoGroup: mockHasMirrorIntoGroup,
     },
   }),
 }));
@@ -71,6 +81,8 @@ describe("handlePostVacationApproval", () => {
     (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
     mockGetGroupsWhereUserCanApprove.mockResolvedValue(["group_123"]);
     mockAssertApprovalWithinQuota.mockResolvedValue(undefined);
+    mockGetGroupUser.mockResolvedValue({ approverAccess: false });
+    mockHasMirrorIntoGroup.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -139,10 +151,38 @@ describe("handlePostVacationApproval", () => {
     expect(mockApproveVacation).not.toHaveBeenCalled();
   });
 
-  it("refuses an approver deciding on their own request", async () => {
+  it("refuses a role-based approver deciding on their own request", async () => {
     const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
 
     mockGetVacationById.mockResolvedValue(pendingVacation({ userId: "user_123" }));
+
+    await expect(handlePostVacationApproval(req, res)).rejects.toThrow(
+      "You cannot decide on your own leave request"
+    );
+    expect(mockApproveVacation).not.toHaveBeenCalled();
+  });
+
+  it("lets a member with approverAccess decide on their own request", async () => {
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
+
+    mockGetVacationById.mockResolvedValue(pendingVacation({ userId: "user_123" }));
+    mockApproveVacation.mockResolvedValue(
+      pendingVacation({ userId: "user_123", approvedAt: new Date() })
+    );
+    mockGetGroupUser.mockResolvedValue({ approverAccess: true });
+
+    await handlePostVacationApproval(req, res);
+
+    expect(mockApproveVacation).toHaveBeenCalledWith(VACATION_ID, "user_123", {});
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("still refuses their own request when their records are mirrored into the group", async () => {
+    const { req, res } = makeReqRes({ params: { id: VACATION_ID } });
+
+    mockGetVacationById.mockResolvedValue(pendingVacation({ userId: "user_123" }));
+    mockGetGroupUser.mockResolvedValue({ approverAccess: true });
+    mockHasMirrorIntoGroup.mockResolvedValue(true);
 
     await expect(handlePostVacationApproval(req, res)).rejects.toThrow(
       "You cannot decide on your own leave request"

--- a/src/controllers/vacation/utils.ts
+++ b/src/controllers/vacation/utils.ts
@@ -1,6 +1,7 @@
 import { createDBServices } from "../../services/DBServices.js";
 import type { DbTransaction } from "../../db/db.js";
 import type { VacationType } from "../../services/vacation/types.js";
+import { mayDecideOwn } from "./decisionGuards.js";
 
 const services = createDBServices();
 
@@ -37,10 +38,44 @@ export const resolveVacationPermissions = async (
   // A decision is final; re-deciding would overturn it and wipe its stamps.
   const isDecidable =
     !isCancelled && vacationRow.approvedAt === null && vacationRow.rejectedAt === null;
+  const ownAllowed =
+    isOwner && isApprover ? await mayDecideOwn(userId, vacationRow.groupId, tx) : false;
 
   return {
     canView: isOwner || isApprover || (membership?.viewAccess ?? false),
-    canApprove: isApprover && !isOwner && isDecidable,
+    canApprove: isApprover && isDecidable && (!isOwner || ownAllowed),
     canCancel: !isCancelled && (isOwner || isAdmin || isApprover),
+  };
+};
+
+type DecidableRow = Pick<
+  VacationType,
+  "userId" | "groupId" | "deletedAt" | "approvedAt" | "rejectedAt"
+>;
+
+/**
+ * The same `canApprove` verdict as {@link resolveVacationPermissions}, for a
+ * whole list in a fixed number of queries.
+ */
+export const resolveCanApproveForList = async <T extends DecidableRow>(
+  userId: string,
+  rows: T[]
+): Promise<(row: T) => boolean> => {
+  const groupIds = Array.from(new Set(rows.map((row) => row.groupId)));
+  const approvable = new Set(await services.group.getGroupsWhereUserCanApprove(groupIds, userId));
+
+  const ownGroupIds = Array.from(
+    new Set(rows.filter((row) => row.userId === userId).map((row) => row.groupId))
+  ).filter((groupId) => approvable.has(groupId));
+
+  const selfDecidable = new Set<string>();
+  for (const groupId of ownGroupIds) {
+    if (await mayDecideOwn(userId, groupId)) selfDecidable.add(groupId);
+  }
+
+  return (row) => {
+    if (!approvable.has(row.groupId)) return false;
+    if (row.deletedAt !== null || row.approvedAt !== null || row.rejectedAt !== null) return false;
+    return row.userId !== userId || selfDecidable.has(row.groupId);
   };
 };

--- a/src/db/schema/group-users-schema.ts
+++ b/src/db/schema/group-users-schema.ts
@@ -15,6 +15,7 @@ export const groupUsers = pgTable(
       .references(() => user.id, { onDelete: "cascade" }),
     viewAccess: boolean("view_access").notNull().default(false),
     adminAccess: boolean("admin_access").notNull().default(false),
+    approverAccess: boolean("approver_access").notNull().default(false),
     controlledUser: boolean("controlled_user").notNull().default(false),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),

--- a/src/db/schema/out/0011_lovely_angel.sql
+++ b/src/db/schema/out/0011_lovely_angel.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "group_users" ADD COLUMN "approver_access" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+-- Backfill: whoever could already approve for a group keeps that right.
+UPDATE "group_users" AS gu
+SET "approver_access" = true
+FROM "groups" AS g
+WHERE g."id" = gu."group_id"
+  AND gu."deleted_at" IS NULL
+  AND g."deleted_at" IS NULL
+  AND gu."user_id" IN (g."manager_user_id", g."main_approval_user", g."temp_approval_user");

--- a/src/db/schema/out/meta/0011_snapshot.json
+++ b/src/db/schema/out/meta/0011_snapshot.json
@@ -1,0 +1,2300 @@
+{
+  "id": "de3e41e9-2f01-404a-b47f-9ec9e64e18ae",
+  "prevId": "17a393e0-9d14-4549-b75e-ad8944071f6b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_mirrors": {
+      "name": "group_mirrors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_group_id": {
+          "name": "target_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_mirrors_user_source_target_uniq": {
+          "name": "group_mirrors_user_source_target_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_mirrors\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_target_group_id": {
+          "name": "idx_group_mirrors_target_group_id",
+          "columns": [
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_user_id": {
+          "name": "idx_group_mirrors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_mirrors_user_id_user_id_fk": {
+          "name": "group_mirrors_user_id_user_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_source_group_id_groups_id_fk": {
+          "name": "group_mirrors_source_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_target_group_id_groups_id_fk": {
+          "name": "group_mirrors_target_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "target_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approver_access": {
+          "name": "approver_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invite_link_group_id": {
+          "name": "idx_invite_link_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_group_email_open_uniq": {
+          "name": "invite_link_group_email_open_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_link\".\"used_at\" IS NULL AND \"invite_link\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_link_invited_by_user_id_user_id_fk": {
+          "name": "invite_link_invited_by_user_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_exports_user_id_idx": {
+          "name": "report_exports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_exports_created_at_idx": {
+          "name": "report_exports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_user_id_user_id_fk": {
+          "name": "report_exports_user_id_user_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboard_scope": {
+          "name": "dashboard_scope",
+          "type": "dashboard_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MINE'"
+        },
+        "dashboard_group_id": {
+          "name": "dashboard_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_settings_dashboard_group_id_groups_id_fk": {
+          "name": "user_settings_dashboard_group_id_groups_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "dashboard_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "carried_over_days": {
+          "name": "carried_over_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        },
+        "user_year_quotas_related_year_range_chk": {
+          "name": "user_year_quotas_related_year_range_chk",
+          "value": "\"user_year_quotas\".\"related_year\"::int BETWEEN 2025 AND 2100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "half_day": {
+          "name": "half_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vacation\".\"deleted_at\" IS NULL AND \"vacation\".\"rejected_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.dashboard_scope": {
+      "name": "dashboard_scope",
+      "schema": "public",
+      "values": [
+        "MINE",
+        "GROUP"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/_journal.json
+++ b/src/db/schema/out/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785702279380,
       "tag": "0010_boring_rachel_grey",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1786177874843,
+      "tag": "0011_lovely_angel",
+      "breakpoints": true
     }
   ]
 }

--- a/src/routes/groupRouter.ts
+++ b/src/routes/groupRouter.ts
@@ -127,11 +127,15 @@ export const groupRouter = (): Router => {
    *   get:
    *     tags:
    *       - Groups
-   *     summary: The caller's mirroring setup for this group
+   *     summary: The mirroring setup for this group
    *     description: |
-   *       Lists every other group the caller belongs to and whether their
-   *       records from it are currently shown inside this group. Mirroring is a
-   *       per-user choice, so this only ever describes the caller.
+   *       For a group admin, every member together with the source groups their
+   *       records may be projected from — the groups the acting admin also
+   *       administers and the member belongs to — and whether each is currently
+   *       mirrored. A candidate with `manageable: false` is an active mirror
+   *       from a group the caller does not administer: shown for completeness,
+   *       not theirs to change. For anyone else, `canManage` is false and the
+   *       response carries only their own mirrors, read-only.
    *     security:
    *       - bearerAuth: []
    *     parameters:
@@ -143,19 +147,22 @@ export const groupRouter = (): Router => {
    *           format: uuid
    *     responses:
    *       '200':
-   *         description: Candidate source groups with their mirrored state
+   *         description: Members with their candidate source groups
    *       '403':
    *         description: Caller does not belong to the group
    *   put:
    *     tags:
    *       - Groups
-   *     summary: Set which groups the caller mirrors into this one
+   *     summary: Set which groups a member is mirrored from into this one
    *     description: |
-   *       Replaces the caller's mirror sources for this group. Mirrored records
-   *       are shown here read-only: they are approved, counted against quotas
-   *       and reported in their source group alone, and never need a decision
-   *       in this one. The caller must belong to the target and to every source
-   *       group; an empty array turns mirroring off.
+   *       Replaces one member's mirror sources for this group, within the
+   *       sources the caller administers — mirrors from other groups are left
+   *       untouched. Mirrored records are shown here read-only: they are
+   *       approved, counted against quotas and reported in their source group
+   *       alone, and never need a decision in this one. Requires admin access on
+   *       the target group and on every source group named, and the member must
+   *       belong to all of them. An empty array turns the caller's manageable
+   *       mirrors off.
    *     security:
    *       - bearerAuth: []
    *     parameters:
@@ -172,8 +179,11 @@ export const groupRouter = (): Router => {
    *           schema:
    *             type: object
    *             required:
+   *               - userId
    *               - sourceGroupIds
    *             properties:
+   *               userId:
+   *                 type: string
    *               sourceGroupIds:
    *                 type: array
    *                 items:
@@ -181,11 +191,11 @@ export const groupRouter = (): Router => {
    *                   format: uuid
    *     responses:
    *       '200':
-   *         description: The caller's mirrors into this group after the update
+   *         description: The member's mirrors into this group after the update
    *       '403':
-   *         description: Caller does not belong to the target or a source group
+   *         description: Caller is not an admin of the target or of a source group
    *       '422':
-   *         description: A group cannot mirror itself
+   *         description: A group cannot mirror itself, or the member does not belong to a named group
    */
   /**
    * @openapi

--- a/src/routes/groupUsersRouter.ts
+++ b/src/routes/groupUsersRouter.ts
@@ -154,6 +154,65 @@ export const groupUsersRouter = (): Router => {
     tryCatch(handlePostGroupInvite)
   );
 
+  /**
+   * @openapi
+   * /api/group-user:
+   *   put:
+   *     tags:
+   *       - Group members
+   *     summary: Update members' permissions in a group
+   *     description: |
+   *       Sets the four membership flags for one or more members at once.
+   *       Requires admin access on the group. The flags are independent:
+   *       `adminAccess` manages the group (members, quotas, invites, working
+   *       days, mirroring) but does not decide on leave, and `approverAccess`
+   *       decides on leave but manages nothing. `controlledUser` marks a member
+   *       whose time off is tracked; `viewAccess` lets them see the group's
+   *       records.
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - groupId
+   *               - data
+   *             properties:
+   *               groupId:
+   *                 type: string
+   *                 format: uuid
+   *               data:
+   *                 type: array
+   *                 items:
+   *                   type: object
+   *                   required:
+   *                     - userId
+   *                     - viewAccess
+   *                     - adminAccess
+   *                     - approverAccess
+   *                     - controlledUser
+   *                   properties:
+   *                     userId:
+   *                       type: string
+   *                     viewAccess:
+   *                       type: boolean
+   *                     adminAccess:
+   *                       type: boolean
+   *                     approverAccess:
+   *                       type: boolean
+   *                     controlledUser:
+   *                       type: boolean
+   *     responses:
+   *       '200':
+   *         description: Permissions updated
+   *       '400':
+   *         description: A named member does not belong to the group
+   *       '403':
+   *         description: No permission for related group
+   */
   app.put(
     "/",
     bodyValidationMiddleware(validatePutGroupUserUpdate),

--- a/src/routes/vacationRouter.ts
+++ b/src/routes/vacationRouter.ts
@@ -40,7 +40,9 @@ export const vacationRouter = (): Router => {
    *
    *       Group scope requires view access on that group (view access, admin
    *       access, or being its manager); a plain member gets a 403.
-   *       Each row includes a denormalized `user` summary used by the calendar UI.
+   *       Each row includes a denormalized `user` summary used by the calendar UI,
+   *       and `canApprove` — the same verdict the decision endpoints enforce, so
+   *       a client can render the action without re-deriving the rule.
    *     operationId: handleGetVacations
    *     security:
    *       - bearerAuth: []
@@ -110,6 +112,9 @@ export const vacationRouter = (): Router => {
    *             mirroredFromGroupName:
    *               type: string
    *               nullable: true
+   *             canApprove:
+   *               type: boolean
+   *               description: Whether the caller may decide on this request right now.
    */
   app.get("/", tryCatch(handleGetVacations));
 

--- a/src/services/DBServices.ts
+++ b/src/services/DBServices.ts
@@ -46,6 +46,8 @@ export type DBServices = Readonly<{
     updateGroupUserPermissions: typeof groupUserServices.updateGroupUserPermissions;
     deleteGroupUser: typeof groupUserServices.deleteGroupUser;
     getAllGroupsForUser: typeof groupUserServices.getAllGroupsForUser;
+    getAdminGroupIdsForUser: typeof groupUserServices.getAdminGroupIdsForUser;
+    getMembershipPairs: typeof groupUserServices.getMembershipPairs;
     countDistinctUsersInGroups: typeof groupUserServices.countDistinctUsersInGroups;
   };
   inviteLinks: {
@@ -72,7 +74,9 @@ export type DBServices = Readonly<{
   };
   groupMirror: {
     getMirrorsIntoGroupForUser: typeof groupMirrorServices.getMirrorsIntoGroupForUser;
+    getMirrorsIntoGroupForUsers: typeof groupMirrorServices.getMirrorsIntoGroupForUsers;
     getMirrorsForUser: typeof groupMirrorServices.getMirrorsForUser;
+    hasMirrorIntoGroup: typeof groupMirrorServices.hasMirrorIntoGroup;
     setMirrorsIntoGroupForUser: typeof groupMirrorServices.setMirrorsIntoGroupForUser;
   };
   userYearQuotas: {
@@ -172,6 +176,8 @@ export const createDBServices = (): DBServices => {
       updateGroupUserPermissions: groupUserServices.updateGroupUserPermissions,
       deleteGroupUser: groupUserServices.deleteGroupUser,
       getAllGroupsForUser: groupUserServices.getAllGroupsForUser,
+      getAdminGroupIdsForUser: groupUserServices.getAdminGroupIdsForUser,
+      getMembershipPairs: groupUserServices.getMembershipPairs,
       countDistinctUsersInGroups: groupUserServices.countDistinctUsersInGroups,
     },
     inviteLinks: {
@@ -198,7 +204,9 @@ export const createDBServices = (): DBServices => {
     },
     groupMirror: {
       getMirrorsIntoGroupForUser: groupMirrorServices.getMirrorsIntoGroupForUser,
+      getMirrorsIntoGroupForUsers: groupMirrorServices.getMirrorsIntoGroupForUsers,
       getMirrorsForUser: groupMirrorServices.getMirrorsForUser,
+      hasMirrorIntoGroup: groupMirrorServices.hasMirrorIntoGroup,
       setMirrorsIntoGroupForUser: groupMirrorServices.setMirrorsIntoGroupForUser,
     },
     userYearQuotas: {

--- a/src/services/dev/devSeedServices.ts
+++ b/src/services/dev/devSeedServices.ts
@@ -143,6 +143,7 @@ export const addMember = async (input: {
   userId: string;
   groupId: string;
   adminAccess?: boolean;
+  approverAccess?: boolean;
 }): Promise<void> => {
   await services.groupUser.createGroupUser({
     id: generateRandomUUID(),
@@ -150,6 +151,7 @@ export const addMember = async (input: {
     groupId: input.groupId,
     viewAccess: true,
     adminAccess: input.adminAccess ?? false,
+    approverAccess: input.approverAccess ?? false,
     controlledUser: true,
   });
 };
@@ -197,9 +199,9 @@ export const addVacation = async (input: {
       vacationType: input.type ?? vacationType.Vacation,
       note: input.note,
       approvedAt: input.state === "approved" ? now : null,
-      approvedBy: input.state === "approved" ? (input.actorUserId ?? null) : null,
+      approvedBy: input.state === "approved" ? input.actorUserId ?? null : null,
       rejectedAt: input.state === "rejected" ? now : null,
-      rejectedBy: input.state === "rejected" ? (input.actorUserId ?? null) : null,
+      rejectedBy: input.state === "rejected" ? input.actorUserId ?? null : null,
       rejectionReason: input.state === "rejected" ? "Team coverage on that day" : null,
       createdAt: now,
       updatedAt: now,

--- a/src/services/group/groupServices.ts
+++ b/src/services/group/groupServices.ts
@@ -3,6 +3,7 @@ import { db, type DbTransaction } from "../../db/db.js";
 import { groups } from "../../db/schema/group-schema.js";
 import { and, eq, inArray, isNull, or } from "drizzle-orm";
 import { user } from "../../db/schema/auth-schema.js";
+import { groupUsers } from "../../db/schema/group-users-schema.js";
 import { alias } from "drizzle-orm/pg-core";
 
 export const getGroup = async (
@@ -122,7 +123,8 @@ type GroupApprovalUsersType = {
 
 /**
  * Returns the subset of supplied group ids on which the given user is an
- * authorized approver (manager, main, or temp approver). Used by bulk
+ * authorized approver: the group's manager, its main or temp approver, or a
+ * member whose membership carries `approverAccess`. Used by bulk
  * approve/reject to verify the caller can act on every distinct group in a
  * batch in a single query.
  */
@@ -135,6 +137,14 @@ export const getGroupsWhereUserCanApprove = async (
   const rows = await (tx ?? db)
     .select({ id: groups.id })
     .from(groups)
+    .leftJoin(
+      groupUsers,
+      and(
+        eq(groupUsers.groupId, groups.id),
+        eq(groupUsers.userId, approverUserId),
+        isNull(groupUsers.deletedAt)
+      )
+    )
     .where(
       and(
         inArray(groups.id, groupIds),
@@ -142,7 +152,8 @@ export const getGroupsWhereUserCanApprove = async (
         or(
           eq(groups.managerUserId, approverUserId),
           eq(groups.mainApprovalUser, approverUserId),
-          eq(groups.tempApprovalUser, approverUserId)
+          eq(groups.tempApprovalUser, approverUserId),
+          eq(groupUsers.approverAccess, true)
         )
       )
     );

--- a/src/services/groupMirror/groupMirrorServices.ts
+++ b/src/services/groupMirror/groupMirrorServices.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, notInArray } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import { db, type DbTransaction } from "../../db/db.js";
 import { groupMirrors } from "../../db/schema/group-mirror-schema.js";
 import { groups } from "../../db/schema/group-schema.js";
@@ -44,16 +44,64 @@ export const getMirrorsForUser = async (userId: string): Promise<GroupMirror[]> 
     .where(and(eq(groupMirrors.userId, userId), isNull(groupMirrors.deletedAt)));
 };
 
+/** Whether the user's records are projected into this group from elsewhere. */
+export const hasMirrorIntoGroup = async (
+  userId: string,
+  targetGroupId: string,
+  tx?: DbTransaction
+): Promise<boolean> => {
+  const [row] = await (tx ?? db)
+    .select({ id: groupMirrors.id })
+    .from(groupMirrors)
+    .where(
+      and(
+        eq(groupMirrors.userId, userId),
+        eq(groupMirrors.targetGroupId, targetGroupId),
+        isNull(groupMirrors.deletedAt)
+      )
+    )
+    .limit(1);
+
+  return row !== undefined;
+};
+
+/** The active mirror sources for several members of one group, at once. */
+export const getMirrorsIntoGroupForUsers = async (
+  userIds: string[],
+  targetGroupId: string,
+  tx?: DbTransaction
+): Promise<{ userId: string; sourceGroupId: string; sourceGroupName: string }[]> => {
+  if (userIds.length === 0) return [];
+  return (tx ?? db)
+    .select({
+      userId: groupMirrors.userId,
+      sourceGroupId: groupMirrors.sourceGroupId,
+      sourceGroupName: groups.groupName,
+    })
+    .from(groupMirrors)
+    .innerJoin(groups, eq(groupMirrors.sourceGroupId, groups.id))
+    .where(
+      and(
+        inArray(groupMirrors.userId, userIds),
+        eq(groupMirrors.targetGroupId, targetGroupId),
+        isNull(groupMirrors.deletedAt),
+        isNull(groups.deletedAt)
+      )
+    );
+};
+
 /**
- * Makes the user's mirrors into `targetGroupId` exactly `sourceGroupIds`.
- * Diffed rather than wiped and re-inserted so an untouched mirror keeps its
- * original `createdAt`. Callers must have already verified the user is an
- * active member of the target and of every source group.
+ * Makes the user's mirrors into `targetGroupId` exactly `sourceGroupIds`,
+ * *within* `manageableSourceGroupIds` — an admin sees only some of a member's
+ * groups, and the rest must survive a save rather than read as a removal.
+ * Diffed rather than wiped so an untouched mirror keeps its `createdAt`.
+ * Callers must have already verified membership of the target and every source.
  */
 export const setMirrorsIntoGroupForUser = async (
   userId: string,
   targetGroupId: string,
   sourceGroupIds: string[],
+  manageableSourceGroupIds: string[],
   tx?: DbTransaction
 ): Promise<GroupMirrorListItem[]> => {
   const runner = tx ?? db;
@@ -71,20 +119,23 @@ export const setMirrorsIntoGroupForUser = async (
 
   const existingIds = new Set(existing.map((row) => row.sourceGroupId));
 
-  const removedBase = and(
-    eq(groupMirrors.userId, userId),
-    eq(groupMirrors.targetGroupId, targetGroupId),
-    isNull(groupMirrors.deletedAt)
+  const removed = manageableSourceGroupIds.filter(
+    (id) => existingIds.has(id) && !sourceGroupIds.includes(id)
   );
 
-  await runner
-    .update(groupMirrors)
-    .set({ deletedAt: new Date() })
-    .where(
-      sourceGroupIds.length === 0
-        ? removedBase
-        : and(removedBase, notInArray(groupMirrors.sourceGroupId, sourceGroupIds))
-    );
+  if (removed.length > 0) {
+    await runner
+      .update(groupMirrors)
+      .set({ deletedAt: new Date() })
+      .where(
+        and(
+          eq(groupMirrors.userId, userId),
+          eq(groupMirrors.targetGroupId, targetGroupId),
+          isNull(groupMirrors.deletedAt),
+          inArray(groupMirrors.sourceGroupId, removed)
+        )
+      );
+  }
 
   const added = sourceGroupIds.filter((id) => !existingIds.has(id));
 

--- a/src/services/groupMirror/types.ts
+++ b/src/services/groupMirror/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { UserSummary } from "../../utils/userPresentation.js";
 
 export type GroupMirror = {
   id: string;
@@ -16,16 +17,28 @@ export type GroupMirrorListItem = GroupMirror & {
 };
 
 /**
- * One of the caller's other groups, and whether its records are currently
- * mirrored into the group being configured.
+ * A group a member's records could be projected from, and whether they
+ * currently are. `manageable` is false for a source the viewer does not
+ * administer: shown for completeness, not theirs to change.
  */
 export type MirrorCandidate = {
   groupId: string;
   groupName: string;
   mirrored: boolean;
+  manageable: boolean;
+};
+
+/** One member of the group being configured, with their mirror sources. */
+export type MirrorMember = {
+  userId: string;
+  user: UserSummary;
+  email: string;
+  candidates: MirrorCandidate[];
 };
 
 export const validatePutGroupMirrors = z.object({
+  // better-auth user ids are opaque non-UUID strings.
+  userId: z.string().min(1),
   sourceGroupIds: z
     .array(z.uuid())
     .max(50)

--- a/src/services/groupUser/groupUserServices.ts
+++ b/src/services/groupUser/groupUserServices.ts
@@ -86,6 +86,44 @@ export const getAllGroupsForUser = async (userId: string): Promise<{ groupId: st
     .where(and(eq(groupUsers.userId, userId), isNull(groupUsers.deletedAt)));
 };
 
+/** The groups the user administers — the reach of any admin-only action. */
+export const getAdminGroupIdsForUser = async (
+  userId: string,
+  tx?: DbTransaction
+): Promise<string[]> => {
+  const rows = await (tx ?? db)
+    .select({ groupId: groupUsers.groupId })
+    .from(groupUsers)
+    .where(
+      and(
+        eq(groupUsers.userId, userId),
+        eq(groupUsers.adminAccess, true),
+        isNull(groupUsers.deletedAt)
+      )
+    );
+
+  return rows.map((row) => row.groupId);
+};
+
+/** Active (user, group) membership pairs, for cross-referencing many at once. */
+export const getMembershipPairs = async (
+  userIds: string[],
+  groupIds: string[],
+  tx?: DbTransaction
+): Promise<{ userId: string; groupId: string }[]> => {
+  if (userIds.length === 0 || groupIds.length === 0) return [];
+  return (tx ?? db)
+    .select({ userId: groupUsers.userId, groupId: groupUsers.groupId })
+    .from(groupUsers)
+    .where(
+      and(
+        inArray(groupUsers.userId, userIds),
+        inArray(groupUsers.groupId, groupIds),
+        isNull(groupUsers.deletedAt)
+      )
+    );
+};
+
 /**
  * Lists the active members of a group together with their identity, so the
  * members screen can show names instead of raw user ids.
@@ -98,6 +136,7 @@ export const getGroupUsers = async (groupId: string): Promise<GroupUserListItem[
       userId: groupUsers.userId,
       viewAccess: groupUsers.viewAccess,
       adminAccess: groupUsers.adminAccess,
+      approverAccess: groupUsers.approverAccess,
       controlledUser: groupUsers.controlledUser,
       deletedAt: groupUsers.deletedAt,
       createdAt: groupUsers.createdAt,

--- a/src/services/groupUser/types.ts
+++ b/src/services/groupUser/types.ts
@@ -7,6 +7,7 @@ export type GroupUser = {
   userId: string;
   viewAccess: boolean;
   adminAccess: boolean;
+  approverAccess: boolean;
   controlledUser: boolean;
   deletedAt: Date | null;
   createdAt: Date;
@@ -19,10 +20,14 @@ export type GroupUserInsertType = {
   userId: string;
   viewAccess?: boolean;
   adminAccess?: boolean;
+  approverAccess?: boolean;
   controlledUser?: boolean;
 };
 
-export type GroupUserPermissions = Pick<GroupUser, "viewAccess" | "adminAccess" | "controlledUser">;
+export type GroupUserPermissions = Pick<
+  GroupUser,
+  "viewAccess" | "adminAccess" | "approverAccess" | "controlledUser"
+>;
 
 /**
  * A membership row enriched with the member's identity. The members list is
@@ -76,6 +81,7 @@ export const validatePutGroupUserUpdate = z.object({
       userId: z.string().min(1),
       viewAccess: z.boolean(),
       adminAccess: z.boolean(),
+      approverAccess: z.boolean(),
       controlledUser: z.boolean(),
     })
   ),

--- a/src/services/vacation/tests/vacationNotifier.test.ts
+++ b/src/services/vacation/tests/vacationNotifier.test.ts
@@ -7,6 +7,7 @@ const {
   mockGetApprovalUsers,
   mockGetUsersByIds,
   mockGetUserById,
+  mockGetGroupUsers,
 } = vi.hoisted(() => ({
   mockSendTemplated: vi.fn(),
   mockFilterUsersAcceptingEmail: vi.fn(),
@@ -14,6 +15,7 @@ const {
   mockGetApprovalUsers: vi.fn(),
   mockGetUsersByIds: vi.fn(),
   mockGetUserById: vi.fn(),
+  mockGetGroupUsers: vi.fn(),
 }));
 
 vi.mock("../../email/index.js", () => ({
@@ -25,6 +27,7 @@ vi.mock("../../DBServices.js", () => ({
     userSettings: { filterUsersAcceptingEmail: mockFilterUsersAcceptingEmail },
     notification: { createNotification: mockCreateNotification },
     group: { getApprovalUsers: mockGetApprovalUsers },
+    groupUser: { getGroupUsers: mockGetGroupUsers },
     user: { getUsersByIds: mockGetUsersByIds, getUserById: mockGetUserById },
   }),
 }));
@@ -83,6 +86,7 @@ describe("vacation notifier", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetApprovalUsers.mockResolvedValue(group);
+    mockGetGroupUsers.mockResolvedValue([]);
     mockFilterUsersAcceptingEmail.mockImplementation((ids: string[]) => new Set(ids));
   });
 
@@ -106,6 +110,41 @@ describe("vacation notifier", () => {
       }),
     });
     expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("also reaches members holding approverAccess, and only once each", async () => {
+    mockGetGroupUsers.mockResolvedValue([
+      // Already the main approver: must not be mailed twice.
+      {
+        userId: "approver-1",
+        approverAccess: true,
+        email: "ada@example.com",
+        user: { name: "Ada Lovelace" },
+      },
+      {
+        userId: "approver-2",
+        approverAccess: true,
+        email: "grace@example.com",
+        user: { name: "Grace Hopper" },
+      },
+      {
+        userId: "member-3",
+        approverAccess: false,
+        email: "bob@example.com",
+        user: { name: "Bob Dvorak" },
+      },
+      {
+        userId: "employee-1",
+        approverAccess: true,
+        email: "dana@example.com",
+        user: { name: "Dana Holt" },
+      },
+    ]);
+
+    await notifyVacationRequested([row()], { id: "employee-1", name: "Dana Holt" }, null);
+
+    const recipients = mockSendTemplated.mock.calls.map(([email]) => (email as { to: string }).to);
+    expect(recipients.sort()).toEqual(["ada@example.com", "grace@example.com"]);
   });
 
   it("substitutes a dash for an empty note so SES never renders a blank", async () => {

--- a/src/services/vacation/vacationNotifier.ts
+++ b/src/services/vacation/vacationNotifier.ts
@@ -135,6 +135,39 @@ const deliver = async (deliveries: Delivery[]): Promise<void> => {
 };
 
 /**
+ * Everyone who can decide for a group: the named main and temp approver plus
+ * every member holding `approverAccess`, de-duplicated and with
+ * `excludeUserId` dropped.
+ */
+const approverContacts = async (
+  group: NonNullable<Awaited<ReturnType<typeof services.group.getApprovalUsers>>>,
+  excludeUserId: string
+): Promise<UserContact[]> => {
+  const members = await services.groupUser.getGroupUsers(group.groupId);
+
+  const candidates = [
+    {
+      id: group.mainApprovalUserId,
+      name: group.mainApprovalUserName,
+      email: group.mainApprovalUserEmail,
+    },
+    {
+      id: group.tempApprovalUserId,
+      name: group.tempApprovalUserName,
+      email: group.tempApprovalUserEmail,
+    },
+    ...members
+      .filter((member) => member.approverAccess)
+      .map((member) => ({ id: member.userId, name: member.user.name, email: member.email })),
+  ].filter(
+    (a): a is UserContact =>
+      Boolean(a.id) && Boolean(a.name) && Boolean(a.email) && a.id !== excludeUserId
+  );
+
+  return [...new Map(candidates.map((a) => [a.id, a])).values()];
+};
+
+/**
  * Notifies the group's approvers that a new request needs a decision.
  * Called after the rows are committed.
  */
@@ -147,31 +180,15 @@ export const notifyVacationRequested = async (
     const summary = summarize(rows);
     if (!summary) return;
 
-    const group = await services.group.getApprovalUsers(rows[0]?.groupId ?? "");
+    const groupId = rows[0]?.groupId ?? "";
+    const group = await services.group.getApprovalUsers(groupId);
     if (!group) return;
 
-    const approvers = [
-      {
-        id: group.mainApprovalUserId,
-        name: group.mainApprovalUserName,
-        email: group.mainApprovalUserEmail,
-      },
-      {
-        id: group.tempApprovalUserId,
-        name: group.tempApprovalUserName,
-        email: group.tempApprovalUserEmail,
-      },
-    ].filter(
-      (a): a is { id: string; name: string; email: string } =>
-        Boolean(a.id) && Boolean(a.name) && Boolean(a.email) && a.id !== requester.id
-    );
-
-    // De-duplicate: main and temp approver are often the same person.
-    const unique = new Map(approvers.map((a) => [a.id, a]));
-    if (unique.size === 0) return;
+    const unique = await approverContacts(group, requester.id);
+    if (unique.length === 0) return;
 
     await deliver(
-      [...unique.values()].map((approver) => ({
+      unique.map((approver) => ({
         userId: approver.id,
         email: {
           to: approver.email,
@@ -287,21 +304,7 @@ export const notifyVacationComment = async (
 
     const recipients: UserContact[] =
       actor.id === row.userId
-        ? [
-            {
-              id: group.mainApprovalUserId,
-              name: group.mainApprovalUserName,
-              email: group.mainApprovalUserEmail,
-            },
-            {
-              id: group.tempApprovalUserId,
-              name: group.tempApprovalUserName,
-              email: group.tempApprovalUserEmail,
-            },
-          ].filter(
-            (a): a is UserContact =>
-              Boolean(a.id) && Boolean(a.name) && Boolean(a.email) && a.id !== actor.id
-          )
+        ? await approverContacts(group, actor.id)
         : [employee].filter((e) => e.id !== actor.id);
 
     const unique = [...new Map(recipients.map((r) => [r.id, r])).values()];
@@ -362,23 +365,7 @@ export const notifyVacationCancelled = async (
     if (!employee) return;
 
     const recipients: UserContact[] =
-      actor.id === row.userId
-        ? [
-            {
-              id: group.mainApprovalUserId,
-              name: group.mainApprovalUserName,
-              email: group.mainApprovalUserEmail,
-            },
-            {
-              id: group.tempApprovalUserId,
-              name: group.tempApprovalUserName,
-              email: group.tempApprovalUserEmail,
-            },
-          ].filter(
-            (a): a is UserContact =>
-              Boolean(a.id) && Boolean(a.name) && Boolean(a.email) && a.id !== actor.id
-          )
-        : [employee];
+      actor.id === row.userId ? await approverContacts(group, actor.id) : [employee];
 
     const unique = [...new Map(recipients.map((r) => [r.id, r])).values()];
 

--- a/src/services/vacation/vacationServices.ts
+++ b/src/services/vacation/vacationServices.ts
@@ -15,6 +15,7 @@ import {
   lt,
   lte,
   ne,
+  not,
   notInArray,
   or,
   sql,
@@ -524,14 +525,30 @@ export type PendingApprovalRow = {
 
 /**
  * Returns pending (not yet approved, not rejected, not deleted) vacation rows
- * for groups where the caller is a manager / main approver / temp approver.
- * Rows are ordered by user/group/day so the caller can collapse contiguous
- * ranges into single approval entries. The approver's own requests are
- * excluded — the decision endpoints refuse them.
+ * for groups where the caller may approve — as manager / main approver / temp
+ * approver, or through the `approverAccess` membership flag. Rows are ordered
+ * by user/group/day so the caller can collapse contiguous ranges into single
+ * approval entries. The caller's own requests appear only where the decision
+ * endpoints would accept them (see `mayDecideOwn`).
  */
 export const getPendingApprovalsForApprover = async (
   approverUserId: string
 ): Promise<PendingApprovalRow[]> => {
+  const approverMembership = alias(groupUsers, "approverMembership");
+
+  const mirroredIntoGroup = exists(
+    db
+      .select({ one: sql`1` })
+      .from(groupMirrors)
+      .where(
+        and(
+          eq(groupMirrors.userId, approverUserId),
+          eq(groupMirrors.targetGroupId, vacation.groupId),
+          isNull(groupMirrors.deletedAt)
+        )
+      )
+  );
+
   return db
     .select({
       vacationId: vacation.id,
@@ -547,17 +564,29 @@ export const getPendingApprovalsForApprover = async (
     .from(vacation)
     .innerJoin(groups, eq(vacation.groupId, groups.id))
     .innerJoin(user, eq(vacation.userId, user.id))
+    .leftJoin(
+      approverMembership,
+      and(
+        eq(approverMembership.groupId, groups.id),
+        eq(approverMembership.userId, approverUserId),
+        isNull(approverMembership.deletedAt)
+      )
+    )
     .where(
       and(
         isNull(vacation.deletedAt),
         isNull(vacation.approvedAt),
         isNull(vacation.rejectedAt),
         isNull(groups.deletedAt),
-        ne(vacation.userId, approverUserId),
+        or(
+          ne(vacation.userId, approverUserId),
+          and(eq(approverMembership.approverAccess, true), not(mirroredIntoGroup))
+        ),
         or(
           eq(groups.managerUserId, approverUserId),
           eq(groups.mainApprovalUser, approverUserId),
-          eq(groups.tempApprovalUser, approverUserId)
+          eq(groups.tempApprovalUser, approverUserId),
+          eq(approverMembership.approverAccess, true)
         )
       )
     )

--- a/src/tests/e2e/groupMirror.e2e.test.ts
+++ b/src/tests/e2e/groupMirror.e2e.test.ts
@@ -46,6 +46,9 @@ describe("group mirroring", () => {
       .delete(groupUsers)
       .where(and(eq(groupUsers.userId, userId), eq(groupUsers.groupId, groupId)));
 
+  const setMirrors = (sourceGroupIds: string[], manageable: string[] = [teamA.id]) =>
+    setMirrorsIntoGroupForUser(dana.id, allEng.id, sourceGroupIds, manageable);
+
   const book = (userId: string, groupId: string, day: string, approved = true) =>
     db.insert(vacation).values({
       id: uuidv4(),
@@ -91,7 +94,7 @@ describe("group mirroring", () => {
 
   it("shows a mirrored record in the target group, flagged with its source", async () => {
     await book(dana.id, teamA.id, "2026-03-10");
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrors([teamA.id]);
 
     const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
 
@@ -119,7 +122,7 @@ describe("group mirroring", () => {
     await addMember(outsider.id, allEng.id);
     await book(dana.id, teamA.id, "2026-03-10");
     await book(outsider.id, allEng.id, "2026-03-12");
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrors([teamA.id]);
 
     const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
 
@@ -131,7 +134,7 @@ describe("group mirroring", () => {
 
   it("stops projecting a member's records once they leave the target group", async () => {
     await book(dana.id, teamA.id, "2026-03-10");
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrors([teamA.id]);
     expect(await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END)).toHaveLength(1);
 
     // The mirror row survives, but someone who left must not keep leaking time
@@ -145,7 +148,7 @@ describe("group mirroring", () => {
 
   it("does not mirror in the opposite direction", async () => {
     await book(dana.id, allEng.id, "2026-03-13");
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrors([teamA.id]);
 
     const rows = await getVacationsForGroup(teamA.id, MONTH_START, MONTH_END);
 
@@ -154,7 +157,7 @@ describe("group mirroring", () => {
 
   it("never makes a mirrored record approvable in the target group", async () => {
     await book(dana.id, teamA.id, "2026-03-14", false);
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrors([teamA.id]);
 
     const pending = await getPendingApprovalsForApprover(manager.id);
 
@@ -165,7 +168,7 @@ describe("group mirroring", () => {
 
   it("mirrors pending records too, so the team sees planned absence", async () => {
     await book(dana.id, teamA.id, "2026-03-15", false);
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrors([teamA.id]);
 
     const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
 
@@ -175,8 +178,8 @@ describe("group mirroring", () => {
 
   it("stops mirroring when the source is removed", async () => {
     await book(dana.id, teamA.id, "2026-03-10");
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, []);
+    await setMirrors([teamA.id]);
+    await setMirrors([]);
 
     const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
 
@@ -187,7 +190,7 @@ describe("group mirroring", () => {
   it("only mirrors the user who opted in, not everyone in the source group", async () => {
     await book(dana.id, teamA.id, "2026-03-10");
     await book(outsider.id, teamA.id, "2026-03-16");
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrors([teamA.id]);
 
     const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
 
@@ -198,7 +201,7 @@ describe("group mirroring", () => {
   it("keeps the date-range filter", async () => {
     await book(dana.id, teamA.id, "2026-02-20");
     await book(dana.id, teamA.id, "2026-03-10");
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrors([teamA.id]);
 
     const rows = await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END);
 
@@ -208,7 +211,7 @@ describe("group mirroring", () => {
 
   it("honours the per-user filter", async () => {
     await book(dana.id, teamA.id, "2026-03-10");
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrors([teamA.id]);
 
     expect(await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END, dana.id)).toHaveLength(1);
     expect(await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END, outsider.id)).toHaveLength(
@@ -218,18 +221,27 @@ describe("group mirroring", () => {
 
   it("is idempotent and does not duplicate rows when set twice", async () => {
     await book(dana.id, teamA.id, "2026-03-10");
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrors([teamA.id]);
+    await setMirrors([teamA.id]);
 
     expect(await getMirrorsIntoGroupForUser(dana.id, allEng.id)).toHaveLength(1);
     expect(await getVacationsForGroup(allEng.id, MONTH_START, MONTH_END)).toHaveLength(1);
   });
 
   it("names the source group for the settings screen", async () => {
-    await setMirrorsIntoGroupForUser(dana.id, allEng.id, [teamA.id]);
+    await setMirrors([teamA.id]);
 
     const mirrors = await getMirrorsIntoGroupForUser(dana.id, allEng.id);
 
     expect(mirrors[0]).toMatchObject({ sourceGroupId: teamA.id, sourceGroupName: "Team A" });
+  });
+
+  it("leaves a mirror outside the caller's reach alone when saving", async () => {
+    await setMirrors([teamA.id]);
+
+    // Team A is not this admin's to remove, so it must survive the save.
+    await setMirrors([], []);
+
+    expect(await getMirrorsIntoGroupForUser(dana.id, allEng.id)).toHaveLength(1);
   });
 });

--- a/src/tests/e2e/helpers/reportFixtures.ts
+++ b/src/tests/e2e/helpers/reportFixtures.ts
@@ -46,7 +46,12 @@ export async function makeGroup(groupName: string, managerUserId: string): Promi
 export async function addMember(
   groupId: string,
   userId: string,
-  permissions: { viewAccess?: boolean; adminAccess?: boolean; controlledUser?: boolean } = {}
+  permissions: {
+    viewAccess?: boolean;
+    adminAccess?: boolean;
+    approverAccess?: boolean;
+    controlledUser?: boolean;
+  } = {}
 ): Promise<void> {
   await db.insert(groupUsers).values({
     id: uuidv4(),
@@ -54,6 +59,7 @@ export async function addMember(
     userId,
     viewAccess: permissions.viewAccess ?? false,
     adminAccess: permissions.adminAccess ?? false,
+    approverAccess: permissions.approverAccess ?? false,
     controlledUser: permissions.controlledUser ?? true,
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/src/tests/e2e/vacation.e2e.test.ts
+++ b/src/tests/e2e/vacation.e2e.test.ts
@@ -3,9 +3,12 @@ import request from "supertest";
 import {
   setupTestEnvironment,
   cleanupTestData,
+  createTestGroup,
   createTestVacation,
   type TestContext,
 } from "./helpers/testSetup.js";
+import { setMirrorsIntoGroupForUser } from "../../services/groupMirror/groupMirrorServices.js";
+import { groupMirrors } from "../../db/schema/group-mirror-schema.js";
 import { authCookieFor } from "./helpers/authHelper.js";
 import { db } from "../../db/db.js";
 import { vacation } from "../../db/schema/vacation-schema.js";
@@ -38,12 +41,18 @@ const NEXT_MON = isoDay(shift(MONDAY_OF_WEEK, 7));
 describe("Vacation API E2E Tests", () => {
   let context: TestContext;
 
-  const addToGroup = async (userId: string, groupId: string) => {
+  const addToGroup = async (
+    userId: string,
+    groupId: string,
+    permissions: { adminAccess?: boolean; approverAccess?: boolean } = {}
+  ) => {
     await db.insert(groupUsers).values({
       id: uuidv4(),
       groupId,
       userId,
       controlledUser: true,
+      adminAccess: permissions.adminAccess ?? false,
+      approverAccess: permissions.approverAccess ?? false,
       createdAt: new Date(),
       updatedAt: new Date(),
     });
@@ -59,6 +68,7 @@ describe("Vacation API E2E Tests", () => {
 
   beforeEach(async () => {
     await db.delete(vacation);
+    await db.delete(groupMirrors);
     await db.delete(groupUsers);
     await db.delete(session);
   });
@@ -429,6 +439,66 @@ describe("Vacation API E2E Tests", () => {
 
       const rows = await db.select().from(vacation).where(eq(vacation.id, vacationId));
       expect(rows[0]?.approvedAt).toBeNull();
+    });
+
+    it("lets a member holding approverAccess decide, without any group role", async () => {
+      await addToGroup(context.user2.id, context.group.id, { approverAccess: true });
+      const cookie = await authCookieFor(context.user2.id);
+
+      await request(context.app)
+        .post(`/api/vacation/approve/${vacationId}`)
+        .set("Cookie", cookie)
+        .expect(200);
+
+      const rows = await db.select().from(vacation).where(eq(vacation.id, vacationId));
+      expect(rows[0]?.approvedBy).toBe(context.user2.id);
+    });
+
+    it("lets an approverAccess member approve their own request", async () => {
+      await addToGroup(context.user2.id, context.group.id, { approverAccess: true });
+      const own = await createTestVacation(context.user2.id, context.group.id, "2025-12-23");
+      const cookie = await authCookieFor(context.user2.id);
+
+      await request(context.app)
+        .post(`/api/vacation/approve/${own}`)
+        .set("Cookie", cookie)
+        .expect(200);
+
+      const rows = await db.select().from(vacation).where(eq(vacation.id, own));
+      expect(rows[0]?.approvedBy).toBe(context.user2.id);
+    });
+
+    it("refuses their own request while their records are mirrored into the group", async () => {
+      await addToGroup(context.user2.id, context.group.id, { approverAccess: true });
+      const otherGroup = await createTestGroup("Other Team", context.user1.id, context.user1.id);
+      await addToGroup(context.user2.id, otherGroup.id);
+      await setMirrorsIntoGroupForUser(
+        context.user2.id,
+        context.group.id,
+        [otherGroup.id],
+        [otherGroup.id]
+      );
+
+      const own = await createTestVacation(context.user2.id, context.group.id, "2025-12-23");
+      const cookie = await authCookieFor(context.user2.id);
+
+      await request(context.app)
+        .post(`/api/vacation/approve/${own}`)
+        .set("Cookie", cookie)
+        .expect(403);
+
+      const rows = await db.select().from(vacation).where(eq(vacation.id, own));
+      expect(rows[0]?.approvedAt).toBeNull();
+    });
+
+    it("still refuses a role-based approver deciding on their own request", async () => {
+      const own = await createTestVacation(context.approverUser.id, context.group.id, "2025-12-23");
+      const cookie = await authCookieFor(context.approverUser.id);
+
+      await request(context.app)
+        .post(`/api/vacation/approve/${own}`)
+        .set("Cookie", cookie)
+        .expect(403);
     });
   });
 });


### PR DESCRIPTION
## Approver is now its own permission

`group_users` gains `approver_access`, fully independent of `admin_access`:

| Flag | Can |
|---|---|
| `adminAccess` | manage members, quotas, invites, working days, mirroring — **not** approve |
| `approverAccess` | decide on the group's leave — **nothing** else |

`getGroupsWhereUserCanApprove` ORs the flag in alongside the existing `managerUserId` / `mainApprovalUser` / `tempApprovalUser` roles, which are untouched. Migration `0011` backfills the flag for each group's manager and named approvers, so the new column reads truthfully on existing data and today's approvers pick up the self-approval fix below.

## Self-approval fix

An admin (in practice, the group's approver) could not approve their own request. The blanket "no own rows" block in `assertMayDecide` is now per-group: an own request is decidable when the actor holds `approverAccess` there **and** has no active mirror into that group — leave projected in from another group stays governed by its source. A manager or named approver without the flag stays blocked, as before.

`mayDecideOwn` is shared with `resolveVacationPermissions`, keeping that file's contract that the detail endpoint reports exactly what the mutation endpoints allow.

## Mirroring is admin-managed

`PUT /api/group/:groupId/mirrors` now takes a `userId` and is no longer self-service. It requires admin access on the target group **and** on every source group named, with the member an active member of all of them — otherwise projecting a group's records into a team would only need rights on the receiving side.

One thing worth a look in review: **a save is scoped to the sources the caller administers.** An admin only sees some of a member's groups; a naive replace would read "not in my list" as "remove" and silently wipe mirrors set up by an admin of a group they cannot see. `setMirrorsIntoGroupForUser` diffs only inside `manageableSourceGroupIds`, and the GET returns out-of-reach active mirrors as `manageable: false` so the UI can show them locked rather than pretend they do not exist.

## Also in here

- **`canApprove` on vacation list rows** — the frontend was re-implementing the decision predicate from group columns, which cannot see the new flag or the mirror rule. Serving the verdict stops the two drifting.
- **`getPendingApprovalsForApprover`** duplicated the approver predicate in SQL and needed both new rules, or a pure approver would never see their queue.
- **Workflow mail** built its recipient list from main/temp approver only. A shared `approverContacts` helper now includes `approverAccess` members across the request, comment and cancellation mails.
- `dev:scenario` seeds Alice as an approver who administers nothing, so the split is visible locally.

## Testing

313 unit + 90 e2e passing. New coverage for the decision guard (role-based approver still blocked, flag holder allowed, blocked again once mirrored), mirror authorization in both directions, `canApprove` on the list, and an e2e case that a save leaves an out-of-reach mirror alone.

Verified end to end in the local stack: a member with only `approverAccess` and no group role can decide, including on their own request; adding a mirror for them immediately flips `canApprove` to false and the API 403s, while they can still decide for others.

> Pairs with the frontend PR — merge this first, the UI reads `canApprove` and the new mirrors shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable approver access for group members.
  * Vacation listings now show whether you can approve each request.
  * Eligible approvers can approve requests, including their own when permitted and not mirrored.
  * Vacation notifications now reach eligible group approvers.
  * Group administrators can manage mirrors for individual members while preserving unmanaged mirrors.

* **Bug Fixes**
  * Improved authorization and validation for group mirror management.
  * Existing memberships are safely migrated with appropriate approver permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->