### PR TITLE
feat: clearable notifications + stop mailing reserved domains

### DIFF
--- a/src/controllers/notification/handleDeleteAllNotifications.ts
+++ b/src/controllers/notification/handleDeleteAllNotifications.ts
@@ -1,0 +1,13 @@
+import type { Request, Response } from "express";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+
+const services = createDBServices();
+
+export const handleDeleteAllNotifications = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const removed = await services.notification.deleteAllNotificationsForUser(auth.userId);
+
+  return res.status(200).json({ message: "Notifications cleared", removed });
+};

--- a/src/controllers/notification/handleDeleteNotification.ts
+++ b/src/controllers/notification/handleDeleteNotification.ts
@@ -1,0 +1,30 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+import AppError from "../../utils/appError.js";
+
+const services = createDBServices();
+
+const validateUUID = z.uuid();
+
+export const handleDeleteNotification = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const notificationId = validateUUID.parse(req.params.id);
+
+  const deleted = await services.notification.deleteNotificationForUser(
+    notificationId,
+    auth.userId
+  );
+
+  if (!deleted) {
+    throw new AppError({
+      code: 404,
+      message: "Notification not found",
+      context: { auth, notificationId },
+    });
+  }
+
+  return res.status(200).json({ message: "Notification removed" });
+};

--- a/src/controllers/notification/handlePostNotificationsReadAll.ts
+++ b/src/controllers/notification/handlePostNotificationsReadAll.ts
@@ -1,0 +1,13 @@
+import type { Request, Response } from "express";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+
+const services = createDBServices();
+
+export const handlePostNotificationsReadAll = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const updated = await services.notification.markAllNotificationsRead(auth.userId);
+
+  return res.status(200).json({ message: "Notifications marked as read", updated });
+};

--- a/src/controllers/notification/tests/notificationActions.test.ts
+++ b/src/controllers/notification/tests/notificationActions.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockDeleteOne, mockDeleteAll, mockMarkAllRead } = vi.hoisted(() => ({
+  mockDeleteOne: vi.fn(),
+  mockDeleteAll: vi.fn(),
+  mockMarkAllRead: vi.fn(),
+}));
+
+vi.mock("../../../middleware/authSession.js", () => ({
+  getAuth: vi.fn(),
+}));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    notification: {
+      deleteNotificationForUser: mockDeleteOne,
+      deleteAllNotificationsForUser: mockDeleteAll,
+      markAllNotificationsRead: mockMarkAllRead,
+    },
+  }),
+}));
+
+import { handleDeleteNotification } from "../handleDeleteNotification.js";
+import { handleDeleteAllNotifications } from "../handleDeleteAllNotifications.js";
+import { handlePostNotificationsReadAll } from "../handlePostNotificationsReadAll.js";
+import { getAuth } from "../../../middleware/authSession.js";
+import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
+import AppError from "../../../utils/appError.js";
+
+const NOTIFICATION_ID = "3f1b8a2c-9d47-4c1e-8f2a-5b6c7d8e9f01";
+
+describe("notification actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
+  });
+
+  describe("handleDeleteNotification", () => {
+    it("removes the notification scoped to the caller", async () => {
+      mockDeleteOne.mockResolvedValue({ id: NOTIFICATION_ID });
+      const { req, res } = makeReqRes({ params: { id: NOTIFICATION_ID } });
+
+      await handleDeleteNotification(req, res);
+
+      expect(mockDeleteOne).toHaveBeenCalledWith(NOTIFICATION_ID, mockAuthData.userId);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ message: "Notification removed" });
+    });
+
+    it("throws 404 when nothing was deleted", async () => {
+      mockDeleteOne.mockResolvedValue(undefined);
+      const { req, res } = makeReqRes({ params: { id: NOTIFICATION_ID } });
+
+      await expect(handleDeleteNotification(req, res)).rejects.toThrow(AppError);
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-uuid id", async () => {
+      const { req, res } = makeReqRes({ params: { id: "not-a-uuid" } });
+
+      await expect(handleDeleteNotification(req, res)).rejects.toThrow();
+      expect(mockDeleteOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleDeleteAllNotifications", () => {
+    it("clears every notification of the caller and reports the count", async () => {
+      mockDeleteAll.mockResolvedValue(3);
+      const { req, res } = makeReqRes();
+
+      await handleDeleteAllNotifications(req, res);
+
+      expect(mockDeleteAll).toHaveBeenCalledWith(mockAuthData.userId);
+      expect(res.json).toHaveBeenCalledWith({ message: "Notifications cleared", removed: 3 });
+    });
+
+    it("succeeds when there was nothing to clear", async () => {
+      mockDeleteAll.mockResolvedValue(0);
+      const { req, res } = makeReqRes();
+
+      await handleDeleteAllNotifications(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ message: "Notifications cleared", removed: 0 });
+    });
+  });
+
+  describe("handlePostNotificationsReadAll", () => {
+    it("marks every unread notification of the caller as read", async () => {
+      mockMarkAllRead.mockResolvedValue(2);
+      const { req, res } = makeReqRes();
+
+      await handlePostNotificationsReadAll(req, res);
+
+      expect(mockMarkAllRead).toHaveBeenCalledWith(mockAuthData.userId);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Notifications marked as read",
+        updated: 2,
+      });
+    });
+  });
+});

