### PR TITLE
feat: replace the global rate limit with per-session and per-credential tiers

### DIFF
--- a/src/middleware/limiter.ts
+++ b/src/middleware/limiter.ts
@@ -1,15 +1,83 @@
-import { rateLimit } from "express-rate-limit";
+import { createHash } from "node:crypto";
+import type { Request, Response } from "express";
+import { ipKeyGenerator, rateLimit } from "express-rate-limit";
 
-export const limiter = rateLimit({
-  windowMs: 5 * 60 * 1000,
-  limit: 500,
+const FIVE_MINUTES = 5 * 60 * 1000;
+const FIFTEEN_MINUTES = 15 * 60 * 1000;
+const ONE_HOUR = 60 * 60 * 1000;
+
+const shared = {
   statusCode: 429,
   standardHeaders: true,
   legacyHeaders: false,
-  handler: (req, res) => {
+  handler: (_req: Request, res: Response) => {
     res.status(429).json({
       error: "Too many requests",
       retryAfter: res.getHeader("Retry-After") ?? undefined,
     });
   },
+} as const;
+
+const ipKey = (req: Request) => ipKeyGenerator(req.ip ?? "");
+
+/**
+ * Bucket authenticated traffic per session rather than per IP. Keying on the
+ * IP pools every user behind one office NAT, VPN or mobile CGNAT into a single
+ * allowance, which is what makes a shared limit feel arbitrarily strict.
+ */
+function sessionKey(req: Request): string | null {
+  const cookies = req.headers.cookie;
+  if (!cookies) return null;
+  const match = /(?:^|;\s*)(?:__Secure-)?better-auth\.session_token=([^;]*)/.exec(cookies);
+  if (!match?.[1]) return null;
+  return `s:${createHash("sha256").update(match[1]).digest("hex").slice(0, 32)}`;
+}
+
+/**
+ * Outermost backstop against floods. Deliberately far above anything a real
+ * client produces — the per-session and per-credential limits below are what
+ * actually shape traffic.
+ */
+export const floodLimiter = rateLimit({
+  ...shared,
+  windowMs: FIVE_MINUTES,
+  limit: 5000,
+  keyGenerator: ipKey,
+  // Preflights are not attack surface (CORS `maxAge` already caches them) and
+  // the health check must not spend a caller's budget.
+  skip: (req) => req.method === "OPTIONS" || req.path === "/health",
+});
+
+/** Authenticated API traffic. ~10 requests per page load, so this is ~100 loads. */
+export const apiLimiter = rateLimit({
+  ...shared,
+  windowMs: FIVE_MINUTES,
+  limit: 1000,
+  keyGenerator: (req) => sessionKey(req) ?? ipKey(req),
+  skip: (req) => req.method === "OPTIONS",
+});
+
+/**
+ * The credential surface, where brute force actually costs something. Only
+ * failures count, so a whole office signing in at 9am is unaffected while a
+ * guesser burns the budget.
+ */
+export const credentialsLimiter = rateLimit({
+  ...shared,
+  windowMs: FIFTEEN_MINUTES,
+  limit: 20,
+  skipSuccessfulRequests: true,
+  keyGenerator: ipKey,
+});
+
+/**
+ * Calendar clients subscribe with a token and no cookie, and Google polls every
+ * subscribed feed from a handful of shared ranges — keying this on the IP would
+ * make one popular provider throttle every user at once.
+ */
+export const calendarFeedLimiter = rateLimit({
+  ...shared,
+  windowMs: ONE_HOUR,
+  limit: 120,
+  keyGenerator: (req) => (req.params.token ? `t:${req.params.token}` : ipKey(req)),
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,12 @@ import express from "express";
 import * as Sentry from "@sentry/node";
 import { serverCors } from "./middleware/cors.js";
 import { helmetHeaders } from "./middleware/headers.js";
-import { limiter } from "./middleware/limiter.js";
+import {
+  apiLimiter,
+  calendarFeedLimiter,
+  credentialsLimiter,
+  floodLimiter,
+} from "./middleware/limiter.js";
 import { toNodeHandler } from "better-auth/node";
 import { auth } from "./utils/auth.js";
 import { config } from "./config.js";
@@ -26,7 +31,26 @@ import { requestContext } from "./middleware/requestContext.js";
 export const createServer = () => {
   const app = express();
   // `requestContext` sits ahead of every route, including better-auth's catch-all.
-  app.set("trust proxy", 1).use(serverCors).use(requestContext).use(helmetHeaders).use(limiter);
+  app
+    .set("trust proxy", 1)
+    .use(serverCors)
+    .use(requestContext)
+    .use(helmetHeaders)
+    .use(floodLimiter);
+
+  // Only the endpoints where a wrong guess is the point. Registered before
+  // better-auth's catch-all so it cannot swallow them, and before any body
+  // parser so better-auth still receives its raw body.
+  app.use(
+    [
+      "/api/auth/sign-in",
+      "/api/auth/sign-up",
+      "/api/auth/sign-up-with-team",
+      "/api/auth/forget-password",
+      "/api/auth/reset-password",
+    ],
+    credentialsLimiter
+  );
 
   // Project-specific auth orchestration endpoints. These must be registered
   // BEFORE better-auth's catch-all `.all()` so the catch-all does not swallow
@@ -44,6 +68,10 @@ export const createServer = () => {
     app.use("/api/dev", devRouter());
   }
 
+  // Everything below is the authenticated API. `/api/auth` and `/api/dev` are
+  // already handled above, so this never double-counts them.
+  app.use("/api", apiLimiter);
+
   app.use("/api/vacation", authSession, vacationRouter());
   app.use("/api/group", authSession, groupRouter());
   app.use("/api/group-user", authSession, groupUsersRouter());
@@ -57,7 +85,7 @@ export const createServer = () => {
   // Public, token-authenticated iCalendar feed. Deliberately NOT behind
   // `authSession`: calendar clients subscribe with just the secret token in
   // the URL and cannot send session cookies.
-  app.get("/calendars/:token.ics", tryCatch(handleGetCalendarFeed));
+  app.get("/calendars/:token.ics", calendarFeedLimiter, tryCatch(handleGetCalendarFeed));
 
   app.get("/health", (_, res) => {
     res.setHeader("Cache-Control", "no-store");

--- a/src/tests/middleware/limiter.test.ts
+++ b/src/tests/middleware/limiter.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for the rate limiters.
+ * Test library/framework: Vitest
+ */
+import { describe, it, expect } from "vitest";
+import express, { type Express } from "express";
+import request from "supertest";
+import {
+  apiLimiter,
+  calendarFeedLimiter,
+  credentialsLimiter,
+  floodLimiter,
+} from "../../middleware/limiter.js";
+
+const SESSION = "better-auth.session_token=abc.def";
+const OTHER_SESSION = "better-auth.session_token=zzz.yyy";
+
+function appWith(mount: (app: Express) => void): Express {
+  const app = express();
+  app.set("trust proxy", 1);
+  mount(app);
+  return app;
+}
+
+/** Drive one key up to (and past) its allowance without waiting for the window. */
+async function hammer(app: Express, path: string, times: number, headers: Record<string, string>) {
+  const statuses: number[] = [];
+  for (let i = 0; i < times; i++) {
+    const res = await request(app).get(path).set(headers);
+    statuses.push(res.status);
+  }
+  return statuses;
+}
+
+describe("floodLimiter", () => {
+  it("does not count preflights or the health check", async () => {
+    const app = appWith((a) => {
+      a.use(floodLimiter);
+      a.get("/health", (_, res) => res.status(200).json({ ok: true }));
+      a.options("/api/vacation", (_, res) => res.status(204).end());
+    });
+
+    const health = await request(app).get("/health");
+    expect(health.status).toBe(200);
+    expect(health.headers["ratelimit-remaining"]).toBeUndefined();
+
+    const preflight = await request(app).options("/api/vacation");
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers["ratelimit-remaining"]).toBeUndefined();
+  });
+
+  it("counts ordinary requests", async () => {
+    const app = appWith((a) => {
+      a.use(floodLimiter);
+      a.get("/api/thing", (_, res) => res.status(200).json({ ok: true }));
+    });
+
+    const res = await request(app).get("/api/thing");
+    expect(res.status).toBe(200);
+    expect(Number(res.headers["ratelimit-remaining"])).toBeLessThan(5000);
+  });
+});
+
+describe("apiLimiter", () => {
+  it("gives two sessions from the same IP separate budgets", async () => {
+    const app = appWith((a) => {
+      a.use(apiLimiter);
+      a.get("/api/thing", (_, res) => res.status(200).json({ ok: true }));
+    });
+
+    const first = await request(app).get("/api/thing").set("Cookie", SESSION);
+    const second = await request(app).get("/api/thing").set("Cookie", OTHER_SESSION);
+
+    // Both are the first request against their own key.
+    expect(first.headers["ratelimit-remaining"]).toBe(second.headers["ratelimit-remaining"]);
+  });
+
+  it("shares a budget across requests carrying the same session", async () => {
+    const app = appWith((a) => {
+      a.use(apiLimiter);
+      a.get("/api/thing", (_, res) => res.status(200).json({ ok: true }));
+    });
+
+    const first = await request(app).get("/api/thing").set("Cookie", SESSION);
+    const second = await request(app).get("/api/thing").set("Cookie", SESSION);
+
+    expect(Number(second.headers["ratelimit-remaining"])).toBe(
+      Number(first.headers["ratelimit-remaining"]) - 1
+    );
+  });
+
+  it("also matches the __Secure- prefixed cookie used over https", async () => {
+    const app = appWith((a) => {
+      a.use(apiLimiter);
+      a.get("/api/thing", (_, res) => res.status(200).json({ ok: true }));
+    });
+
+    const plain = await request(app).get("/api/thing").set("Cookie", SESSION);
+    const secure = await request(app)
+      .get("/api/thing")
+      .set("Cookie", "__Secure-better-auth.session_token=abc.def");
+
+    // Same token value, so the secure variant lands in the same bucket.
+    expect(Number(secure.headers["ratelimit-remaining"])).toBe(
+      Number(plain.headers["ratelimit-remaining"]) - 1
+    );
+  });
+
+  it("falls back to the IP when there is no session cookie", async () => {
+    const app = appWith((a) => {
+      a.use(apiLimiter);
+      a.get("/api/thing", (_, res) => res.status(200).json({ ok: true }));
+    });
+
+    const first = await request(app).get("/api/thing").set("X-Forwarded-For", "203.0.113.7");
+    const second = await request(app).get("/api/thing").set("X-Forwarded-For", "203.0.113.7");
+
+    expect(Number(second.headers["ratelimit-remaining"])).toBe(
+      Number(first.headers["ratelimit-remaining"]) - 1
+    );
+  });
+});
+
+describe("credentialsLimiter", () => {
+  it("does not spend the budget on successful sign-ins", async () => {
+    const app = appWith((a) => {
+      a.use(credentialsLimiter);
+      a.get("/api/auth/sign-in", (_, res) => res.status(200).json({ ok: true }));
+    });
+
+    const statuses = await hammer(app, "/api/auth/sign-in", 25, {
+      "X-Forwarded-For": "203.0.113.10",
+    });
+
+    expect(statuses.every((s) => s === 200)).toBe(true);
+  });
+
+  it("locks out after 20 failed attempts from one IP", async () => {
+    const app = appWith((a) => {
+      a.use(credentialsLimiter);
+      a.get("/api/auth/sign-in", (_, res) => res.status(401).json({ error: "nope" }));
+    });
+
+    const statuses = await hammer(app, "/api/auth/sign-in", 22, {
+      "X-Forwarded-For": "203.0.113.11",
+    });
+
+    expect(statuses.slice(0, 20).every((s) => s === 401)).toBe(true);
+    expect(statuses.at(-1)).toBe(429);
+  });
+
+  it("returns the shared error body when it trips", async () => {
+    const app = appWith((a) => {
+      a.use(credentialsLimiter);
+      a.get("/api/auth/sign-in", (_, res) => res.status(401).json({ error: "nope" }));
+    });
+
+    await hammer(app, "/api/auth/sign-in", 20, { "X-Forwarded-For": "203.0.113.12" });
+    const blocked = await request(app)
+      .get("/api/auth/sign-in")
+      .set("X-Forwarded-For", "203.0.113.12");
+
+    expect(blocked.status).toBe(429);
+    expect(blocked.body.error).toBe("Too many requests");
+  });
+});
+
+describe("calendarFeedLimiter", () => {
+  it("keys on the feed token, not the polling IP", async () => {
+    const app = appWith((a) => {
+      a.get("/calendars/:token.ics", calendarFeedLimiter, (_, res) =>
+        res.status(200).send("BEGIN")
+      );
+    });
+
+    // One provider polling two users' feeds from the same address.
+    const first = await request(app)
+      .get("/calendars/tok-a.ics")
+      .set("X-Forwarded-For", "66.102.0.1");
+    const second = await request(app)
+      .get("/calendars/tok-b.ics")
+      .set("X-Forwarded-For", "66.102.0.1");
+
+    expect(first.headers["ratelimit-remaining"]).toBe(second.headers["ratelimit-remaining"]);
+  });
+
+  it("shares a budget across repeat polls of one feed", async () => {
+    const app = appWith((a) => {
+      a.get("/calendars/:token.ics", calendarFeedLimiter, (_, res) =>
+        res.status(200).send("BEGIN")
+      );
+    });
+
+    const first = await request(app).get("/calendars/tok-c.ics");
+    const second = await request(app).get("/calendars/tok-c.ics");
+
+    expect(Number(second.headers["ratelimit-remaining"])).toBe(
+      Number(first.headers["ratelimit-remaining"]) - 1
+    );
+  });
+});


### PR DESCRIPTION
## Why

`limiter.ts` was a single bucket of **500 requests / 5 min, keyed by IP**, mounted ahead of every route. Two problems:

- **It throttles real users.** The IP key pools everyone behind one office NAT, VPN or mobile CGNAT into a single allowance.
- **It under-protects what matters.** Cheap authenticated reads shared a budget with sign-in attempts, so the credential surface was effectively governed by better-auth's own `max: 50` per 10s — far too permissive for password guessing.

## What

Four limiters instead of one:

| Limiter | Mounted on | Key | Budget |
|---|---|---|---|
| `floodLimiter` | everything | IP | 5000 / 5 min |
| `apiLimiter` | `/api` | session cookie, IP fallback | 1000 / 5 min |
| `credentialsLimiter` | sign-in / sign-up / forget- / reset-password | IP | 20 **failures** / 15 min |
| `calendarFeedLimiter` | `/calendars/:token.ics` | feed token | 120 / hour |

Net effect: much looser for real users, tighter where abuse costs something.

## Decisions worth reviewing

- **`apiLimiter` keys on the session, not the IP.** A dashboard load is ~10 requests (measured), so 1000/5min is ~100 loads per user. Custom key generators run IPs through `ipKeyGenerator` — a bare `req.ip` would let one IPv6 /64 rotate addresses freely.
- **`credentialsLimiter` sets `skipSuccessfulRequests`.** Only failures count. I originally intended to key this on IP + submitted email, but that middleware runs before any body parser and better-auth needs its raw body untouched, so the email isn't readable there. Counting only failures gets the same protection without parsing.
- **`calendarFeedLimiter` keys on the token.** Google polls subscribed feeds from shared ranges; an IP key would throttle every user's feed at once. This one may already have been biting silently.
- **Placement.** `app.use("/api", apiLimiter)` sits after the better-auth catch-all and the dev router, so those terminate first and are never double-counted.

## Verification

11 new unit tests (supertest) covering session-vs-IP keying, the `__Secure-` cookie variant, OPTIONS/`/health` skipping, failures-only counting, and token keying. Full suite: **345 passing**. Build and lint clean (the 3 remaining warnings are pre-existing in `appError.ts`).

Checked against the running stack:

- `/health` → no `RateLimit-*` headers
- `/api/group` → `RateLimit-Policy: 1000;w=300`
- one failed sign-in → `RateLimit-Policy: 20;w=900`, remaining 19
- two different feed tokens from one IP → each got its own 119 remaining

## Notes

- The store is **in-memory**: counters are per-process and reset on deploy. Running more than one instance multiplies the effective limits — needs a shared store before scaling out.
- The biggest remaining source of request volume is `/api/auth/get-session` (2-3 per page load, bursts of 8 during interaction, because `useSession()` doesn't go through the query cache). Being handled separately in the frontend.
- `CLAUDE.md` is gitignored in this repo, so the rate-limiting docs I wrote aren't in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tailored rate limits for general traffic, APIs, authentication attempts, and calendar feeds.
  * Added protections based on IP addresses, sessions, and calendar access tokens.
  * Excluded health checks and preflight requests where appropriate.
  * Counted only failed authentication attempts toward credential limits.

* **Bug Fixes**
  * Improved protection against flooding and repeated unauthorized access while preserving consistent rate-limit responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->