### PR TITLE
fix: key the API rate limit on a validated user, not the raw cookie

### DIFF
--- a/src/middleware/limiter.ts
+++ b/src/middleware/limiter.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import type { Request, Response } from "express";
 import { ipKeyGenerator, rateLimit } from "express-rate-limit";
 
@@ -21,19 +20,6 @@ const shared = {
 const ipKey = (req: Request) => ipKeyGenerator(req.ip ?? "");
 
 /**
- * Bucket authenticated traffic per session rather than per IP. Keying on the
- * IP pools every user behind one office NAT, VPN or mobile CGNAT into a single
- * allowance, which is what makes a shared limit feel arbitrarily strict.
- */
-function sessionKey(req: Request): string | null {
-  const cookies = req.headers.cookie;
-  if (!cookies) return null;
-  const match = /(?:^|;\s*)(?:__Secure-)?better-auth\.session_token=([^;]*)/.exec(cookies);
-  if (!match?.[1]) return null;
-  return `s:${createHash("sha256").update(match[1]).digest("hex").slice(0, 32)}`;
-}
-
-/**
  * Outermost backstop against floods. Deliberately far above anything a real
  * client produces — the per-session and per-credential limits below are what
  * actually shape traffic.
@@ -48,12 +34,35 @@ export const floodLimiter = rateLimit({
   skip: (req) => req.method === "OPTIONS" || req.path === "/health",
 });
 
-/** Authenticated API traffic. ~10 requests per page load, so this is ~100 loads. */
+/**
+ * Rejected `/api` traffic, counted per IP ahead of session validation. Only
+ * failures count, so a whole office's real requests never touch it — but
+ * unauthenticated probing, and anyone rotating forged session cookies to mint
+ * fresh `apiLimiter` buckets, is cut off long before the flood ceiling.
+ */
+export const apiFailureLimiter = rateLimit({
+  ...shared,
+  windowMs: FIVE_MINUTES,
+  limit: 100,
+  skipSuccessfulRequests: true,
+  keyGenerator: ipKey,
+  skip: (req) => req.method === "OPTIONS",
+});
+
+/**
+ * Authenticated API traffic, ~10 requests per page load, so this is ~100 loads.
+ *
+ * Keyed on the user id that `authSession` has already validated — never on the
+ * raw cookie, which a caller can invent to hand itself an unused bucket. Keying
+ * on the IP instead would pool every user behind one office NAT, VPN or mobile
+ * CGNAT into a single allowance, which is what makes a shared limit feel
+ * arbitrarily strict.
+ */
 export const apiLimiter = rateLimit({
   ...shared,
   windowMs: FIVE_MINUTES,
   limit: 1000,
-  keyGenerator: (req) => sessionKey(req) ?? ipKey(req),
+  keyGenerator: (req) => (req.auth?.userId ? `u:${req.auth.userId}` : ipKey(req)),
   skip: (req) => req.method === "OPTIONS",
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/node";
 import { serverCors } from "./middleware/cors.js";
 import { helmetHeaders } from "./middleware/headers.js";
 import {
+  apiFailureLimiter,
   apiLimiter,
   calendarFeedLimiter,
   credentialsLimiter,
@@ -68,19 +69,22 @@ export const createServer = () => {
     app.use("/api/dev", devRouter());
   }
 
-  // Everything below is the authenticated API. `/api/auth` and `/api/dev` are
-  // already handled above, so this never double-counts them.
-  app.use("/api", apiLimiter);
+  // Everything below is the authenticated API; `/api/auth` and `/api/dev` are
+  // already handled above, so this never double-counts them. The order is the
+  // point: a cheap per-IP bound on rejected requests, then session validation,
+  // then the per-user budget — which must key on a validated user id, because a
+  // caller can invent a session cookie to hand itself an unused bucket.
+  app.use("/api", apiFailureLimiter, authSession, apiLimiter);
 
-  app.use("/api/vacation", authSession, vacationRouter());
-  app.use("/api/group", authSession, groupRouter());
-  app.use("/api/group-user", authSession, groupUsersRouter());
-  app.use("/api/quotas", authSession, quotasRouter());
-  app.use("/api/users", authSession, usersRouter());
-  app.use("/api/bank-holidays", authSession, bankHolidayRouter());
-  app.use("/api/notifications", authSession, notificationRouter());
-  app.use("/api/calendar-sync", authSession, calendarSyncRouter());
-  app.use("/api/reports", authSession, reportRouter());
+  app.use("/api/vacation", vacationRouter());
+  app.use("/api/group", groupRouter());
+  app.use("/api/group-user", groupUsersRouter());
+  app.use("/api/quotas", quotasRouter());
+  app.use("/api/users", usersRouter());
+  app.use("/api/bank-holidays", bankHolidayRouter());
+  app.use("/api/notifications", notificationRouter());
+  app.use("/api/calendar-sync", calendarSyncRouter());
+  app.use("/api/reports", reportRouter());
 
   // Public, token-authenticated iCalendar feed. Deliberately NOT behind
   // `authSession`: calendar clients subscribe with just the secret token in

--- a/src/tests/middleware/limiter.test.ts
+++ b/src/tests/middleware/limiter.test.ts
@@ -5,15 +5,14 @@
 import { describe, it, expect } from "vitest";
 import express, { type Express } from "express";
 import request from "supertest";
+import type { NextFunction, Request, Response } from "express";
 import {
+  apiFailureLimiter,
   apiLimiter,
   calendarFeedLimiter,
   credentialsLimiter,
   floodLimiter,
 } from "../../middleware/limiter.js";
-
-const SESSION = "better-auth.session_token=abc.def";
-const OTHER_SESSION = "better-auth.session_token=zzz.yyy";
 
 function appWith(mount: (app: Express) => void): Express {
   const app = express();
@@ -21,6 +20,26 @@ function appWith(mount: (app: Express) => void): Express {
   mount(app);
   return app;
 }
+
+/**
+ * Stands in for `authSession`: only a request carrying the magic cookie counts
+ * as validated, so a forged one reaches the limiter with no `req.auth` — the
+ * case that must not mint its own bucket.
+ */
+const fakeAuthSession =
+  (validCookie: string, userId: string) => (req: Request, res: Response, next: NextFunction) => {
+    if (req.headers.cookie === validCookie) {
+      req.auth = {
+        sessionId: "sess-1",
+        userId,
+        userName: "Test",
+        userEmail: "test@dev.local",
+        emailVerified: true,
+      };
+      return next();
+    }
+    res.status(401).json({ error: "Unauthorized" });
+  };
 
 /** Drive one key up to (and past) its allowance without waiting for the window. */
 async function hammer(app: Express, path: string, times: number, headers: Record<string, string>) {
@@ -62,62 +81,76 @@ describe("floodLimiter", () => {
 });
 
 describe("apiLimiter", () => {
-  it("gives two sessions from the same IP separate budgets", async () => {
-    const app = appWith((a) => {
-      a.use(apiLimiter);
+  /** Mirrors the real mount order: failure bound, session validation, per-user budget. */
+  const apiApp = (userId: string, validCookie = "session=real") =>
+    appWith((a) => {
+      a.use("/api", fakeAuthSession(validCookie, userId), apiLimiter);
       a.get("/api/thing", (_, res) => res.status(200).json({ ok: true }));
     });
 
-    const first = await request(app).get("/api/thing").set("Cookie", SESSION);
-    const second = await request(app).get("/api/thing").set("Cookie", OTHER_SESSION);
+  it("gives two users on the same IP separate budgets", async () => {
+    const alice = apiApp("user-alice");
+    const bob = apiApp("user-bob");
+
+    const first = await request(alice).get("/api/thing").set("Cookie", "session=real");
+    const second = await request(bob).get("/api/thing").set("Cookie", "session=real");
 
     // Both are the first request against their own key.
     expect(first.headers["ratelimit-remaining"]).toBe(second.headers["ratelimit-remaining"]);
   });
 
-  it("shares a budget across requests carrying the same session", async () => {
-    const app = appWith((a) => {
-      a.use(apiLimiter);
-      a.get("/api/thing", (_, res) => res.status(200).json({ ok: true }));
-    });
+  it("shares one budget across a user's requests", async () => {
+    const app = apiApp("user-carol");
 
-    const first = await request(app).get("/api/thing").set("Cookie", SESSION);
-    const second = await request(app).get("/api/thing").set("Cookie", SESSION);
+    const first = await request(app).get("/api/thing").set("Cookie", "session=real");
+    const second = await request(app).get("/api/thing").set("Cookie", "session=real");
 
     expect(Number(second.headers["ratelimit-remaining"])).toBe(
       Number(first.headers["ratelimit-remaining"]) - 1
     );
   });
 
-  it("also matches the __Secure- prefixed cookie used over https", async () => {
+  it("never reaches the per-user budget for a forged session cookie", async () => {
+    const app = apiApp("user-dave");
+
+    const forged = await request(app).get("/api/thing").set("Cookie", "session=forged");
+
+    // Rejected at validation, so it cannot mint itself a fresh bucket.
+    expect(forged.status).toBe(401);
+    expect(forged.headers["ratelimit-remaining"]).toBeUndefined();
+  });
+});
+
+describe("apiFailureLimiter", () => {
+  it("does not spend the budget on requests that succeed", async () => {
     const app = appWith((a) => {
-      a.use(apiLimiter);
+      a.use(apiFailureLimiter);
       a.get("/api/thing", (_, res) => res.status(200).json({ ok: true }));
     });
 
-    const plain = await request(app).get("/api/thing").set("Cookie", SESSION);
-    const secure = await request(app)
-      .get("/api/thing")
-      .set("Cookie", "__Secure-better-auth.session_token=abc.def");
+    const statuses = await hammer(app, "/api/thing", 120, { "X-Forwarded-For": "203.0.113.20" });
 
-    // Same token value, so the secure variant lands in the same bucket.
-    expect(Number(secure.headers["ratelimit-remaining"])).toBe(
-      Number(plain.headers["ratelimit-remaining"]) - 1
-    );
+    expect(statuses.every((s) => s === 200)).toBe(true);
   });
 
-  it("falls back to the IP when there is no session cookie", async () => {
+  it("cuts off cookie rotation well before the flood ceiling", async () => {
     const app = appWith((a) => {
-      a.use(apiLimiter);
+      a.use("/api", apiFailureLimiter, fakeAuthSession("session=real", "user-eve"));
       a.get("/api/thing", (_, res) => res.status(200).json({ ok: true }));
     });
 
-    const first = await request(app).get("/api/thing").set("X-Forwarded-For", "203.0.113.7");
-    const second = await request(app).get("/api/thing").set("X-Forwarded-For", "203.0.113.7");
+    const statuses: number[] = [];
+    for (let i = 0; i < 102; i++) {
+      // A different invented cookie every time — the bypass this bound closes.
+      const res = await request(app)
+        .get("/api/thing")
+        .set("X-Forwarded-For", "203.0.113.21")
+        .set("Cookie", `session=forged-${i}`);
+      statuses.push(res.status);
+    }
 
-    expect(Number(second.headers["ratelimit-remaining"])).toBe(
-      Number(first.headers["ratelimit-remaining"]) - 1
-    );
+    expect(statuses.slice(0, 100).every((s) => s === 401)).toBe(true);
+    expect(statuses.at(-1)).toBe(429);
   });
 });
 


### PR DESCRIPTION
Follow-up to #80, which merged before this fix was pushed. **`main` currently has the weakness described below.**

## The problem

`apiLimiter` as merged hashes any non-empty `better-auth.session_token` straight off the cookie header, in middleware that runs *before* `authSession` validates anything. A caller can rotate invented cookie values to hand itself a fresh 1000-request bucket per value.

Reproduced against a running server on the merged code:

```
fake-aaa -> RateLimit-Remaining: 999
fake-bbb -> RateLimit-Remaining: 999
```

**Impact is a weakened rate limit, not an auth bypass** — `authSession` still rejects these requests, so nothing is exposed. The effect is that unauthenticated `/api` traffic is bounded by the 5000/5min flood ceiling rather than the intended 1000, i.e. 10x the pre-#80 global limit of 500. Worth fixing promptly; not an emergency.

Credit to CodeRabbit, which flagged this on #80.

## The fix

- **`apiLimiter` keys on `req.auth.userId`.** The key only exists once the session has been validated, so there is nothing forgeable to key on.
- **Mount order is now `app.use("/api", apiFailureLimiter, authSession, apiLimiter)`**, which also lifts `authSession` off the nine individual router mounts instead of running it twice.
- **New `apiFailureLimiter`**: 100 *rejected* `/api` requests / 5 min per IP, ahead of validation. `skipSuccessfulRequests` keeps legitimate traffic off it entirely, so a shared office IP is unaffected while cookie rotation is cut off 50x below the flood ceiling.

That third piece is why I did not simply move the existing limiter behind `authSession`. On its own that would leave unauthenticated probing free to force a session lookup on every request up to the 5000 flood limit; the failure bound makes that cheap to shed.

## Verification

Same two cookies against the fixed server now return 401 and draw down one shared bucket:

```
fake-aaa -> 401  RateLimit-Remaining: 90
fake-bbb -> 401  RateLimit-Remaining: 89
fake-ccc -> 401  RateLimit-Remaining: 88
```

An authenticated dashboard load is unchanged at 10 requests, all 200.

Tests reworked: the `apiLimiter` cases drive a stub `authSession` so a forged cookie never reaches the per-user budget, plus two new cases for the failure bound. **346 passing**, build and lint clean (3 pre-existing warnings in `appError.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)