--- a/src/routes/notificationRouter.ts
+++ b/src/routes/notificationRouter.ts
@@ -2,6 +2,9 @@ import { Router } from "express";
 import { tryCatch } from "../middleware/tryCatch.js";
 import { handleGetNotifications } from "../controllers/notification/handleGetNotifications.js";
 import { handlePostNotificationRead } from "../controllers/notification/handlePostNotificationRead.js";
+import { handlePostNotificationsReadAll } from "../controllers/notification/handlePostNotificationsReadAll.js";
+import { handleDeleteNotification } from "../controllers/notification/handleDeleteNotification.js";
+import { handleDeleteAllNotifications } from "../controllers/notification/handleDeleteAllNotifications.js";
 
 export const notificationRouter = (): Router => {
   const app = Router();
@@ -50,6 +53,78 @@ export const notificationRouter = (): Router => {
    *         description: Notification not found
    */
   app.post("/:id/read", tryCatch(handlePostNotificationRead));
+
+  /**
+   * @openapi
+   * /api/notifications/read-all:
+   *   post:
+   *     tags:
+   *       - Notifications
+   *     summary: Mark every unread notification of the caller as read
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       '200':
+   *         description: Number of notifications that were marked as read
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 message:
+   *                   type: string
+   *                 updated:
+   *                   type: integer
+   */
+  app.post("/read-all", tryCatch(handlePostNotificationsReadAll));
+
+  /**
+   * @openapi
+   * /api/notifications/{id}:
+   *   delete:
+   *     tags:
+   *       - Notifications
+   *     summary: Remove a single notification of the caller
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: id
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *     responses:
+   *       '200':
+   *         description: Notification removed
+   *       '404':
+   *         description: Notification not found
+   */
+  app.delete("/:id", tryCatch(handleDeleteNotification));
+
+  /**
+   * @openapi
+   * /api/notifications:
+   *   delete:
+   *     tags:
+   *       - Notifications
+   *     summary: Remove every notification of the caller
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       '200':
+   *         description: Number of notifications that were removed
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 message:
+   *                   type: string
+   *                 removed:
+   *                   type: integer
+   */
+  app.delete("/", tryCatch(handleDeleteAllNotifications));
 
   return app;
 };

--- a/src/services/DBServices.ts
+++ b/src/services/DBServices.ts
@@ -108,8 +108,11 @@ export type DBServices = Readonly<{
   notification: {
     listNotificationsForUser: typeof notificationServices.listNotificationsForUser;
     markNotificationRead: typeof notificationServices.markNotificationRead;
+    markAllNotificationsRead: typeof notificationServices.markAllNotificationsRead;
     getNotificationForUser: typeof notificationServices.getNotificationForUser;
     createNotification: typeof notificationServices.createNotification;
+    deleteNotificationForUser: typeof notificationServices.deleteNotificationForUser;
+    deleteAllNotificationsForUser: typeof notificationServices.deleteAllNotificationsForUser;
   };
   calendarSync: {
     generateFeedToken: typeof calendarSyncServices.generateFeedToken;
@@ -238,8 +241,11 @@ export const createDBServices = (): DBServices => {
     notification: {
       listNotificationsForUser: notificationServices.listNotificationsForUser,
       markNotificationRead: notificationServices.markNotificationRead,
+      markAllNotificationsRead: notificationServices.markAllNotificationsRead,
       getNotificationForUser: notificationServices.getNotificationForUser,
       createNotification: notificationServices.createNotification,
+      deleteNotificationForUser: notificationServices.deleteNotificationForUser,
+      deleteAllNotificationsForUser: notificationServices.deleteAllNotificationsForUser,
     },
     calendarSync: {
       generateFeedToken: calendarSyncServices.generateFeedToken,

--- a/src/services/email/index.ts
+++ b/src/services/email/index.ts
@@ -2,6 +2,7 @@ import { config } from "../../config.js";
 import type { EmailSender } from "./emailSender.js";
 import { sesEmailSender } from "./sesEmailSender.js";
 import { logEmailSender } from "./logEmailSender.js";
+import { suppressUndeliverable } from "./suppressUndeliverable.js";
 
 export type {
   EmailSender,
@@ -18,6 +19,10 @@ export type {
 
 /**
  * The active email sender. Tests use the log-only sender so they never hit
- * AWS; every other environment uses the real SES adapter.
+ * AWS; every other environment uses the real SES adapter. Both are wrapped so
+ * recipients at reserved domains — the seeded `@dev.local` accounts above all
+ * — are dropped rather than bounced off SES.
  */
-export const emailSender: EmailSender = config.api.env === "test" ? logEmailSender : sesEmailSender;
+export const emailSender: EmailSender = suppressUndeliverable(
+  config.api.env === "test" ? logEmailSender : sesEmailSender
+);

--- a/src/services/email/suppressUndeliverable.ts
+++ b/src/services/email/suppressUndeliverable.ts
@@ -1,0 +1,49 @@
+import { logger } from "../../middleware/logger.js";
+import type { EmailSender, TemplatedEmail } from "./emailSender.js";
+
+/**
+ * Reserved TLDs that can never hold a real mailbox: RFC 2606 / RFC 6761
+ * (`test`, `example`, `invalid`, `localhost`) plus RFC 6762's `local`, which
+ * is mDNS-only and covers the `@dev.local` accounts the seeding surface
+ * creates.
+ */
+const UNDELIVERABLE_TLDS = new Set(["test", "example", "invalid", "localhost", "local"]);
+
+/** RFC 2606 second-level domains reserved for documentation and examples. */
+const UNDELIVERABLE_DOMAINS = new Set(["example.com", "example.net", "example.org"]);
+
+/**
+ * True when the address provably cannot receive mail. Delivering to one only
+ * ever produces a hard bounce, and bounces are charged against the SES
+ * account's sender reputation — so these are dropped before they reach AWS.
+ *
+ * Deliberately keyed on reserved domains alone, not on `NODE_ENV` or the dev
+ * seed domain: pointing `DEV_SEED_EMAIL_DOMAIN` at a domain you own is how you
+ * exercise real delivery locally, and that must keep sending.
+ */
+export const isUndeliverableAddress = (address: string): boolean => {
+  const domain = address.trim().toLowerCase().split("@").pop();
+  if (!domain) return false;
+
+  if (UNDELIVERABLE_DOMAINS.has(domain)) return true;
+
+  const tld = domain.split(".").pop();
+  return tld !== undefined && UNDELIVERABLE_TLDS.has(tld);
+};
+
+/**
+ * Wraps an {@link EmailSender} so undeliverable recipients are logged and
+ * dropped instead of sent. Applied to every sender, production included — a
+ * reserved-domain address in production is bad data, and bouncing it costs
+ * reputation that real mail depends on.
+ */
+export const suppressUndeliverable = (inner: EmailSender): EmailSender => ({
+  async sendTemplated(email: TemplatedEmail): Promise<void> {
+    if (isUndeliverableAddress(email.to)) {
+      logger.info("email.suppressed", { to: email.to, template: email.template });
+      return;
+    }
+
+    await inner.sendTemplated(email);
+  },
+});

--- a/src/services/notification/notificationServices.ts
+++ b/src/services/notification/notificationServices.ts
@@ -63,6 +63,57 @@ export const getNotificationForUser = async (
 };
 
 /**
+ * Marks every unread notification of a user as read. Scoped to `readAt IS
+ * NULL` so notifications read earlier keep their original timestamp. Returns
+ * how many rows were flipped.
+ */
+export const markAllNotificationsRead = async (
+  userId: string,
+  tx?: DbTransaction
+): Promise<number> => {
+  const rows = await (tx ?? db)
+    .update(notifications)
+    .set({ readAt: new Date() })
+    .where(and(eq(notifications.userId, userId), isNull(notifications.readAt)))
+    .returning({ id: notifications.id });
+
+  return rows.length;
+};
+
+/**
+ * Deletes a single notification. The owner predicate is part of the WHERE
+ * clause, so a foreign id simply matches nothing. Returns undefined when
+ * nothing was deleted, which the controller reports as 404.
+ */
+export const deleteNotificationForUser = async (
+  notificationId: string,
+  userId: string,
+  tx?: DbTransaction
+): Promise<NotificationRecord | undefined> => {
+  const [row] = await (tx ?? db)
+    .delete(notifications)
+    .where(and(eq(notifications.id, notificationId), eq(notifications.userId, userId)))
+    .returning();
+
+  return row;
+};
+
+/**
+ * Deletes every notification of a user. Returns how many rows went.
+ */
+export const deleteAllNotificationsForUser = async (
+  userId: string,
+  tx?: DbTransaction
+): Promise<number> => {
+  const rows = await (tx ?? db)
+    .delete(notifications)
+    .where(eq(notifications.userId, userId))
+    .returning({ id: notifications.id });
+
+  return rows.length;
+};
+
+/**
  * Inserts a notification row. Used by future workflow code; kept in the same
  * service module so all notification persistence lives in one place.
  */

--- a/src/tests/services/email/suppressUndeliverable.test.ts
+++ b/src/tests/services/email/suppressUndeliverable.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../middleware/logger.js", () => ({
+  logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  isUndeliverableAddress,
+  suppressUndeliverable,
+} from "../../../services/email/suppressUndeliverable.js";
+import type { EmailSender, TemplatedEmail } from "../../../services/email/emailSender.js";
+
+const email = (to: string): TemplatedEmail => ({
+  to,
+  template: "email-confirmation",
+  data: { name: "Olivia", confirmationUrl: "https://example.test/c", expiresIn: "1 hour" },
+});
+
+describe("isUndeliverableAddress", () => {
+  it.each([
+    "owner@dev.local",
+    "alice@DEV.LOCAL",
+    "  bob@dev.local  ",
+    "carol@anything.test",
+    "dan@foo.invalid",
+    "eve@app.localhost",
+    "frank@example.com",
+    "grace@example.org",
+  ])("suppresses %s", (address) => {
+    expect(isUndeliverableAddress(address)).toBe(true);
+  });
+
+  it.each([
+    "daniel@hrynusiw.cz",
+    "someone@flexi-day.com",
+    "user@localhost.co.uk",
+    "team@example.company",
+  ])("allows %s", (address) => {
+    expect(isUndeliverableAddress(address)).toBe(false);
+  });
+});
+
+describe("suppressUndeliverable", () => {
+  let inner: EmailSender;
+  let sendTemplated: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sendTemplated = vi.fn().mockResolvedValue(undefined);
+    inner = { sendTemplated } as unknown as EmailSender;
+  });
+
+  it("drops mail to a seeded dev address without calling the inner sender", async () => {
+    await suppressUndeliverable(inner).sendTemplated(email("owner@dev.local"));
+
+    expect(sendTemplated).not.toHaveBeenCalled();
+  });
+
+  it("passes real addresses through untouched", async () => {
+    const message = email("daniel@hrynusiw.cz");
+
+    await suppressUndeliverable(inner).sendTemplated(message);
+
+    expect(sendTemplated).toHaveBeenCalledWith(message);
+  });
+
+  it("propagates a failure from the inner sender", async () => {
+    sendTemplated.mockRejectedValue(new Error("SES down"));
+
+    await expect(
+      suppressUndeliverable(inner).sendTemplated(email("daniel@hrynusiw.cz"))
+    ).rejects.toThrow("SES down");
+  });
+});


### PR DESCRIPTION
## Why

Two problems, both surfaced while working on the notification bell:

1. Notifications could only ever be **marked read** — nothing removed them, so the bell accumulated everything a user had ever received.
2. The seeded `@dev.local` accounts were being handed to SES on every approval. Those addresses don't exist, so each one **hard-bounces**, and bounces are charged against the SES account's sender reputation.

## Notification removal

| Endpoint | Effect |
|---|---|
| `POST /api/notifications/read-all` | mark every unread notification of the caller read |
| `DELETE /api/notifications/:id` | remove one (404 when nothing matched) |
| `DELETE /api/notifications` | clear all |

**Hard delete, so no migration.** Notifications are a derived read model — `vacation_events` is still the audit log, so nothing is lost. The alternative (a `dismissedAt` column) means a migration, rows that grow forever, and an extra predicate on every read.

Ownership is a WHERE-clause predicate on every statement, so a foreign id simply matches nothing rather than erroring or leaking. Mark-all-read stays scoped to `readAt IS NULL`, preserving the existing first-read-timestamp invariant.

## Email suppression

`emailSender` is now wrapped by `suppressUndeliverable`, which logs (`email.suppressed`) and drops recipients at domains that provably cannot receive mail: RFC 2606/6761 (`.test`, `.example`, `.invalid`, `.localhost`, `example.com/.net/.org`) and RFC 6762 `.local`.

The rule keys on **the domain alone** — deliberately not on `NODE_ENV` and not on `DEV_SEED_EMAIL_DOMAIN`. Pointing the seed domain at a domain you actually own is how you exercise real delivery locally, and that has to keep sending. It applies in production too: a reserved-domain address there is bad data, and bouncing it helps nobody.

`emailSender` is the only path that reaches SES (password reset is still the log-only `tempEmailSend` stub), so one wrapper covers verification, group invites and vacation notifications.

## Verification

334 unit tests pass; lint clean (3 pre-existing `any` warnings in `appError.ts`).

Checked against the running stack with the seeded scenario:

- Approving a request logged `{"message":"email.suppressed","to":"bob@dev.local","template":"vacation-approved"}` with **no SES call**, and the in-app notification was still created — suppression doesn't break the fan-out.
- Removing one notification, mark-all-read and clear-all each returned 200. A DB check confirmed only the caller's rows went: the other three users' 19 rows were untouched.

## Note

Frontend counterpart: https://github.com/Daniel88dev/flexi-day/pull/51 — merge this one first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users can mark all notifications as read.
  - Users can delete individual notifications or clear all notifications at once.
  - Notification actions now provide clear success and not-found responses.
- **Bug Fixes**
  - Prevents delivery attempts to reserved or undeliverable email addresses while preserving delivery for valid recipients.
- **Tests**
  - Added coverage for notification actions, validation, bulk operations, and email suppression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->