### PR TITLE
feat(billing): Paddle subscriptions, organization layer and plan limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sesv2": "^3.1106.0",
+        "@paddle/paddle-node-sdk": "^3.10.0",
         "@sentry/node": "^10.69.0",
         "@sentry/profiling-node": "^10.69.0",
         "better-auth": "^1.6.26",
@@ -1703,6 +1704,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paddle/paddle-node-sdk": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@paddle/paddle-node-sdk/-/paddle-node-sdk-3.10.0.tgz",
+      "integrity": "sha512-njqp+L6e/2aR99EYh/Ulyu6B9sIyVERTFclGOznKmLZcy11pAwHoHyIgq1BUH1ybQH+YmJQmrrUQC/Rfg8JAAw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@paralleldrive/cuid2": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "homepage": "https://github.com/Daniel88dev/flexi-day-be#readme",
   "dependencies": {
     "@aws-sdk/client-sesv2": "^3.1106.0",
+    "@paddle/paddle-node-sdk": "^3.10.0",
     "@sentry/node": "^10.69.0",
     "@sentry/profiling-node": "^10.69.0",
     "better-auth": "^1.6.26",

--- a/src/config.ts
+++ b/src/config.ts
@@ -120,18 +120,26 @@ const parsePaddle = (): PaddleConfig | undefined => {
     throw new Error("PADDLE_ENV=sandbox must never be set when NODE_ENV=production");
   }
 
+  const prices = {
+    proMonthly: envOrThrow("PADDLE_PRICE_PRO_MONTHLY"),
+    proYearly: envOrThrow("PADDLE_PRICE_PRO_YEARLY"),
+    enterpriseMonthly: envOrThrow("PADDLE_PRICE_ENTERPRISE_MONTHLY"),
+    enterpriseYearly: envOrThrow("PADDLE_PRICE_ENTERPRISE_YEARLY"),
+    extraGroupMonthly: envOrThrow("PADDLE_PRICE_EXTRA_GROUP_MONTHLY"),
+    extraGroupYearly: envOrThrow("PADDLE_PRICE_EXTRA_GROUP_YEARLY"),
+  };
+
+  // A price id pasted into two slots would make `derivePlanFromItems` resolve
+  // the wrong plan from a webhook — cheap to catch at boot, invisible later.
+  if (new Set(Object.values(prices)).size !== Object.keys(prices).length) {
+    throw new Error("Paddle price ids must all be distinct");
+  }
+
   return {
     apiKey: envOrThrow("PADDLE_API_KEY"),
     webhookSecret: envOrThrow("PADDLE_WEBHOOK_SECRET"),
     environment: rawEnv,
-    prices: {
-      proMonthly: envOrThrow("PADDLE_PRICE_PRO_MONTHLY"),
-      proYearly: envOrThrow("PADDLE_PRICE_PRO_YEARLY"),
-      enterpriseMonthly: envOrThrow("PADDLE_PRICE_ENTERPRISE_MONTHLY"),
-      enterpriseYearly: envOrThrow("PADDLE_PRICE_ENTERPRISE_YEARLY"),
-      extraGroupMonthly: envOrThrow("PADDLE_PRICE_EXTRA_GROUP_MONTHLY"),
-      extraGroupYearly: envOrThrow("PADDLE_PRICE_EXTRA_GROUP_YEARLY"),
-    },
+    prices,
   };
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,21 @@ type QuotaRolloverConfig = {
   timezone: string;
 };
 
+type PaddleConfig = {
+  apiKey: string;
+  webhookSecret: string;
+  environment: "sandbox" | "production";
+  /** Paddle price ids for the six catalog prices (EUR, tax-exclusive). */
+  prices: {
+    proMonthly: string;
+    proYearly: string;
+    enterpriseMonthly: string;
+    enterpriseYearly: string;
+    extraGroupMonthly: string;
+    extraGroupYearly: string;
+  };
+};
+
 type DevToolsConfig = {
   /** Shared secret every `/api/dev/*` request must present as `x-dev-token`. */
   token: string;
@@ -47,6 +62,8 @@ type Config = {
   auth?: AuthConfig;
   email: EmailConfig;
   quotaRollover: QuotaRolloverConfig;
+  /** Billing via Paddle. `undefined` until the keys are provisioned — billing routes then 503. */
+  paddle?: PaddleConfig;
   /** Local seeding/session surface. `undefined` means the routes do not exist. */
   dev?: DevToolsConfig;
 };
@@ -84,6 +101,39 @@ const parseTemplateStage = (): "dev" | "prod" => {
 const databaseUrl = envOrThrow("DATABASE");
 
 const LOCAL_DB_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/**
+ * Paddle stays optional so every environment without keys (tests, fresh local
+ * setups) boots normally — but once PADDLE_API_KEY is present, every other
+ * variable must be too, so a half-configured deploy fails at boot instead of
+ * at the first checkout.
+ */
+const parsePaddle = (): PaddleConfig | undefined => {
+  if (!process.env.PADDLE_API_KEY) return undefined;
+
+  const rawEnv =
+    process.env.PADDLE_ENV ?? (environment === "production" ? "production" : "sandbox");
+  if (rawEnv !== "sandbox" && rawEnv !== "production") {
+    throw new Error(`Invalid PADDLE_ENV: "${rawEnv}". Expected "sandbox" or "production"`);
+  }
+  if (environment === "production" && rawEnv === "sandbox") {
+    throw new Error("PADDLE_ENV=sandbox must never be set when NODE_ENV=production");
+  }
+
+  return {
+    apiKey: envOrThrow("PADDLE_API_KEY"),
+    webhookSecret: envOrThrow("PADDLE_WEBHOOK_SECRET"),
+    environment: rawEnv,
+    prices: {
+      proMonthly: envOrThrow("PADDLE_PRICE_PRO_MONTHLY"),
+      proYearly: envOrThrow("PADDLE_PRICE_PRO_YEARLY"),
+      enterpriseMonthly: envOrThrow("PADDLE_PRICE_ENTERPRISE_MONTHLY"),
+      enterpriseYearly: envOrThrow("PADDLE_PRICE_ENTERPRISE_YEARLY"),
+      extraGroupMonthly: envOrThrow("PADDLE_PRICE_EXTRA_GROUP_MONTHLY"),
+      extraGroupYearly: envOrThrow("PADDLE_PRICE_EXTRA_GROUP_YEARLY"),
+    },
+  };
+};
 
 /**
  * Gate for the local dev/seeding surface (`/api/dev/*`). It stays `undefined`
@@ -166,5 +216,8 @@ export const config: Config = {
     cron: process.env.QUOTA_ROLLOVER_CRON ?? "0 2 * * *",
     timezone: process.env.QUOTA_ROLLOVER_TIMEZONE ?? "Europe/Prague",
   },
+  paddle: parsePaddle(),
   dev: parseDevTools(),
 };
+
+export type { PaddleConfig };

--- a/src/controllers/auth/handleSignUpWithTeam.ts
+++ b/src/controllers/auth/handleSignUpWithTeam.ts
@@ -131,9 +131,12 @@ export const handleSignUpWithTeam = async (req: Request, res: Response) => {
 
 const createTeamForUser = async (userId: string, teamName: string) =>
   db.transaction(async (tx) => {
+    const organization = await services.organization.ensureOrganizationForUser(userId, tx);
+
     const newGroup = await services.group.createGroup(
       {
         id: generateRandomUUID(),
+        organizationId: organization.id,
         groupName: teamName,
         managerUserId: userId,
         mainApprovalUser: userId,

--- a/src/controllers/auth/tests/handleSignUpWithTeam.test.ts
+++ b/src/controllers/auth/tests/handleSignUpWithTeam.test.ts
@@ -6,12 +6,14 @@ const {
   mockCreateGroupUser,
   mockDelete,
   mockOpenQuotaFromGroupDefaults,
+  mockEnsureOrganizationForUser,
 } = vi.hoisted(() => ({
   mockSignUpEmail: vi.fn(),
   mockCreateGroup: vi.fn(),
   mockCreateGroupUser: vi.fn(),
   mockDelete: vi.fn(),
   mockOpenQuotaFromGroupDefaults: vi.fn(),
+  mockEnsureOrganizationForUser: vi.fn(),
 }));
 
 vi.mock("../../../utils/auth.js", () => ({
@@ -32,7 +34,16 @@ vi.mock("../../../services/DBServices.js", () => ({
     group: { createGroup: mockCreateGroup },
     groupUser: { createGroupUser: mockCreateGroupUser },
     userYearQuotas: { openQuotaFromGroupDefaults: mockOpenQuotaFromGroupDefaults },
+    organization: { ensureOrganizationForUser: mockEnsureOrganizationForUser },
   }),
+}));
+
+// Billing plan-limit guards are no-ops here; their behavior has its own suite.
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertCanCreateGroup: vi.fn(),
+  assertCanAddMember: vi.fn(),
+  assertGroupWritable: vi.fn(),
+  assertGroupsWritable: vi.fn(),
 }));
 
 import { handleSignUpWithTeam, validateSignUpWithTeam } from "../handleSignUpWithTeam.js";
@@ -81,6 +92,7 @@ describe("handleSignUpWithTeam", () => {
     mockSignUpEmail.mockResolvedValue(okSignUp());
     mockCreateGroup.mockResolvedValue({ id: "group-1", groupName: "Platform" });
     mockCreateGroupUser.mockResolvedValue({ id: "membership-1" });
+    mockEnsureOrganizationForUser.mockResolvedValue({ id: "org-1" });
     mockDelete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
   });
 

--- a/src/controllers/billing/handleGetSubscription.ts
+++ b/src/controllers/billing/handleGetSubscription.ts
@@ -1,0 +1,61 @@
+import type { Request, Response } from "express";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+import { resolveEntitlements, PLAN_LIMITS } from "../../services/billing/entitlements.js";
+
+const services = createDBServices();
+
+/**
+ * The caller's own organization only — the org is resolved from the session
+ * user's ownership, never from a client-supplied id. Users who own no org yet
+ * get Free entitlements and empty usage.
+ */
+export const handleGetSubscription = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const organization = await services.organization.getOrganizationForOwner(auth.userId);
+
+  if (!organization) {
+    return res.status(200).json({
+      organization: null,
+      subscription: null,
+      entitlements: resolveEntitlements(null, new Date()),
+      usage: { groupsUsed: 0, groups: [] },
+      planLimits: PLAN_LIMITS,
+    });
+  }
+
+  const subscription = await services.billing.getSubscriptionForOrganization(organization.id);
+  const entitlements = resolveEntitlements(subscription ?? null, new Date());
+  const groups = await services.group.getGroupUsageForOrganization(organization.id);
+
+  return res.status(200).json({
+    organization: {
+      id: organization.id,
+      name: organization.name,
+      billingEmail: organization.billingEmail,
+      hasPaddleCustomer: organization.paddleCustomerId !== null,
+    },
+    subscription: subscription
+      ? {
+          plan: subscription.plan,
+          status: subscription.status,
+          billingCycle: subscription.billingCycle,
+          extraGroupSlots: subscription.extraGroupSlots,
+          currentPeriodEnd: subscription.currentPeriodEnd,
+          graceEndsAt: subscription.graceEndsAt,
+          cancelAt: subscription.cancelAt,
+        }
+      : null,
+    entitlements,
+    usage: {
+      groupsUsed: groups.length,
+      groups: groups.map((group) => ({
+        id: group.id,
+        groupName: group.groupName,
+        members: group.members,
+      })),
+    },
+    planLimits: PLAN_LIMITS,
+  });
+};

--- a/src/controllers/billing/handlePaddleWebhook.ts
+++ b/src/controllers/billing/handlePaddleWebhook.ts
@@ -1,0 +1,278 @@
+import type { Request, Response } from "express";
+import { EventName, type SubscriptionNotification } from "@paddle/paddle-node-sdk";
+import AppError from "../../utils/appError.js";
+import { requirePaddle } from "../../utils/paddle.js";
+import { createDBServices } from "../../services/DBServices.js";
+import { derivePlanFromItems } from "../../services/billing/paddleCatalog.js";
+import { subscriptionStatus } from "../../db/schema/subscription-schema.js";
+import type { SubscriptionPatch } from "../../services/billing/types.js";
+import { notifySubscriptionGrace } from "../../services/billing/billingNotifier.js";
+import { logger } from "../../middleware/logger.js";
+import { db, type DbTransaction } from "../../db/db.js";
+import type { OrganizationType } from "../../services/organization/types.js";
+import { lockOrganization } from "../../services/organization/organizationServices.js";
+
+const services = createDBServices();
+
+export const GRACE_PERIOD_DAYS = 14;
+
+const graceEnd = (from: Date): Date =>
+  new Date(from.getTime() + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000);
+
+const STATUS_MAP: Record<string, subscriptionStatus> = {
+  active: subscriptionStatus.Active,
+  trialing: subscriptionStatus.Trialing,
+  past_due: subscriptionStatus.PastDue,
+  paused: subscriptionStatus.Paused,
+  canceled: subscriptionStatus.Canceled,
+};
+
+const LAPSED_STATUSES = new Set([
+  subscriptionStatus.PastDue,
+  subscriptionStatus.Paused,
+  subscriptionStatus.Canceled,
+]);
+
+/** A grace email to send once the transaction has committed. */
+type PendingGraceEmail = { organization: OrganizationType; plan: string; graceEndsAt: Date };
+
+/**
+ * `custom_data.organizationId` is stamped on the checkout transaction and
+ * inherited by the subscription; older events fall back to the stored
+ * subscription row. Returns undefined for foreign subscriptions, which are
+ * acknowledged and ignored.
+ */
+const resolveOrganizationId = async (
+  data: SubscriptionNotification,
+  tx: DbTransaction
+): Promise<string | undefined> => {
+  const custom = (data.customData as { organizationId?: unknown } | null)?.organizationId;
+  if (typeof custom === "string" && custom.length > 0) {
+    const organization = await services.organization.getOrganizationById(custom, tx);
+    if (organization) return organization.id;
+  }
+  const existing = await services.billing.getSubscriptionByPaddleId(data.id, tx);
+  return existing?.organizationId;
+};
+
+const syncSubscriptionFromEvent = async (
+  data: SubscriptionNotification,
+  occurredAt: Date | null,
+  tx: DbTransaction
+): Promise<PendingGraceEmail | null> => {
+  const organizationId = await resolveOrganizationId(data, tx);
+  if (!organizationId) {
+    logger.warn("paddle webhook: subscription without a resolvable organization", {
+      paddleSubscriptionId: data.id,
+    });
+    return null;
+  }
+
+  // Serialise webhook processing per organization before reading `existing`.
+  // Both guards below are check-then-act on that read, and Paddle can deliver
+  // two events for the same subscription concurrently — without this, a late
+  // `past_due` re-arms grace on top of an `active` that just committed.
+  await lockOrganization(organizationId, tx);
+
+  const existing = await services.billing.getSubscriptionForOrganization(organizationId, tx);
+
+  // Paddle does not guarantee delivery order, and a retry can land an old
+  // event after a newer one. Applying it would resurrect stale state — e.g. a
+  // late `past_due` re-arming grace for a customer who has already paid.
+  // Strictly older only: `Date` truncates Paddle's microsecond `occurred_at`
+  // to milliseconds, and Paddle emits paired events (created + activated,
+  // updated + canceled) that can share a millisecond. `<=` would drop the
+  // second half of every such pair.
+  if (occurredAt && existing?.lastEventAt && occurredAt < existing.lastEventAt) {
+    logger.info("paddle webhook: discarding out-of-order event", {
+      organizationId,
+      paddleSubscriptionId: data.id,
+      occurredAt: occurredAt.toISOString(),
+      lastEventAt: existing.lastEventAt.toISOString(),
+    });
+    return null;
+  }
+
+  // An org keeps exactly one subscription row, so an event for a *different*
+  // Paddle subscription must not clobber a live one — otherwise cancelling a
+  // previously paused subscription wipes the replacement the org just bought.
+  const status = STATUS_MAP[data.status];
+  if (
+    existing?.paddleSubscriptionId &&
+    existing.paddleSubscriptionId !== data.id &&
+    (existing.status === subscriptionStatus.Active ||
+      existing.status === subscriptionStatus.Trialing) &&
+    status !== subscriptionStatus.Active &&
+    status !== subscriptionStatus.Trialing
+  ) {
+    logger.warn("paddle webhook: ignoring event for a superseded subscription", {
+      organizationId,
+      incoming: data.id,
+      current: existing.paddleSubscriptionId,
+    });
+    return null;
+  }
+
+  const derived = derivePlanFromItems(
+    requirePaddle().paddleConfig.prices,
+    data.items.map((item) => ({ priceId: item.price?.id, quantity: item.quantity }))
+  );
+
+  const patch: SubscriptionPatch = {
+    paddleSubscriptionId: data.id,
+    paddleCustomerId: data.customerId,
+    ...(status ? { status } : {}),
+    ...(derived ?? {}),
+    currentPeriodEnd: data.currentBillingPeriod?.endsAt
+      ? new Date(data.currentBillingPeriod.endsAt)
+      : null,
+    cancelAt:
+      data.scheduledChange?.action === "cancel" && data.scheduledChange.effectiveAt
+        ? new Date(data.scheduledChange.effectiveAt)
+        : null,
+    ...(occurredAt ? { lastEventAt: occurredAt } : {}),
+  };
+
+  let startedGrace: Date | null = null;
+  if (status === subscriptionStatus.Active || status === subscriptionStatus.Trialing) {
+    patch.graceEndsAt = null;
+  } else if (status && LAPSED_STATUSES.has(status) && !existing?.graceEndsAt) {
+    startedGrace = graceEnd(new Date());
+    patch.graceEndsAt = startedGrace;
+  }
+
+  const organization = await services.organization.getOrganizationById(organizationId, tx);
+
+  // The organization UPDATE runs BEFORE the subscription upsert on purpose.
+  // Inserting a subscription takes a FK share lock on the organization row;
+  // upgrading that to exclusive afterwards is the classic Postgres lock-upgrade
+  // deadlock against a concurrent `lockOrganization` in assertCanCreateGroup.
+  if (organization && !organization.paddleCustomerId) {
+    await services.organization.setOrganizationPaddleCustomerId(
+      organizationId,
+      data.customerId,
+      tx
+    );
+  }
+
+  await services.billing.upsertSubscription(organizationId, patch, tx);
+
+  if (startedGrace && organization) {
+    return {
+      organization,
+      plan: derived?.plan ?? existing?.plan ?? "PRO",
+      graceEndsAt: startedGrace,
+    };
+  }
+  return null;
+};
+
+/** Payment failed on a transaction tied to a subscription: start grace early. */
+const handlePaymentFailed = async (
+  paddleSubscriptionId: string | null,
+  tx: DbTransaction
+): Promise<PendingGraceEmail | null> => {
+  if (!paddleSubscriptionId) return null;
+  const found = await services.billing.getSubscriptionByPaddleId(paddleSubscriptionId, tx);
+  if (!found) return null;
+
+  // Same check-then-act on `graceEndsAt`: two concurrent payment_failed events
+  // would otherwise both read null and both send a grace email.
+  await lockOrganization(found.organizationId, tx);
+  const existing = await services.billing.getSubscriptionForOrganization(found.organizationId, tx);
+  if (!existing || existing.graceEndsAt) return null;
+
+  const endsAt = graceEnd(new Date());
+  await services.billing.upsertSubscription(existing.organizationId, { graceEndsAt: endsAt }, tx);
+
+  const organization = await services.organization.getOrganizationById(existing.organizationId, tx);
+  if (!organization) return null;
+  return { organization, plan: existing.plan ?? "PRO", graceEndsAt: endsAt };
+};
+
+/**
+ * Paddle webhook receiver. MUST be mounted with `express.raw()` and before the
+ * global JSON parser — signature verification needs the exact raw bytes.
+ * Everything that parses and verifies answers 200, including duplicates and
+ * events we ignore: a non-2xx makes Paddle retry a poison event indefinitely.
+ */
+export const handlePaddleWebhook = async (req: Request, res: Response) => {
+  const { paddle, paddleConfig } = requirePaddle();
+
+  const signature = req.headers["paddle-signature"];
+  if (typeof signature !== "string" || signature.length === 0) {
+    throw new AppError({ message: "Missing Paddle-Signature header", logging: true, code: 400 });
+  }
+
+  const rawBody = Buffer.isBuffer(req.body) ? req.body.toString("utf8") : undefined;
+  if (!rawBody) {
+    throw new AppError({ message: "Missing raw webhook body", logging: true, code: 400 });
+  }
+
+  let event;
+  try {
+    event = await paddle.webhooks.unmarshal(rawBody, paddleConfig.webhookSecret, signature);
+  } catch (error) {
+    throw new AppError({
+      message: "Invalid webhook signature",
+      logging: true,
+      code: 400,
+      cause: error,
+    });
+  }
+
+  const occurredAt = event.occurredAt ? new Date(event.occurredAt) : null;
+
+  // The idempotency record and the state change share one transaction: if
+  // processing throws, the event id rolls back with it and Paddle's retry
+  // reprocesses instead of being swallowed as a duplicate.
+  const { duplicate, graceEmail } = await db.transaction(async (tx) => {
+    const firstDelivery = await services.billing.recordPaddleEvent(
+      event.eventId,
+      event.eventType,
+      tx
+    );
+    if (!firstDelivery) return { duplicate: true, graceEmail: null };
+
+    let pending: PendingGraceEmail | null = null;
+
+    switch (event.eventType) {
+      case EventName.SubscriptionCreated:
+      case EventName.SubscriptionUpdated:
+      case EventName.SubscriptionActivated:
+      case EventName.SubscriptionTrialing:
+      case EventName.SubscriptionPastDue:
+      case EventName.SubscriptionPaused:
+      case EventName.SubscriptionResumed:
+      case EventName.SubscriptionCanceled:
+        pending = await syncSubscriptionFromEvent(event.data, occurredAt, tx);
+        break;
+      case EventName.TransactionPaymentFailed: {
+        const data = event.data as { subscriptionId: string | null };
+        pending = await handlePaymentFailed(data.subscriptionId, tx);
+        break;
+      }
+      case EventName.TransactionCompleted:
+        // Subscription state arrives via subscription.* events; nothing to do
+        // beyond the idempotency record.
+        break;
+      default:
+        logger.info("paddle webhook: ignoring event type", { eventType: event.eventType });
+        break;
+    }
+
+    return { duplicate: false, graceEmail: pending };
+  });
+
+  if (duplicate) {
+    return res.status(200).json({ received: true, duplicate: true });
+  }
+
+  // Post-commit and best-effort: the notifier logs its own failures, so a mail
+  // problem never turns a committed state change into a Paddle retry.
+  if (graceEmail) {
+    await notifySubscriptionGrace(graceEmail.organization, graceEmail.plan, graceEmail.graceEndsAt);
+  }
+
+  return res.status(200).json({ received: true });
+};

--- a/src/controllers/billing/handlePaddleWebhook.ts
+++ b/src/controllers/billing/handlePaddleWebhook.ts
@@ -182,6 +182,21 @@ const handlePaymentFailed = async (
   const existing = await services.billing.getSubscriptionForOrganization(found.organizationId, tx);
   if (!existing || existing.graceEndsAt) return null;
 
+  // Paddle retries a failed delivery, and the payment can succeed before the
+  // retry lands. Arming grace off a stale `payment_failed` would email a
+  // customer who has already paid — unlike syncSubscriptionFromEvent, this
+  // event carries no subscription status of its own to order against.
+  if (
+    existing.status === subscriptionStatus.Active ||
+    existing.status === subscriptionStatus.Trialing
+  ) {
+    logger.info("paddle webhook: ignoring payment_failed for an active subscription", {
+      organizationId: existing.organizationId,
+      paddleSubscriptionId,
+    });
+    return null;
+  }
+
   const endsAt = graceEnd(new Date());
   await services.billing.upsertSubscription(existing.organizationId, { graceEndsAt: endsAt }, tx);
 

--- a/src/controllers/billing/handlePatchSlots.ts
+++ b/src/controllers/billing/handlePatchSlots.ts
@@ -1,0 +1,122 @@
+import type { Request, Response } from "express";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+import { requirePaddle } from "../../utils/paddle.js";
+import AppError from "../../utils/appError.js";
+import { PLAN_LIMITS } from "../../services/billing/entitlements.js";
+import {
+  derivePlanFromItems,
+  planPriceId,
+  slotPriceId,
+} from "../../services/billing/paddleCatalog.js";
+import {
+  billingCycle,
+  subscriptionPlan,
+  subscriptionStatus,
+} from "../../db/schema/subscription-schema.js";
+import type { Subscription, ValidatedPatchSlotsType } from "../../services/billing/types.js";
+
+const services = createDBServices();
+
+export type ActiveSubscription = Subscription & {
+  paddleSubscriptionId: string;
+  plan: subscriptionPlan;
+  billingCycle: billingCycle;
+};
+
+/** 409s unless the caller's own org has an active Paddle subscription. */
+export const requireOwnedActiveSubscription = async (
+  userId: string
+): Promise<{ organizationId: string; subscription: ActiveSubscription }> => {
+  const organization = await services.organization.getOrganizationForOwner(userId);
+  const subscription = organization
+    ? await services.billing.getSubscriptionForOrganization(organization.id)
+    : undefined;
+
+  if (
+    !organization ||
+    !subscription?.paddleSubscriptionId ||
+    !subscription.plan ||
+    !subscription.billingCycle ||
+    subscription.status !== subscriptionStatus.Active
+  ) {
+    throw new AppError({
+      message: "No active subscription to modify",
+      logging: true,
+      code: 409,
+      context: { userId },
+    });
+  }
+
+  return { organizationId: organization.id, subscription: subscription as ActiveSubscription };
+};
+
+/**
+ * Changes the extra-group-slot quantity on the existing Paddle subscription.
+ * Slots are bought explicitly here, never implicitly on group creation — a
+ * paid-for empty slot is harmless, a created-but-unpaid group is not.
+ */
+export const handlePatchSlots = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+  const { paddle, paddleConfig } = requirePaddle();
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data: ValidatedPatchSlotsType = req.body;
+
+  const { organizationId, subscription } = await requireOwnedActiveSubscription(auth.userId);
+
+  const planKey = subscription.plan === subscriptionPlan.Enterprise ? "ENTERPRISE" : "PRO";
+  const maxExtraSlots = PLAN_LIMITS[planKey].maxExtraSlots;
+  if (data.extraGroupSlots > maxExtraSlots) {
+    throw new AppError({
+      message: `${planKey} allows at most ${maxExtraSlots.toString()} extra group slots`,
+      logging: true,
+      code: 422,
+      publicContext: { limit: maxExtraSlots, requested: data.extraGroupSlots },
+    });
+  }
+
+  if (data.extraGroupSlots === subscription.extraGroupSlots) {
+    return res.status(200).json({ extraGroupSlots: subscription.extraGroupSlots, changed: false });
+  }
+
+  // All items on one Paddle subscription must share the billing period, so
+  // the slot price always follows the plan's cycle.
+  const items = [
+    {
+      priceId: planPriceId(paddleConfig.prices, subscription.plan, subscription.billingCycle),
+      quantity: 1,
+    },
+    ...(data.extraGroupSlots > 0
+      ? [
+          {
+            priceId: slotPriceId(paddleConfig.prices, subscription.billingCycle),
+            quantity: data.extraGroupSlots,
+          },
+        ]
+      : []),
+  ];
+
+  const updated = await paddle.subscriptions.update(subscription.paddleSubscriptionId, {
+    items,
+    prorationBillingMode:
+      data.extraGroupSlots > subscription.extraGroupSlots
+        ? "prorated_immediately"
+        : "prorated_next_billing_period",
+  });
+
+  // The webhook remains the source of truth; this optimistic sync just keeps
+  // the UI from lagging behind the change it triggered.
+  const derived = derivePlanFromItems(
+    paddleConfig.prices,
+    updated.items.map((item) => ({ priceId: item.price?.id, quantity: item.quantity }))
+  );
+  if (derived) {
+    await services.billing.upsertSubscription(organizationId, derived);
+  }
+
+  return res.status(200).json({
+    extraGroupSlots: derived?.extraGroupSlots ?? data.extraGroupSlots,
+    changed: true,
+  });
+};

--- a/src/controllers/billing/handlePostChangePlan.ts
+++ b/src/controllers/billing/handlePostChangePlan.ts
@@ -11,6 +11,7 @@ import {
 import { billingCycle, subscriptionPlan } from "../../db/schema/subscription-schema.js";
 import type { ValidatedChangePlanType } from "../../services/billing/types.js";
 import { requireOwnedActiveSubscription } from "./handlePatchSlots.js";
+import { logger } from "../../middleware/logger.js";
 
 const services = createDBServices();
 
@@ -55,6 +56,20 @@ export const handlePostChangePlan = async (req: Request, res: Response) => {
   );
   if (derived) {
     await services.billing.upsertSubscription(organizationId, derived);
+  } else {
+    // Paddle accepted the change but returned prices outside our catalog.
+    // Persisting the intended state is better than leaving the row on the old
+    // plan indefinitely — the next subscription.updated webhook still wins.
+    logger.error("change-plan: Paddle returned items outside the price catalog", {
+      organizationId,
+      paddleSubscriptionId: subscription.paddleSubscriptionId,
+      priceIds: updated.items.map((item) => item.price?.id),
+    });
+    await services.billing.upsertSubscription(organizationId, {
+      plan: newPlan,
+      billingCycle: newCycle,
+      extraGroupSlots: keptSlots,
+    });
   }
 
   return res.status(200).json({

--- a/src/controllers/billing/handlePostChangePlan.ts
+++ b/src/controllers/billing/handlePostChangePlan.ts
@@ -1,0 +1,66 @@
+import type { Request, Response } from "express";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+import { requirePaddle } from "../../utils/paddle.js";
+import { PLAN_LIMITS } from "../../services/billing/entitlements.js";
+import {
+  derivePlanFromItems,
+  planPriceId,
+  slotPriceId,
+} from "../../services/billing/paddleCatalog.js";
+import { billingCycle, subscriptionPlan } from "../../db/schema/subscription-schema.js";
+import type { ValidatedChangePlanType } from "../../services/billing/types.js";
+import { requireOwnedActiveSubscription } from "./handlePatchSlots.js";
+
+const services = createDBServices();
+
+/** Pro ⇄ Enterprise and monthly ⇄ yearly on the existing subscription. */
+export const handlePostChangePlan = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+  const { paddle, paddleConfig } = requirePaddle();
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data: ValidatedChangePlanType = req.body;
+
+  const { organizationId, subscription } = await requireOwnedActiveSubscription(auth.userId);
+
+  const newPlan = data.plan === "ENTERPRISE" ? subscriptionPlan.Enterprise : subscriptionPlan.Pro;
+  const newCycle = data.billingCycle === "YEARLY" ? billingCycle.Yearly : billingCycle.Monthly;
+
+  if (newPlan === subscription.plan && newCycle === subscription.billingCycle) {
+    return res
+      .status(200)
+      .json({ plan: data.plan, billingCycle: data.billingCycle, changed: false });
+  }
+
+  // A downgrade may allow fewer extra slots than are currently held — clamp
+  // rather than reject, so Enterprise → Pro is always possible in one step.
+  const keptSlots = Math.min(subscription.extraGroupSlots, PLAN_LIMITS[data.plan].maxExtraSlots);
+
+  const items = [
+    { priceId: planPriceId(paddleConfig.prices, newPlan, newCycle), quantity: 1 },
+    ...(keptSlots > 0
+      ? [{ priceId: slotPriceId(paddleConfig.prices, newCycle), quantity: keptSlots }]
+      : []),
+  ];
+
+  const updated = await paddle.subscriptions.update(subscription.paddleSubscriptionId, {
+    items,
+    prorationBillingMode: "prorated_immediately",
+  });
+
+  const derived = derivePlanFromItems(
+    paddleConfig.prices,
+    updated.items.map((item) => ({ priceId: item.price?.id, quantity: item.quantity }))
+  );
+  if (derived) {
+    await services.billing.upsertSubscription(organizationId, derived);
+  }
+
+  return res.status(200).json({
+    plan: derived?.plan ?? newPlan,
+    billingCycle: derived?.billingCycle ?? newCycle,
+    extraGroupSlots: derived?.extraGroupSlots ?? keptSlots,
+    changed: true,
+  });
+};

--- a/src/controllers/billing/handlePostCheckout.ts
+++ b/src/controllers/billing/handlePostCheckout.ts
@@ -1,0 +1,66 @@
+import type { Request, Response } from "express";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+import { requirePaddle } from "../../utils/paddle.js";
+import AppError from "../../utils/appError.js";
+import { PLAN_LIMITS } from "../../services/billing/entitlements.js";
+import { planPriceId, slotPriceId } from "../../services/billing/paddleCatalog.js";
+import { billingCycle, subscriptionPlan } from "../../db/schema/subscription-schema.js";
+import type { ValidatedPostCheckoutType } from "../../services/billing/types.js";
+
+const services = createDBServices();
+
+const ACTIVE_STATUSES = new Set(["active", "trialing", "past_due"]);
+
+/**
+ * Creates a Paddle transaction for the Paddle.js overlay to open. No price or
+ * organization id ever originates client-side: the caller only names a plan,
+ * and the org is always the caller's own.
+ */
+export const handlePostCheckout = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+  const { paddle, paddleConfig } = requirePaddle();
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data: ValidatedPostCheckoutType = req.body;
+
+  const plan = data.plan === "ENTERPRISE" ? subscriptionPlan.Enterprise : subscriptionPlan.Pro;
+  const cycle = data.billingCycle === "YEARLY" ? billingCycle.Yearly : billingCycle.Monthly;
+
+  const maxExtraSlots = PLAN_LIMITS[data.plan].maxExtraSlots;
+  if (data.extraGroupSlots > maxExtraSlots) {
+    throw new AppError({
+      message: `${data.plan} allows at most ${maxExtraSlots.toString()} extra group slots`,
+      logging: true,
+      code: 422,
+      publicContext: { limit: maxExtraSlots, requested: data.extraGroupSlots },
+    });
+  }
+
+  const organization = await services.organization.ensureOrganizationForUser(auth.userId);
+
+  const existing = await services.billing.getSubscriptionForOrganization(organization.id);
+  if (existing?.paddleSubscriptionId && existing.status && ACTIVE_STATUSES.has(existing.status)) {
+    throw new AppError({
+      message: "This organization already has a subscription — use change-plan instead",
+      logging: true,
+      code: 409,
+      context: { organizationId: organization.id },
+    });
+  }
+
+  const items = [
+    { priceId: planPriceId(paddleConfig.prices, plan, cycle), quantity: 1 },
+    ...(data.extraGroupSlots > 0
+      ? [{ priceId: slotPriceId(paddleConfig.prices, cycle), quantity: data.extraGroupSlots }]
+      : []),
+  ];
+
+  const transaction = await paddle.transactions.create({
+    items,
+    customData: { organizationId: organization.id },
+    ...(organization.paddleCustomerId ? { customerId: organization.paddleCustomerId } : {}),
+  });
+
+  return res.status(201).json({ transactionId: transaction.id });
+};

--- a/src/controllers/billing/handlePostCheckout.ts
+++ b/src/controllers/billing/handlePostCheckout.ts
@@ -5,12 +5,27 @@ import { requirePaddle } from "../../utils/paddle.js";
 import AppError from "../../utils/appError.js";
 import { PLAN_LIMITS } from "../../services/billing/entitlements.js";
 import { planPriceId, slotPriceId } from "../../services/billing/paddleCatalog.js";
-import { billingCycle, subscriptionPlan } from "../../db/schema/subscription-schema.js";
+import {
+  billingCycle,
+  subscriptionPlan,
+  subscriptionStatus,
+} from "../../db/schema/subscription-schema.js";
 import type { ValidatedPostCheckoutType } from "../../services/billing/types.js";
 
 const services = createDBServices();
 
-const ACTIVE_STATUSES = new Set(["active", "trialing", "past_due"]);
+/**
+ * Statuses that still represent a subscription Paddle can bill or resume.
+ * `paused` counts: buying a second one would leave the org owning two Paddle
+ * subscriptions against a single local row, and a later `subscription.resumed`
+ * for the old one would clobber the new.
+ */
+const ACTIVE_STATUSES = new Set<string>([
+  subscriptionStatus.Active,
+  subscriptionStatus.Trialing,
+  subscriptionStatus.PastDue,
+  subscriptionStatus.Paused,
+]);
 
 /**
  * Creates a Paddle transaction for the Paddle.js overlay to open. No price or

--- a/src/controllers/billing/handlePostPortal.ts
+++ b/src/controllers/billing/handlePostPortal.ts
@@ -1,0 +1,32 @@
+import type { Request, Response } from "express";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+import { requirePaddle } from "../../utils/paddle.js";
+import AppError from "../../utils/appError.js";
+
+const services = createDBServices();
+
+/** Returns a Paddle customer-portal URL for managing the payment method. */
+export const handlePostPortal = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+  const { paddle } = requirePaddle();
+
+  const organization = await services.organization.getOrganizationForOwner(auth.userId);
+  if (!organization?.paddleCustomerId) {
+    throw new AppError({
+      message: "No billing account yet — subscribe first",
+      logging: true,
+      code: 404,
+      context: { userId: auth.userId },
+    });
+  }
+
+  const subscription = await services.billing.getSubscriptionForOrganization(organization.id);
+
+  const session = await paddle.customerPortalSessions.create(
+    organization.paddleCustomerId,
+    subscription?.paddleSubscriptionId ? [subscription.paddleSubscriptionId] : []
+  );
+
+  return res.status(200).json({ url: session.urls.general.overview });
+};

--- a/src/controllers/billing/tests/guardWiring.test.ts
+++ b/src/controllers/billing/tests/guardWiring.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Every other controller suite mocks the billing guards to no-ops, which means
+ * deleting a guard call from a controller would leave the whole suite green and
+ * silently drop plan enforcement from that route. This suite exists purely to
+ * assert the wiring: that each guarded controller really does invoke its guard.
+ */
+
+const {
+  mockAssertCanCreateGroup,
+  mockAssertCanAddMember,
+  mockAssertGroupWritable,
+  mockAssertGroupsWritable,
+} = vi.hoisted(() => ({
+  mockAssertCanCreateGroup: vi.fn(),
+  mockAssertCanAddMember: vi.fn(),
+  mockAssertGroupWritable: vi.fn(),
+  mockAssertGroupsWritable: vi.fn(),
+}));
+
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertCanCreateGroup: mockAssertCanCreateGroup,
+  assertCanAddMember: mockAssertCanAddMember,
+  assertGroupWritable: mockAssertGroupWritable,
+  assertGroupsWritable: mockAssertGroupsWritable,
+}));
+
+const VACATION = {
+  id: "vac-1",
+  userId: "user-1",
+  groupId: "group-1",
+  approvedAt: null,
+  rejectedAt: null,
+  deletedAt: null,
+};
+
+const services = vi.hoisted(() => ({
+  getVacationById: vi.fn(),
+  createVacationEvent: vi.fn(),
+  approveVacation: vi.fn(),
+  deleteVacation: vi.fn(),
+  createGroup: vi.fn(),
+  createGroupUser: vi.fn(),
+  openQuotaFromGroupDefaults: vi.fn(),
+  ensureOrganizationForUser: vi.fn(),
+  getGroupUser: vi.fn(),
+  upsertUserYearQuota: vi.fn(),
+  getUserYearGroupQuotas: vi.fn(),
+  postChanges: vi.fn(),
+}));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    vacation: {
+      getVacationById: services.getVacationById,
+      approveVacation: services.approveVacation,
+      deleteVacation: services.deleteVacation,
+    },
+    vacationEvent: { createVacationEvent: services.createVacationEvent },
+    group: { createGroup: services.createGroup },
+    groupUser: {
+      createGroupUser: services.createGroupUser,
+      getGroupUser: services.getGroupUser,
+    },
+    userYearQuotas: {
+      openQuotaFromGroupDefaults: services.openQuotaFromGroupDefaults,
+      upsertUserYearQuota: services.upsertUserYearQuota,
+      getUserYearGroupQuotas: services.getUserYearGroupQuotas,
+    },
+    changes: { postChanges: services.postChanges },
+    organization: { ensureOrganizationForUser: services.ensureOrganizationForUser },
+  }),
+}));
+
+vi.mock("../../../db/db.js", () => ({
+  db: { transaction: (cb: (tx: unknown) => unknown) => cb({}) },
+}));
+
+vi.mock("../../../middleware/authSession.js", () => ({
+  getAuth: () => ({
+    userId: "user-1",
+    sessionId: "s-1",
+    userName: "Olivia",
+    userEmail: "olivia@dev.local",
+    emailVerified: true,
+  }),
+}));
+
+vi.mock("../../vacation/decisionGuards.js", () => ({
+  assertMayDecide: vi.fn(),
+  assertStillPending: vi.fn(),
+  mayDecideOwn: vi.fn(),
+}));
+
+vi.mock("../../../services/vacation/quotaGuard.js", () => ({
+  assertApprovalWithinQuota: vi.fn(),
+  assertRequestWithinQuota: vi.fn(),
+}));
+
+vi.mock("../../../services/vacation/vacationNotifier.js", () => ({
+  notifyVacationDecision: vi.fn(),
+  notifyVacationCancelled: vi.fn(),
+  notifyVacationRequested: vi.fn(),
+}));
+
+vi.mock("../../vacation/utils.js", () => ({
+  resolveVacationPermissions: () => ({ canCancel: true, canView: true }),
+}));
+
+import { handlePostVacationApproval } from "../../vacation/handlePostVacationApproval.js";
+import { handleDeleteVacation } from "../../vacation/handleDeleteVacation.js";
+import { handlePostGroup } from "../../group/handlePostGroup.js";
+import { handlePutUserQuota } from "../../quotas/handlePutUserQuota.js";
+import { makeReqRes } from "../../../tests/testUtils.js";
+
+describe("billing guard wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    services.getVacationById.mockResolvedValue(VACATION);
+    services.approveVacation.mockResolvedValue({ ...VACATION, approvedAt: new Date() });
+    services.deleteVacation.mockResolvedValue({ ...VACATION, deletedAt: new Date() });
+    services.createVacationEvent.mockResolvedValue({ id: "ev-1" });
+    services.ensureOrganizationForUser.mockResolvedValue({ id: "org-1" });
+    services.createGroup.mockResolvedValue({
+      id: "group-1",
+      defaultVacationDays: 20,
+      defaultHomeOfficeDays: 0,
+    });
+    services.createGroupUser.mockResolvedValue({ id: "gu-1" });
+    services.getGroupUser.mockResolvedValue({ adminAccess: true });
+    services.getUserYearGroupQuotas.mockResolvedValue([]);
+    services.upsertUserYearQuota.mockResolvedValue({ id: "q-1" });
+  });
+
+  it("handlePostVacationApproval checks the group is writable", async () => {
+    const { req, res } = makeReqRes({ params: { id: "3f1b1a2c-0000-4000-8000-000000000000" } });
+    await handlePostVacationApproval(req, res);
+    expect(mockAssertGroupWritable).toHaveBeenCalledWith("group-1", {});
+  });
+
+  it("handleDeleteVacation checks the group is writable", async () => {
+    const { req, res } = makeReqRes({ params: { id: "3f1b1a2c-0000-4000-8000-000000000000" } });
+    await handleDeleteVacation(req, res);
+    expect(mockAssertGroupWritable).toHaveBeenCalledWith("group-1", {});
+  });
+
+  it("handlePostGroup checks the organization may create another group", async () => {
+    const { req, res } = makeReqRes({ body: { groupName: "Platform" } });
+    await handlePostGroup(req, res);
+    expect(mockAssertCanCreateGroup).toHaveBeenCalledWith("org-1", {});
+  });
+
+  it("handlePutUserQuota checks the group is writable before touching the quota", async () => {
+    const { req, res } = makeReqRes({
+      params: { groupId: "3f1b1a2c-0000-4000-8000-000000000000" },
+      body: { userId: "user-2", year: 2026, vacationDays: 20, homeOfficeDays: 5 },
+    });
+    services.getGroupUser.mockResolvedValue({ adminAccess: true });
+
+    // The guard runs early, so what the handler does afterwards is irrelevant
+    // to the wiring this asserts.
+    await handlePutUserQuota(req, res).catch(() => undefined);
+
+    expect(mockAssertGroupWritable).toHaveBeenCalledWith(
+      "3f1b1a2c-0000-4000-8000-000000000000",
+      {}
+    );
+  });
+});

--- a/src/controllers/billing/tests/handlePaddleWebhook.test.ts
+++ b/src/controllers/billing/tests/handlePaddleWebhook.test.ts
@@ -229,7 +229,6 @@ describe("handlePaddleWebhook", () => {
   });
 
   it("falls back to the stored row when custom data names no organization", async () => {
-    mockGetOrgById.mockResolvedValueOnce(undefined);
     mockGetSubByPaddleId.mockResolvedValue({ organizationId: "org-1", graceEndsAt: null });
     mockGetOrgById.mockResolvedValue(ORG);
     mockUnmarshal.mockResolvedValue({
@@ -299,8 +298,41 @@ describe("handlePaddleWebhook", () => {
       plan: "PRO",
       graceEndsAt: new Date(),
     });
+    // The guard reads the row again under the org lock, so this is the stub
+    // that actually decides the branch.
+    mockGetSubForOrg.mockResolvedValue({
+      organizationId: "org-1",
+      plan: "PRO",
+      graceEndsAt: new Date(),
+    });
     mockUnmarshal.mockResolvedValue({
       eventId: "evt-9",
+      occurredAt: OCCURRED_AT,
+      eventType: "transaction.payment_failed",
+      data: { subscriptionId: "psub-1" },
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    expect(mockUpsertSubscription).not.toHaveBeenCalled();
+    expect(mockNotifyGrace).not.toHaveBeenCalled();
+  });
+
+  it("ignores a retried payment_failed once the subscription is active again", async () => {
+    mockGetSubByPaddleId.mockResolvedValue({
+      organizationId: "org-1",
+      plan: "PRO",
+      graceEndsAt: null,
+    });
+    mockGetSubForOrg.mockResolvedValue({
+      organizationId: "org-1",
+      plan: "PRO",
+      status: "active",
+      graceEndsAt: null,
+    });
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-9b",
       occurredAt: OCCURRED_AT,
       eventType: "transaction.payment_failed",
       data: { subscriptionId: "psub-1" },

--- a/src/controllers/billing/tests/handlePaddleWebhook.test.ts
+++ b/src/controllers/billing/tests/handlePaddleWebhook.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Request } from "express";
+
+const {
+  mockUnmarshal,
+  mockRecordPaddleEvent,
+  mockUpsertSubscription,
+  mockGetSubForOrg,
+  mockGetSubByPaddleId,
+  mockGetOrgById,
+  mockSetCustomerId,
+  mockNotifyGrace,
+} = vi.hoisted(() => ({
+  mockUnmarshal: vi.fn(),
+  mockRecordPaddleEvent: vi.fn(),
+  mockUpsertSubscription: vi.fn(),
+  mockGetSubForOrg: vi.fn(),
+  mockGetSubByPaddleId: vi.fn(),
+  mockGetOrgById: vi.fn(),
+  mockSetCustomerId: vi.fn(),
+  mockNotifyGrace: vi.fn(),
+}));
+
+const PRICES = {
+  proMonthly: "pri_pro_m",
+  proYearly: "pri_pro_y",
+  enterpriseMonthly: "pri_ent_m",
+  enterpriseYearly: "pri_ent_y",
+  extraGroupMonthly: "pri_slot_m",
+  extraGroupYearly: "pri_slot_y",
+};
+
+vi.mock("../../../utils/paddle.js", () => ({
+  requirePaddle: () => ({
+    paddle: { webhooks: { unmarshal: mockUnmarshal } },
+    paddleConfig: {
+      apiKey: "key",
+      webhookSecret: "whsec_test",
+      environment: "sandbox",
+      prices: PRICES,
+    },
+  }),
+}));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    billing: {
+      recordPaddleEvent: mockRecordPaddleEvent,
+      upsertSubscription: mockUpsertSubscription,
+      getSubscriptionForOrganization: mockGetSubForOrg,
+      getSubscriptionByPaddleId: mockGetSubByPaddleId,
+    },
+    organization: {
+      getOrganizationById: mockGetOrgById,
+      setOrganizationPaddleCustomerId: mockSetCustomerId,
+    },
+  }),
+}));
+
+vi.mock("../../../services/billing/billingNotifier.js", () => ({
+  notifySubscriptionGrace: mockNotifyGrace,
+}));
+
+// Serialises webhook processing per organization; behaviour is covered by the
+// e2e suite against a real database.
+vi.mock("../../../services/organization/organizationServices.js", () => ({
+  lockOrganization: vi.fn(),
+}));
+
+// The handler wraps the idempotency record and the state change in one
+// transaction; the callback runs against this stand-in.
+vi.mock("../../../db/db.js", () => ({
+  db: { transaction: (cb: (tx: unknown) => unknown) => cb({}) },
+}));
+
+import { handlePaddleWebhook } from "../handlePaddleWebhook.js";
+import { makeReqRes } from "../../../tests/testUtils.js";
+
+const ORG = {
+  id: "org-1",
+  name: "Dana Holt",
+  ownerUserId: "user-1",
+  billingEmail: "dana@northwind.co",
+  paddleCustomerId: null,
+};
+
+const OCCURRED_AT = "2026-08-11T12:00:00.000Z";
+
+const subscriptionData = (overrides: Record<string, unknown> = {}) => ({
+  id: "psub-1",
+  status: "active",
+  customerId: "ctm-1",
+  customData: { organizationId: "org-1" },
+  items: [
+    { price: { id: PRICES.proMonthly }, quantity: 1 },
+    { price: { id: PRICES.extraGroupMonthly }, quantity: 2 },
+  ],
+  currentBillingPeriod: { startsAt: "2026-08-11T00:00:00Z", endsAt: "2026-09-11T00:00:00Z" },
+  scheduledChange: null,
+  ...overrides,
+});
+
+const makeWebhookReq = (signature: string | null = "ts=1;h1=abc") => {
+  const { req, res } = makeReqRes({ body: Buffer.from("{}") });
+  (req as unknown as { headers: Record<string, unknown> }).headers = signature
+    ? { "paddle-signature": signature }
+    : {};
+  return { req: req as Request, res };
+};
+
+describe("handlePaddleWebhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRecordPaddleEvent.mockResolvedValue(true);
+    mockGetSubForOrg.mockResolvedValue(undefined);
+    mockGetOrgById.mockResolvedValue(ORG);
+    mockUpsertSubscription.mockResolvedValue({ id: "sub-row-1" });
+  });
+
+  it("400s without a Paddle-Signature header", async () => {
+    const { req, res } = makeWebhookReq(null);
+    await expect(handlePaddleWebhook(req, res)).rejects.toMatchObject({ code: 400 });
+    expect(mockUnmarshal).not.toHaveBeenCalled();
+  });
+
+  it("400s when signature verification fails", async () => {
+    mockUnmarshal.mockRejectedValue(new Error("bad signature"));
+    const { req, res } = makeWebhookReq();
+    await expect(handlePaddleWebhook(req, res)).rejects.toMatchObject({ code: 400 });
+    expect(mockRecordPaddleEvent).not.toHaveBeenCalled();
+  });
+
+  it("answers 200 and skips processing on a replayed event id", async () => {
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-1",
+      occurredAt: OCCURRED_AT,
+      eventType: "subscription.updated",
+      data: subscriptionData(),
+    });
+    mockRecordPaddleEvent.mockResolvedValue(false);
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockUpsertSubscription).not.toHaveBeenCalled();
+  });
+
+  it("syncs plan, cycle and slots from the items on subscription.created", async () => {
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-2",
+      occurredAt: OCCURRED_AT,
+      eventType: "subscription.created",
+      data: subscriptionData(),
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    expect(mockUpsertSubscription).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({
+        paddleSubscriptionId: "psub-1",
+        paddleCustomerId: "ctm-1",
+        status: "active",
+        plan: "PRO",
+        billingCycle: "MONTHLY",
+        extraGroupSlots: 2,
+        graceEndsAt: null,
+      }),
+      {}
+    );
+    expect(mockSetCustomerId).toHaveBeenCalledWith("org-1", "ctm-1", {});
+    expect(mockNotifyGrace).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("starts grace and emails on subscription.canceled", async () => {
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-3",
+      occurredAt: OCCURRED_AT,
+      eventType: "subscription.canceled",
+      data: subscriptionData({ status: "canceled" }),
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    const patch = mockUpsertSubscription.mock.calls[0]?.[1] as { graceEndsAt: Date };
+    expect(patch.graceEndsAt).toBeInstanceOf(Date);
+    expect(patch.graceEndsAt.getTime()).toBeGreaterThan(Date.now() + 13 * 24 * 60 * 60 * 1000);
+    expect(mockNotifyGrace).toHaveBeenCalledWith(ORG, "PRO", patch.graceEndsAt);
+  });
+
+  it("does not restart grace when one is already running", async () => {
+    mockGetSubForOrg.mockResolvedValue({ graceEndsAt: new Date(), plan: "PRO" });
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-4",
+      occurredAt: OCCURRED_AT,
+      eventType: "subscription.past_due",
+      data: subscriptionData({ status: "past_due" }),
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    const patch = mockUpsertSubscription.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(patch.graceEndsAt).toBeUndefined();
+    expect(mockNotifyGrace).not.toHaveBeenCalled();
+  });
+
+  it("clears grace when the subscription is active again", async () => {
+    mockGetSubForOrg.mockResolvedValue({ graceEndsAt: new Date(), plan: "PRO" });
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-5",
+      occurredAt: OCCURRED_AT,
+      eventType: "subscription.updated",
+      data: subscriptionData({ status: "active" }),
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    expect(mockUpsertSubscription).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ graceEndsAt: null }),
+      {}
+    );
+  });
+
+  it("falls back to the stored row when custom data names no organization", async () => {
+    mockGetOrgById.mockResolvedValueOnce(undefined);
+    mockGetSubByPaddleId.mockResolvedValue({ organizationId: "org-1", graceEndsAt: null });
+    mockGetOrgById.mockResolvedValue(ORG);
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-6",
+      occurredAt: OCCURRED_AT,
+      eventType: "subscription.updated",
+      data: subscriptionData({ customData: null }),
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    expect(mockGetSubByPaddleId).toHaveBeenCalledWith("psub-1", {});
+    expect(mockUpsertSubscription).toHaveBeenCalledWith("org-1", expect.anything(), {});
+  });
+
+  it("acknowledges a foreign subscription without writing anything", async () => {
+    mockGetOrgById.mockResolvedValue(undefined);
+    mockGetSubByPaddleId.mockResolvedValue(undefined);
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-7",
+      occurredAt: OCCURRED_AT,
+      eventType: "subscription.updated",
+      data: subscriptionData({ customData: null }),
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    expect(mockUpsertSubscription).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("starts grace on transaction.payment_failed for a known subscription", async () => {
+    mockGetSubByPaddleId.mockResolvedValue({
+      organizationId: "org-1",
+      plan: "PRO",
+      graceEndsAt: null,
+    });
+    // Re-read under the org lock before the check-then-act on graceEndsAt.
+    mockGetSubForOrg.mockResolvedValue({
+      organizationId: "org-1",
+      plan: "PRO",
+      graceEndsAt: null,
+    });
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-8",
+      occurredAt: OCCURRED_AT,
+      eventType: "transaction.payment_failed",
+      data: { subscriptionId: "psub-1" },
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    expect(mockUpsertSubscription).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ graceEndsAt: expect.any(Date) }),
+      {}
+    );
+    expect(mockNotifyGrace).toHaveBeenCalled();
+  });
+
+  it("ignores payment_failed when grace is already running", async () => {
+    mockGetSubByPaddleId.mockResolvedValue({
+      organizationId: "org-1",
+      plan: "PRO",
+      graceEndsAt: new Date(),
+    });
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-9",
+      occurredAt: OCCURRED_AT,
+      eventType: "transaction.payment_failed",
+      data: { subscriptionId: "psub-1" },
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    expect(mockUpsertSubscription).not.toHaveBeenCalled();
+    expect(mockNotifyGrace).not.toHaveBeenCalled();
+  });
+
+  it("rolls the idempotency record back when processing throws", async () => {
+    // The record and the state change share one transaction, so a failure must
+    // not leave the event marked as seen — Paddle's retry has to reprocess it.
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-boom",
+      occurredAt: OCCURRED_AT,
+      eventType: "subscription.canceled",
+      data: subscriptionData({ status: "canceled" }),
+    });
+    mockUpsertSubscription.mockRejectedValue(new Error("deadlock detected"));
+
+    const { req, res } = makeWebhookReq();
+    await expect(handlePaddleWebhook(req, res)).rejects.toThrow("deadlock detected");
+
+    // The insert happened inside the same transaction that just rejected.
+    expect(mockRecordPaddleEvent).toHaveBeenCalledWith("evt-boom", "subscription.canceled", {});
+    expect(mockNotifyGrace).not.toHaveBeenCalled();
+  });
+
+  it("discards an event older than the last one applied", async () => {
+    mockGetSubForOrg.mockResolvedValue({
+      plan: "PRO",
+      graceEndsAt: null,
+      lastEventAt: new Date("2026-08-11T13:00:00.000Z"),
+    });
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-late",
+      occurredAt: "2026-08-11T12:00:00.000Z",
+      eventType: "subscription.past_due",
+      data: subscriptionData({ status: "past_due" }),
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    // A late past_due must not re-arm grace for a customer who already paid.
+    expect(mockUpsertSubscription).not.toHaveBeenCalled();
+    expect(mockNotifyGrace).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("ignores a cancellation for a superseded subscription", async () => {
+    mockGetSubForOrg.mockResolvedValue({
+      paddleSubscriptionId: "psub-NEW",
+      status: "active",
+      plan: "PRO",
+      graceEndsAt: null,
+      lastEventAt: null,
+    });
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-old-cancel",
+      occurredAt: OCCURRED_AT,
+      eventType: "subscription.canceled",
+      data: subscriptionData({ id: "psub-OLD", status: "canceled" }),
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    // Cancelling the replaced subscription must not wipe the live one.
+    expect(mockUpsertSubscription).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("records lastEventAt so ordering can be enforced next time", async () => {
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-order",
+      occurredAt: OCCURRED_AT,
+      eventType: "subscription.updated",
+      data: subscriptionData(),
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    expect(mockUpsertSubscription).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ lastEventAt: new Date(OCCURRED_AT) }),
+      {}
+    );
+  });
+
+  it("answers 200 for event types it does not handle", async () => {
+    mockUnmarshal.mockResolvedValue({
+      eventId: "evt-10",
+      occurredAt: OCCURRED_AT,
+      eventType: "product.updated",
+      data: {},
+    });
+
+    const { req, res } = makeWebhookReq();
+    await handlePaddleWebhook(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockUpsertSubscription).not.toHaveBeenCalled();
+  });
+});

--- a/src/controllers/dev/handlePostDevSetPlan.ts
+++ b/src/controllers/dev/handlePostDevSetPlan.ts
@@ -1,0 +1,94 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { createDBServices } from "../../services/DBServices.js";
+import AppError from "../../utils/appError.js";
+import {
+  manualPlanOverride,
+  subscriptionPlan,
+  subscriptionStatus,
+} from "../../db/schema/subscription-schema.js";
+import { resolveEntitlements } from "../../services/billing/entitlements.js";
+import { assertSeedEmail } from "../../services/dev/devSeedServices.js";
+
+const services = createDBServices();
+
+export const validatePostDevSetPlan = z.object({
+  email: z.email(),
+  /**
+   * What to force:
+   * - FREE / PRO / ENTERPRISE / CUSTOM — a manual plan override;
+   * - GRACE — a lapsed Pro subscription still inside its 14-day grace window;
+   * - EXPIRED — a lapsed Pro subscription past grace (read-only over limits);
+   * - CLEAR — remove the override and any forced state.
+   */
+  state: z.enum(["FREE", "PRO", "ENTERPRISE", "CUSTOM", "GRACE", "EXPIRED", "CLEAR"]),
+  manualMaxGroups: z.number().int().min(0).optional(),
+  manualMaxMembersPerGroup: z.number().int().min(0).optional(),
+});
+
+type ValidatedPostDevSetPlan = z.infer<typeof validatePostDevSetPlan>;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Forces a billing state for a seeded user's organization without touching
+ * Paddle, so limits, grace and read-only behavior can be exercised locally.
+ */
+export const handlePostDevSetPlan = async (req: Request, res: Response) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data: ValidatedPostDevSetPlan = req.body;
+
+  // Same scope as every other dev mutation: only seeded accounts, so that
+  // `POST /api/dev/reset` can always undo whatever this created.
+  assertSeedEmail(data.email);
+
+  const user = await services.user.getUserByEmail(data.email.toLowerCase());
+  if (!user) {
+    throw new AppError({ message: "User not found", code: 404, context: { email: data.email } });
+  }
+
+  const organization = await services.organization.ensureOrganizationForUser(user.id);
+
+  const clearPatch = {
+    manualPlanOverride: null,
+    manualMaxGroups: null,
+    manualMaxMembersPerGroup: null,
+    manualPlanUntil: null,
+  };
+
+  const patch = (() => {
+    switch (data.state) {
+      case "CLEAR":
+        return { ...clearPatch, plan: null, status: null, graceEndsAt: null };
+      case "GRACE":
+        return {
+          ...clearPatch,
+          plan: subscriptionPlan.Pro,
+          status: subscriptionStatus.PastDue,
+          graceEndsAt: new Date(Date.now() + 14 * DAY_MS),
+        };
+      case "EXPIRED":
+        return {
+          ...clearPatch,
+          plan: subscriptionPlan.Pro,
+          status: subscriptionStatus.Canceled,
+          graceEndsAt: new Date(Date.now() - DAY_MS),
+        };
+      default:
+        return {
+          ...clearPatch,
+          manualPlanOverride: data.state as manualPlanOverride,
+          manualMaxGroups: data.manualMaxGroups ?? null,
+          manualMaxMembersPerGroup: data.manualMaxMembersPerGroup ?? null,
+        };
+    }
+  })();
+
+  const subscription = await services.billing.upsertSubscription(organization.id, patch);
+
+  return res.status(200).json({
+    organizationId: organization.id,
+    subscription,
+    entitlements: resolveEntitlements(subscription ?? null, new Date()),
+  });
+};

--- a/src/controllers/group/handlePostGroup.ts
+++ b/src/controllers/group/handlePostGroup.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";
 import { currentYear } from "../../utils/dateFunc.js";
+import { assertCanCreateGroup } from "../../services/billing/guards.js";
 
 const services = createDBServices();
 
@@ -33,9 +34,14 @@ export const handlePostGroup = async (req: Request, res: Response) => {
   }
 
   const result = await db.transaction(async (tx) => {
+    const organization = await services.organization.ensureOrganizationForUser(auth.userId, tx);
+
+    await assertCanCreateGroup(organization.id, tx);
+
     const record = await services.group.createGroup(
       {
         id: generateRandomUUID(),
+        organizationId: organization.id,
         groupName: data.groupName,
         managerUserId: auth.userId,
         defaultVacationDays: data.defaultVacation,

--- a/src/controllers/group/handlePutGroupApprovers.ts
+++ b/src/controllers/group/handlePutGroupApprovers.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
+import { assertGroupWritable } from "../../services/billing/guards.js";
 import { getAuth } from "../../middleware/authSession.js";
 import type { ValidatedPutGroupApproversType } from "../../services/group/types.js";
 import AppError from "../../utils/appError.js";
@@ -28,6 +29,8 @@ export const handlePutGroupApprovers = async (req: Request, res: Response) => {
       context: { url: req.url, user: auth.userId, groupId },
     });
   }
+
+  await assertGroupWritable(groupId);
 
   const candidates = [data.mainApprovalUser, data.tempApprovalUser].filter(
     (id): id is string => id !== null

--- a/src/controllers/group/handlePutGroupMirrors.ts
+++ b/src/controllers/group/handlePutGroupMirrors.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
+import { assertGroupWritable } from "../../services/billing/guards.js";
 import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";
 import type { ValidatedPutGroupMirrorsType } from "../../services/groupMirror/types.js";
@@ -39,6 +40,8 @@ export const handlePutGroupMirrors = async (req: Request, res: Response) => {
       context: { url: req.url, userId: auth.userId, targetGroupId },
     });
   }
+
+  await assertGroupWritable(targetGroupId);
 
   const targetMembership = await services.groupUser.getGroupUser(data.userId, targetGroupId);
   if (!targetMembership) {

--- a/src/controllers/group/handlePutGroupQuotas.ts
+++ b/src/controllers/group/handlePutGroupQuotas.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
+import { assertGroupWritable } from "../../services/billing/guards.js";
 import { getAuth } from "../../middleware/authSession.js";
 import type { ValidatedPutGroupQuotasType } from "../../services/group/types.js";
 import AppError from "../../utils/appError.js";
@@ -32,6 +33,8 @@ export const handlePutGroupQuotas = async (req: Request, res: Response) => {
       context: { url: req.url, user: auth.userId, groupId },
     });
   }
+
+  await assertGroupWritable(groupId);
 
   const updated = await services.group.updateGroupQuotas(
     groupId,

--- a/src/controllers/group/handlePutGroupWorkingDays.ts
+++ b/src/controllers/group/handlePutGroupWorkingDays.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
+import { assertGroupWritable } from "../../services/billing/guards.js";
 import { getAuth } from "../../middleware/authSession.js";
 import type { ValidatedPutGroupWorkingDaysType } from "../../services/group/types.js";
 import AppError from "../../utils/appError.js";
@@ -30,6 +31,8 @@ export const handlePutGroupWorkingDays = async (req: Request, res: Response) => 
       context: { url: req.url, user: auth.userId, groupId },
     });
   }
+
+  await assertGroupWritable(groupId);
 
   const updated = await services.group.updateGroupWorkingDays(groupId, data.workingDays);
 

--- a/src/controllers/group/tests/handleGroupMirrors.test.ts
+++ b/src/controllers/group/tests/handleGroupMirrors.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// Billing plan-limit guards are no-ops here; their behavior has its own suite.
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertCanCreateGroup: vi.fn(),
+  assertCanAddMember: vi.fn(),
+  assertGroupWritable: vi.fn(),
+  assertGroupsWritable: vi.fn(),
+}));
+
 const {
   mockGetGroupUser,
   mockGetGroupUsers,

--- a/src/controllers/groupUser/handleDeleteGroupUser.ts
+++ b/src/controllers/groupUser/handleDeleteGroupUser.ts
@@ -52,6 +52,19 @@ export const handleDeleteGroupUser = async (req: Request, res: Response) => {
   }
 
   const removed = await db.transaction(async (tx) => {
+    // Re-read the group under a row lock: the approver columns below are
+    // rewritten from the values read here, and the copy fetched before the
+    // transaction can already be stale if another admin reassigned approvers.
+    const locked = await services.group.lockGroup(groupId, tx);
+    if (!locked) {
+      throw new AppError({
+        message: "Group not found",
+        logging: true,
+        code: 404,
+        context: { url: req.url, userId: auth.userId, groupId },
+      });
+    }
+
     const row = await services.groupUser.deleteGroupUser(membership.id, tx);
     if (!row) {
       throw new AppError({
@@ -64,11 +77,11 @@ export const handleDeleteGroupUser = async (req: Request, res: Response) => {
 
     // A former member must not keep approval rights through the group's
     // approver columns: main falls back to the manager, temp is cleared.
-    if (group.mainApprovalUser === userId || group.tempApprovalUser === userId) {
+    if (locked.mainApprovalUser === userId || locked.tempApprovalUser === userId) {
       await services.group.updateGroupApprovalUsers(
         groupId,
-        group.mainApprovalUser === userId ? group.managerUserId : group.mainApprovalUser,
-        group.tempApprovalUser === userId ? null : group.tempApprovalUser,
+        locked.mainApprovalUser === userId ? locked.managerUserId : locked.mainApprovalUser,
+        locked.tempApprovalUser === userId ? null : locked.tempApprovalUser,
         tx
       );
     }

--- a/src/controllers/groupUser/handleDeleteGroupUser.ts
+++ b/src/controllers/groupUser/handleDeleteGroupUser.ts
@@ -1,0 +1,80 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { getAuth } from "../../middleware/authSession.js";
+import { createDBServices } from "../../services/DBServices.js";
+import { assertGroupAdmin } from "./utils.js";
+import AppError from "../../utils/appError.js";
+import { db } from "../../db/db.js";
+
+const services = createDBServices();
+
+/**
+ * Removes a member from a group (soft delete). This is also how a downgraded
+ * owner gets back under their plan's member limit, so it must never be gated
+ * on the group being writable.
+ */
+export const handleDeleteGroupUser = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const groupId = z.uuid().parse(req.params.groupId);
+  // better-auth user ids are opaque non-UUID strings.
+  const userId = z.string().min(1).max(128).parse(req.params.userId);
+
+  await assertGroupAdmin(auth.userId, groupId);
+
+  const group = await services.group.getGroup(groupId);
+  if (!group) {
+    throw new AppError({
+      message: "Group not found",
+      logging: true,
+      code: 404,
+      context: { url: req.url, userId: auth.userId, groupId },
+    });
+  }
+
+  if (group.managerUserId === userId) {
+    throw new AppError({
+      message: "The group manager cannot be removed — transfer the group first",
+      logging: true,
+      code: 409,
+      context: { url: req.url, userId: auth.userId, groupId },
+    });
+  }
+
+  const membership = await services.groupUser.getGroupUser(userId, groupId);
+  if (!membership) {
+    throw new AppError({
+      message: "User is not a member of this group",
+      logging: true,
+      code: 404,
+      context: { url: req.url, userId: auth.userId, groupId, targetUser: userId },
+    });
+  }
+
+  const removed = await db.transaction(async (tx) => {
+    const row = await services.groupUser.deleteGroupUser(membership.id, tx);
+    if (!row) {
+      throw new AppError({
+        message: "Failed to remove group member",
+        logging: true,
+        code: 409,
+        context: { url: req.url, userId: auth.userId, groupId, targetUser: userId },
+      });
+    }
+
+    // A former member must not keep approval rights through the group's
+    // approver columns: main falls back to the manager, temp is cleared.
+    if (group.mainApprovalUser === userId || group.tempApprovalUser === userId) {
+      await services.group.updateGroupApprovalUsers(
+        groupId,
+        group.mainApprovalUser === userId ? group.managerUserId : group.mainApprovalUser,
+        group.tempApprovalUser === userId ? null : group.tempApprovalUser,
+        tx
+      );
+    }
+
+    return row;
+  });
+
+  return res.status(200).json(removed);
+};

--- a/src/controllers/groupUser/handlePostGroupInvite.ts
+++ b/src/controllers/groupUser/handlePostGroupInvite.ts
@@ -9,6 +9,8 @@ import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { generateInviteCode } from "../../utils/inviteCode.js";
 import { db } from "../../db/db.js";
 import { inviteExpiryFrom, notifyGroupInvited } from "../../services/groupUser/inviteNotifier.js";
+import { assertCanAddMember, assertGroupWritable } from "../../services/billing/guards.js";
+import { lockOrganization } from "../../services/organization/organizationServices.js";
 
 const services = createDBServices();
 
@@ -26,6 +28,10 @@ export const handlePostGroupInvite = async (req: Request, res: Response) => {
   const data: ValidatedPostGroupInviteType = req.body;
 
   await assertGroupAdmin(auth.userId, groupId);
+
+  // A read-only group must not grow; removing members is the way back under
+  // the limit, not adding more.
+  await assertGroupWritable(groupId);
 
   const group = await services.group.getGroup(groupId);
   if (!group) {
@@ -52,9 +58,22 @@ export const handlePostGroupInvite = async (req: Request, res: Response) => {
   }
 
   const invite = await db.transaction(async (tx) => {
+    // Lock the organization FIRST, before touching invite_link. The redemption
+    // path (handlePostGroupUser) locks organization → invite_link; taking them
+    // in the opposite order here would deadlock a resend against a concurrent
+    // redemption of the code being replaced.
+    await lockOrganization(group.organizationId, tx);
+
     // Supersede any open invite for this address so only the newest code works
-    // — and so the partial unique index does not reject the insert.
+    // — and so the partial unique index does not reject the insert. This runs
+    // BEFORE the seat check: a re-invite reuses the seat its own outstanding
+    // invite already reserves, and counting both would 402 a no-op change.
     await services.inviteLinks.revokeOpenInviteForEmail(groupId, data.email, tx);
+
+    // Inside the transaction, which row-locks the organization, so two admins
+    // inviting at once cannot both pass a check made against the same
+    // pre-insert seat count.
+    await assertCanAddMember(groupId, tx);
 
     const created = await services.inviteLinks.createInviteLink(
       {

--- a/src/controllers/groupUser/handlePostGroupUser.ts
+++ b/src/controllers/groupUser/handlePostGroupUser.ts
@@ -7,6 +7,7 @@ import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { normalizeInviteCode } from "../../utils/inviteCode.js";
 import AppError from "../../utils/appError.js";
 import { currentYear } from "../../utils/dateFunc.js";
+import { assertCanAddMember } from "../../services/billing/guards.js";
 
 const services = createDBServices();
 
@@ -83,6 +84,10 @@ export const handlePostGroupUser = async (req: Request, res: Response) => {
       });
     }
 
+    // The authoritative member-cap gate: runs inside the single-use redemption
+    // transaction, where the invite being redeemed still counts as open.
+    await assertCanAddMember(validateLink.groupId, tx, { redeemingOpenInvite: true });
+
     const createGroupUser = await services.groupUser.createGroupUser(
       {
         id: generateRandomUUID(),
@@ -110,7 +115,9 @@ export const handlePostGroupUser = async (req: Request, res: Response) => {
       });
     }
 
-    const group = await services.group.getGroup(validateLink.groupId);
+    // MUST take `tx`: checking out a second pool connection while this
+    // transaction holds one deadlocks the pool at concurrency >= pool size.
+    const group = await services.group.getGroup(validateLink.groupId, tx);
     await services.userYearQuotas.openQuotaFromGroupDefaults(
       {
         id: generateRandomUUID(),

--- a/src/controllers/groupUser/tests/handlePostGroupInvite.test.ts
+++ b/src/controllers/groupUser/tests/handlePostGroupInvite.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// Billing plan-limit guards are no-ops here; their behavior has its own suite.
+vi.mock("../../../services/organization/organizationServices.js", () => ({
+  lockOrganization: vi.fn(),
+}));
+
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertCanCreateGroup: vi.fn(),
+  assertCanAddMember: vi.fn(),
+  assertGroupWritable: vi.fn(),
+  assertGroupsWritable: vi.fn(),
+}));
+
 const {
   mockGetGroupUser,
   mockGetGroup,

--- a/src/controllers/groupUser/tests/handlePostGroupUser.test.ts
+++ b/src/controllers/groupUser/tests/handlePostGroupUser.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// Billing plan-limit guards are no-ops here; their behavior has its own suite.
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertCanCreateGroup: vi.fn(),
+  assertCanAddMember: vi.fn(),
+  assertGroupWritable: vi.fn(),
+  assertGroupsWritable: vi.fn(),
+}));
+
 const {
   mockGetInviteLinkByCode,
   mockUseInviteLink,

--- a/src/controllers/quotas/handlePutUserQuota.ts
+++ b/src/controllers/quotas/handlePutUserQuota.ts
@@ -8,6 +8,7 @@ import { db } from "../../db/db.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { changesType } from "../../db/schema/changes-schema.js";
 import { describeQuotaChange } from "../../services/userYearQuotas/quotaChangeDetail.js";
+import { assertGroupWritable } from "../../services/billing/guards.js";
 
 const services = createDBServices();
 
@@ -46,6 +47,8 @@ export const handlePutUserQuota = async (req: Request, res: Response) => {
         context: { url: req.url, user: auth.userId, groupId, targetUser: data.userId },
       });
     }
+
+    await assertGroupWritable(groupId, tx);
 
     const relatedYear = data.year.toString();
 

--- a/src/controllers/quotas/tests/handlePutUserQuota.test.ts
+++ b/src/controllers/quotas/tests/handlePutUserQuota.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// Billing plan-limit guards are no-ops here; their behavior has its own suite.
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertCanCreateGroup: vi.fn(),
+  assertCanAddMember: vi.fn(),
+  assertGroupWritable: vi.fn(),
+  assertGroupsWritable: vi.fn(),
+}));
+
 const { mockGetGroupUser, mockGetUserYearGroupQuotas, mockUpsertUserYearQuota, mockPostChanges } =
   vi.hoisted(() => ({
     mockGetGroupUser: vi.fn(),

--- a/src/controllers/vacation/handleBulkApproveVacation.ts
+++ b/src/controllers/vacation/handleBulkApproveVacation.ts
@@ -9,6 +9,7 @@ import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
 import { assertApprovalWithinQuota } from "../../services/vacation/quotaGuard.js";
 import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
+import { assertGroupsWritable } from "../../services/billing/guards.js";
 
 const services = createDBServices();
 
@@ -38,6 +39,10 @@ export const handleBulkApproveVacation = async (req: Request, res: Response) => 
 
     await assertMayDecide(auth.userId, rows, "approve", tx);
     assertStillPending(rows);
+    await assertGroupsWritable(
+      rows.map((row) => row.groupId),
+      tx
+    );
     await assertApprovalWithinQuota(rows, tx);
 
     const updated = await services.vacation.approveVacationsBulk(uniqueIds, auth.userId, tx);

--- a/src/controllers/vacation/handleBulkCancelVacation.ts
+++ b/src/controllers/vacation/handleBulkCancelVacation.ts
@@ -7,6 +7,7 @@ import type { ValidatedBulkCancelVacationType } from "../../services/vacation/ty
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationsCancelled } from "../../services/vacation/vacationNotifier.js";
+import { assertGroupsWritable } from "../../services/billing/guards.js";
 
 const services = createDBServices();
 
@@ -50,6 +51,8 @@ export const handleBulkCancelVacation = async (req: Request, res: Response) => {
         context: { auth, unauthorized: unauthorized.map((r) => r.id) },
       });
     }
+
+    await assertGroupsWritable(distinctGroupIds, tx);
 
     const updated = await services.vacation.cancelVacationsBulk(uniqueIds, tx);
 

--- a/src/controllers/vacation/handleBulkRejectVacation.ts
+++ b/src/controllers/vacation/handleBulkRejectVacation.ts
@@ -8,6 +8,7 @@ import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
 import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
+import { assertGroupsWritable } from "../../services/billing/guards.js";
 
 const services = createDBServices();
 
@@ -31,6 +32,10 @@ export const handleBulkRejectVacation = async (req: Request, res: Response) => {
 
     await assertMayDecide(auth.userId, rows, "reject", tx);
     assertStillPending(rows);
+    await assertGroupsWritable(
+      rows.map((row) => row.groupId),
+      tx
+    );
 
     const updated = await services.vacation.rejectVacationsBulk(
       uniqueIds,

--- a/src/controllers/vacation/handleDeleteVacation.ts
+++ b/src/controllers/vacation/handleDeleteVacation.ts
@@ -9,6 +9,7 @@ import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { resolveVacationPermissions } from "./utils.js";
 import { notifyVacationCancelled } from "../../services/vacation/vacationNotifier.js";
+import { assertGroupWritable } from "../../services/billing/guards.js";
 
 const services = createDBServices();
 
@@ -49,6 +50,8 @@ export const handleDeleteVacation = async (req: Request, res: Response) => {
         context: { auth, vacationId },
       });
     }
+
+    await assertGroupWritable(vacationData.groupId, tx);
 
     const deleted = await services.vacation.deleteVacation(vacationId, tx);
     if (!deleted) {

--- a/src/controllers/vacation/handlePostVacation.ts
+++ b/src/controllers/vacation/handlePostVacation.ts
@@ -90,8 +90,6 @@ export const handlePostVacation = async (req: Request, res: Response) => {
     });
   }
 
-  await assertGroupWritable(data.groupId);
-
   const days = expandDateRangeInclusive(fromIso, toIso);
 
   if (days.length === 0) {
@@ -131,6 +129,11 @@ export const handlePostVacation = async (req: Request, res: Response) => {
   }));
 
   const created = await db.transaction(async (tx) => {
+    // Inside the write transaction, not before it: a downgrade committing
+    // between the check and the insert would otherwise let this request write
+    // into a group that has just become read-only.
+    await assertGroupWritable(data.groupId, tx);
+
     await assertRequestWithinQuota(records, tx);
 
     const rows = await services.vacation.postVacationBulk(records, tx);

--- a/src/controllers/vacation/handlePostVacation.ts
+++ b/src/controllers/vacation/handlePostVacation.ts
@@ -13,6 +13,7 @@ import { db } from "../../db/db.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationRequested } from "../../services/vacation/vacationNotifier.js";
 import { assertRequestWithinQuota } from "../../services/vacation/quotaGuard.js";
+import { assertGroupWritable } from "../../services/billing/guards.js";
 
 const services = createDBServices();
 
@@ -88,6 +89,8 @@ export const handlePostVacation = async (req: Request, res: Response) => {
       context: { groupId: data.groupId },
     });
   }
+
+  await assertGroupWritable(data.groupId);
 
   const days = expandDateRangeInclusive(fromIso, toIso);
 

--- a/src/controllers/vacation/handlePostVacationApproval.ts
+++ b/src/controllers/vacation/handlePostVacationApproval.ts
@@ -10,6 +10,7 @@ import { notifyVacationDecision } from "../../services/vacation/vacationNotifier
 import type { ValidatedApproveVacationType } from "../../services/vacation/types.js";
 import { assertApprovalWithinQuota } from "../../services/vacation/quotaGuard.js";
 import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
+import { assertGroupWritable } from "../../services/billing/guards.js";
 
 const services = createDBServices();
 
@@ -35,6 +36,7 @@ export const handlePostVacationApproval = async (req: Request, res: Response) =>
 
     await assertMayDecide(auth.userId, [vacationData], "approve", tx);
     assertStillPending([vacationData]);
+    await assertGroupWritable(vacationData.groupId, tx);
     await assertApprovalWithinQuota([vacationData], tx);
 
     const row = await services.vacation.approveVacation(vacationId, auth.userId, tx);

--- a/src/controllers/vacation/handlePostVacationComment.ts
+++ b/src/controllers/vacation/handlePostVacationComment.ts
@@ -8,6 +8,7 @@ import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationComment } from "../../services/vacation/vacationNotifier.js";
 import { resolveVacationPermissions } from "./utils.js";
+import { assertGroupWritable } from "../../services/billing/guards.js";
 import type { ValidatedCommentVacationType } from "../../services/vacation/types.js";
 
 const services = createDBServices();
@@ -44,6 +45,8 @@ export const handlePostVacationComment = async (req: Request, res: Response) => 
         context: { userId: auth.userId, vacationId },
       });
     }
+
+    await assertGroupWritable(vacationData.groupId, tx);
 
     await services.vacationEvent.createVacationEvent(
       {

--- a/src/controllers/vacation/handlePostVacationReject.ts
+++ b/src/controllers/vacation/handlePostVacationReject.ts
@@ -6,6 +6,7 @@ import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";
 import type { ValidatedRejectVacationType } from "../../services/vacation/types.js";
 import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
+import { assertGroupWritable } from "../../services/billing/guards.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
@@ -34,6 +35,7 @@ export const handlePostVacationReject = async (req: Request, res: Response) => {
 
     await assertMayDecide(auth.userId, [vacationData], "reject", tx);
     assertStillPending([vacationData]);
+    await assertGroupWritable(vacationData.groupId, tx);
 
     const row = await services.vacation.rejectVacation(
       vacationId,

--- a/src/controllers/vacation/tests/handleBulkCancelVacation.test.ts
+++ b/src/controllers/vacation/tests/handleBulkCancelVacation.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// Billing plan-limit guards are no-ops here; their behavior has its own suite.
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertCanCreateGroup: vi.fn(),
+  assertCanAddMember: vi.fn(),
+  assertGroupWritable: vi.fn(),
+  assertGroupsWritable: vi.fn(),
+}));
+
 const {
   mockGetVacationsByIds,
   mockCancelVacationsBulk,

--- a/src/controllers/vacation/tests/handleDeleteVacation.test.ts
+++ b/src/controllers/vacation/tests/handleDeleteVacation.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// Billing plan-limit guards are no-ops here; their behavior has its own suite.
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertCanCreateGroup: vi.fn(),
+  assertCanAddMember: vi.fn(),
+  assertGroupWritable: vi.fn(),
+  assertGroupsWritable: vi.fn(),
+}));
+
 const {
   mockGetVacationById,
   mockDeleteVacation,

--- a/src/controllers/vacation/tests/handlePostVacation.test.ts
+++ b/src/controllers/vacation/tests/handlePostVacation.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+// Billing plan-limit guards are no-ops here; their behavior has its own suite.
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertCanCreateGroup: vi.fn(),
+  assertCanAddMember: vi.fn(),
+  assertGroupWritable: vi.fn(),
+  assertGroupsWritable: vi.fn(),
+}));
+
 const {
   mockPostVacationBulk,
   mockGetGroupUser,

--- a/src/controllers/vacation/tests/handlePostVacationApproval.test.ts
+++ b/src/controllers/vacation/tests/handlePostVacationApproval.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+// Billing plan-limit guards are no-ops here; their behavior has its own suite.
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertCanCreateGroup: vi.fn(),
+  assertCanAddMember: vi.fn(),
+  assertGroupWritable: vi.fn(),
+  assertGroupsWritable: vi.fn(),
+}));
+
 const {
   mockGetVacationById,
   mockGetGroupsWhereUserCanApprove,

--- a/src/controllers/vacation/tests/handlePostVacationComment.test.ts
+++ b/src/controllers/vacation/tests/handlePostVacationComment.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+// Billing plan-limit guards are no-ops here; their behavior has its own suite.
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertCanCreateGroup: vi.fn(),
+  assertCanAddMember: vi.fn(),
+  assertGroupWritable: vi.fn(),
+  assertGroupsWritable: vi.fn(),
+}));
+
 const { mockGetVacationById, mockCreateVacationEvent, mockResolvePermissions, mockNotifyComment } =
   vi.hoisted(() => ({
     mockGetVacationById: vi.fn(),

--- a/src/db/schema/group-schema.ts
+++ b/src/db/schema/group-schema.ts
@@ -1,11 +1,15 @@
 import { index, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { user } from "./auth-schema.js";
+import { organizations } from "./organization-schema.js";
 import { isNull } from "drizzle-orm";
 
 export const groups = pgTable(
   "groups",
   {
     id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id),
     groupName: text("group_name").notNull(),
     defaultVacationDays: integer("default_vacation_days").notNull().default(20),
     defaultHomeOfficeDays: integer("default_home_office_days").notNull().default(0),
@@ -25,5 +29,8 @@ export const groups = pgTable(
   },
   (table) => [
     index("idx_groups_deleted_at_active").on(table.deletedAt).where(isNull(table.deletedAt)),
+    // Postgres does not index FK columns automatically, and every billing
+    // guard filters groups by organization.
+    index("idx_groups_organization_id").on(table.organizationId),
   ]
 );

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -11,6 +11,9 @@ import { calendarSync, calendarSyncTeams, calendarSyncTypes } from "./calendar-s
 import { vacationEvents } from "./vacation-event-schema.js";
 import { userSettings } from "./user-settings-schema.js";
 import { reportExports } from "./report-export-schema.js";
+import { organizations } from "./organization-schema.js";
+import { subscriptions } from "./subscription-schema.js";
+import { paddleEvents } from "./paddle-event-schema.js";
 
 export const schema = {
   account,
@@ -31,4 +34,7 @@ export const schema = {
   calendarSyncTeams,
   calendarSyncTypes,
   reportExports,
+  organizations,
+  subscriptions,
+  paddleEvents,
 };

--- a/src/db/schema/organization-schema.ts
+++ b/src/db/schema/organization-schema.ts
@@ -1,0 +1,29 @@
+import { pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema.js";
+
+/**
+ * Billing owner sitting above `groups`, so "who pays" is decoupled from "who
+ * manages a group". Phase 1: exactly one org per user (unique index on
+ * ownerUserId) and membership stays implicit (owner only) — an
+ * `organization_users` table can be added later without touching `groups`.
+ * Rows are created lazily by `ensureOrganizationForUser`; users with no
+ * groups get no row.
+ */
+export const organizations = pgTable(
+  "organizations",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    ownerUserId: text("owner_user_id")
+      .notNull()
+      .references(() => user.id),
+    billingEmail: text("billing_email").notNull(),
+    paddleCustomerId: text("paddle_customer_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [uniqueIndex("uq_organizations_owner_user_id").on(table.ownerUserId)]
+);

--- a/src/db/schema/out/0012_confused_elektra.sql
+++ b/src/db/schema/out/0012_confused_elektra.sql
@@ -1,0 +1,62 @@
+CREATE TYPE "public"."billing_cycle" AS ENUM('MONTHLY', 'YEARLY');--> statement-breakpoint
+CREATE TYPE "public"."manual_plan_override" AS ENUM('FREE', 'PRO', 'ENTERPRISE', 'CUSTOM');--> statement-breakpoint
+CREATE TYPE "public"."subscription_plan" AS ENUM('PRO', 'ENTERPRISE');--> statement-breakpoint
+CREATE TYPE "public"."subscription_status" AS ENUM('active', 'trialing', 'past_due', 'paused', 'canceled');--> statement-breakpoint
+CREATE TABLE "organizations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"owner_user_id" text NOT NULL,
+	"billing_email" text NOT NULL,
+	"paddle_customer_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "paddle_events" (
+	"event_id" text PRIMARY KEY NOT NULL,
+	"event_type" text NOT NULL,
+	"received_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "subscriptions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"paddle_subscription_id" text,
+	"paddle_customer_id" text,
+	"plan" "subscription_plan",
+	"status" "subscription_status",
+	"billing_cycle" "billing_cycle",
+	"extra_group_slots" integer DEFAULT 0 NOT NULL,
+	"current_period_end" timestamp with time zone,
+	"grace_ends_at" timestamp with time zone,
+	"cancel_at" timestamp with time zone,
+	"manual_plan_override" "manual_plan_override",
+	"manual_max_groups" integer,
+	"manual_max_members_per_group" integer,
+	"manual_plan_until" timestamp with time zone,
+	"last_event_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "organizations" ADD CONSTRAINT "organizations_owner_user_id_user_id_fk" FOREIGN KEY ("owner_user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD CONSTRAINT "subscriptions_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_organizations_owner_user_id" ON "organizations" USING btree ("owner_user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_subscriptions_organization_id" ON "subscriptions" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "idx_subscriptions_paddle_subscription_id" ON "subscriptions" USING btree ("paddle_subscription_id");--> statement-breakpoint
+-- Backfill: one organization per distinct group manager (soft-deleted groups
+-- included — every row must satisfy the NOT NULL below), then attach each
+-- group to its manager's org. `groups.manager_user_id` is NOT NULL with an FK
+-- to `user`, so this join cannot drop a row.
+INSERT INTO "organizations" ("id", "name", "owner_user_id", "billing_email")
+SELECT gen_random_uuid()::text, u."name", u."id", u."email"
+FROM (SELECT DISTINCT "manager_user_id" FROM "groups") AS m
+JOIN "user" AS u ON u."id" = m."manager_user_id";--> statement-breakpoint
+ALTER TABLE "groups" ADD COLUMN "organization_id" text;--> statement-breakpoint
+UPDATE "groups" AS g
+SET "organization_id" = o."id"
+FROM "organizations" AS o
+WHERE o."owner_user_id" = g."manager_user_id";--> statement-breakpoint
+ALTER TABLE "groups" ALTER COLUMN "organization_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "groups" ADD CONSTRAINT "groups_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_groups_organization_id" ON "groups" USING btree ("organization_id");

--- a/src/db/schema/out/meta/0012_snapshot.json
+++ b/src/db/schema/out/meta/0012_snapshot.json
@@ -1,0 +1,2663 @@
+{
+  "id": "a684d2c5-3a52-4fea-b6d4-90669edd388a",
+  "prevId": "de3e41e9-2f01-404a-b47f-9ec9e64e18ae",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_mirrors": {
+      "name": "group_mirrors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_group_id": {
+          "name": "target_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_mirrors_user_source_target_uniq": {
+          "name": "group_mirrors_user_source_target_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_mirrors\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_target_group_id": {
+          "name": "idx_group_mirrors_target_group_id",
+          "columns": [
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_user_id": {
+          "name": "idx_group_mirrors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_mirrors_user_id_user_id_fk": {
+          "name": "group_mirrors_user_id_user_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_source_group_id_groups_id_fk": {
+          "name": "group_mirrors_source_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_target_group_id_groups_id_fk": {
+          "name": "group_mirrors_target_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "target_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_organization_id": {
+          "name": "idx_groups_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_organization_id_organizations_id_fk": {
+          "name": "groups_organization_id_organizations_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approver_access": {
+          "name": "approver_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invite_link_group_id": {
+          "name": "idx_invite_link_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_group_email_open_uniq": {
+          "name": "invite_link_group_email_open_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_link\".\"used_at\" IS NULL AND \"invite_link\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_link_invited_by_user_id_user_id_fk": {
+          "name": "invite_link_invited_by_user_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_organizations_owner_user_id": {
+          "name": "uq_organizations_owner_user_id",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paddle_events": {
+      "name": "paddle_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_exports_user_id_idx": {
+          "name": "report_exports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_exports_created_at_idx": {
+          "name": "report_exports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_user_id_user_id_fk": {
+          "name": "report_exports_user_id_user_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_subscription_id": {
+          "name": "paddle_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "subscription_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "billing_cycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_group_slots": {
+          "name": "extra_group_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_override": {
+          "name": "manual_plan_override",
+          "type": "manual_plan_override",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_groups": {
+          "name": "manual_max_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_members_per_group": {
+          "name": "manual_max_members_per_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_until": {
+          "name": "manual_plan_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_subscriptions_organization_id": {
+          "name": "uq_subscriptions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_paddle_subscription_id": {
+          "name": "idx_subscriptions_paddle_subscription_id",
+          "columns": [
+            {
+              "expression": "paddle_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_organization_id_organizations_id_fk": {
+          "name": "subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboard_scope": {
+          "name": "dashboard_scope",
+          "type": "dashboard_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MINE'"
+        },
+        "dashboard_group_id": {
+          "name": "dashboard_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_settings_dashboard_group_id_groups_id_fk": {
+          "name": "user_settings_dashboard_group_id_groups_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "dashboard_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "carried_over_days": {
+          "name": "carried_over_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        },
+        "user_year_quotas_related_year_range_chk": {
+          "name": "user_year_quotas_related_year_range_chk",
+          "value": "\"user_year_quotas\".\"related_year\"::int BETWEEN 2025 AND 2100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "half_day": {
+          "name": "half_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vacation\".\"deleted_at\" IS NULL AND \"vacation\".\"rejected_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.billing_cycle": {
+      "name": "billing_cycle",
+      "schema": "public",
+      "values": [
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.manual_plan_override": {
+      "name": "manual_plan_override",
+      "schema": "public",
+      "values": [
+        "FREE",
+        "PRO",
+        "ENTERPRISE",
+        "CUSTOM"
+      ]
+    },
+    "public.subscription_plan": {
+      "name": "subscription_plan",
+      "schema": "public",
+      "values": [
+        "PRO",
+        "ENTERPRISE"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "trialing",
+        "past_due",
+        "paused",
+        "canceled"
+      ]
+    },
+    "public.dashboard_scope": {
+      "name": "dashboard_scope",
+      "schema": "public",
+      "values": [
+        "MINE",
+        "GROUP"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/_journal.json
+++ b/src/db/schema/out/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1786177874843,
       "tag": "0011_lovely_angel",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1786801394616,
+      "tag": "0012_confused_elektra",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/paddle-event-schema.ts
+++ b/src/db/schema/paddle-event-schema.ts
@@ -1,0 +1,11 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * Webhook idempotency ledger: the handler inserts the event id FIRST and
+ * treats a conflict as "already processed" — Paddle retries aggressively.
+ */
+export const paddleEvents = pgTable("paddle_events", {
+  eventId: text("event_id").primaryKey(),
+  eventType: text("event_type").notNull(),
+  receivedAt: timestamp("received_at", { withTimezone: true }).defaultNow().notNull(),
+});

--- a/src/db/schema/subscription-schema.ts
+++ b/src/db/schema/subscription-schema.ts
@@ -1,0 +1,84 @@
+import { index, integer, pgEnum, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { organizations } from "./organization-schema.js";
+import { enumToPgEnum } from "../../utils/enumToPgEnum.js";
+
+export enum subscriptionPlan {
+  Pro = "PRO",
+  Enterprise = "ENTERPRISE",
+}
+
+export enum subscriptionStatus {
+  Active = "active",
+  Trialing = "trialing",
+  PastDue = "past_due",
+  Paused = "paused",
+  Canceled = "canceled",
+}
+
+export enum billingCycle {
+  Monthly = "MONTHLY",
+  Yearly = "YEARLY",
+}
+
+/** Grandfathering, comped accounts and Enterprise Custom — see `manual*` columns. */
+export enum manualPlanOverride {
+  Free = "FREE",
+  Pro = "PRO",
+  Enterprise = "ENTERPRISE",
+  Custom = "CUSTOM",
+}
+
+export const subscriptionPlanEnum = pgEnum("subscription_plan", enumToPgEnum(subscriptionPlan));
+export const subscriptionStatusEnum = pgEnum(
+  "subscription_status",
+  enumToPgEnum(subscriptionStatus)
+);
+export const billingCycleEnum = pgEnum("billing_cycle", enumToPgEnum(billingCycle));
+export const manualPlanOverrideEnum = pgEnum(
+  "manual_plan_override",
+  enumToPgEnum(manualPlanOverride)
+);
+
+/**
+ * One row per organization; absence means Free (the `user_settings` precedent
+ * — readers treat a missing row as defaults). Grace expiry is derived at read
+ * time by `resolveEntitlements`; there is no cron sweep.
+ */
+export const subscriptions = pgTable(
+  "subscriptions",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id),
+    paddleSubscriptionId: text("paddle_subscription_id"),
+    paddleCustomerId: text("paddle_customer_id"),
+    plan: subscriptionPlanEnum("plan"),
+    status: subscriptionStatusEnum("status"),
+    billingCycle: billingCycleEnum("billing_cycle"),
+    extraGroupSlots: integer("extra_group_slots").notNull().default(0),
+    currentPeriodEnd: timestamp("current_period_end", { withTimezone: true }),
+    graceEndsAt: timestamp("grace_ends_at", { withTimezone: true }),
+    cancelAt: timestamp("cancel_at", { withTimezone: true }),
+    // Wins over Paddle state while `manualPlanUntil` is null or in the future.
+    manualPlanOverride: manualPlanOverrideEnum("manual_plan_override"),
+    manualMaxGroups: integer("manual_max_groups"),
+    manualMaxMembersPerGroup: integer("manual_max_members_per_group"),
+    manualPlanUntil: timestamp("manual_plan_until", { withTimezone: true }),
+    // `occurred_at` of the newest Paddle event applied to this row. Paddle
+    // does not guarantee delivery order, so an event older than this is
+    // discarded rather than allowed to resurrect stale state.
+    lastEventAt: timestamp("last_event_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_subscriptions_organization_id").on(table.organizationId),
+    // `getSubscriptionByPaddleId` runs on every payment_failed event and on
+    // any event whose custom_data lost the organization id.
+    index("idx_subscriptions_paddle_subscription_id").on(table.paddleSubscriptionId),
+  ]
+);

--- a/src/middleware/limiter.ts
+++ b/src/middleware/limiter.ts
@@ -90,3 +90,21 @@ export const calendarFeedLimiter = rateLimit({
   limit: 120,
   keyGenerator: (req) => (req.params.token ? `t:${req.params.token}` : ipKey(req)),
 });
+
+/**
+ * The Paddle webhook is unauthenticated by design — the HMAC signature is the
+ * real gate — so this is only a backstop against a garbage-blast doing
+ * signature work at flood volume.
+ *
+ * Deliberately far above any plausible legitimate burst: Paddle delivers from
+ * a small fixed IP range, so every customer's events share one bucket. A
+ * dunning run or a backlog replay must not hit it, because a 429 is a non-2xx
+ * — Paddle retries, and sustained failures pause the notification destination
+ * entirely, which would silently stop all subscription syncing.
+ */
+export const paddleWebhookLimiter = rateLimit({
+  ...shared,
+  windowMs: FIVE_MINUTES,
+  limit: 5000,
+  keyGenerator: ipKey,
+});

--- a/src/routes/billingRouter.ts
+++ b/src/routes/billingRouter.ts
@@ -117,9 +117,10 @@ export const billingRouter = (): Router => {
    *       - Billing
    *     summary: Change the extra group slot quantity
    *     description: |
-   *       Updates the extra-group-slot line on the existing subscription.
-   *       Increases are prorated immediately; decreases take effect at the
-   *       next billing period. Capped by the plan's `maxExtraSlots`.
+   *       Updates the extra-group-slot line on the existing subscription. The
+   *       new quantity applies immediately in both directions; an increase is
+   *       charged straight away, a decrease is credited pro rata at the next
+   *       billing period. Capped by the plan's `maxExtraSlots`.
    *     security:
    *       - bearerAuth: []
    *     requestBody:

--- a/src/routes/billingRouter.ts
+++ b/src/routes/billingRouter.ts
@@ -1,0 +1,194 @@
+import { Router } from "express";
+import { tryCatch } from "../middleware/tryCatch.js";
+import { bodyValidationMiddleware } from "../middleware/validationMiddleware.js";
+import {
+  validateChangePlan,
+  validatePatchSlots,
+  validatePostCheckout,
+} from "../services/billing/types.js";
+import { handleGetSubscription } from "../controllers/billing/handleGetSubscription.js";
+import { handlePostCheckout } from "../controllers/billing/handlePostCheckout.js";
+import { handlePostPortal } from "../controllers/billing/handlePostPortal.js";
+import { handlePatchSlots } from "../controllers/billing/handlePatchSlots.js";
+import { handlePostChangePlan } from "../controllers/billing/handlePostChangePlan.js";
+
+export const billingRouter = (): Router => {
+  const app = Router();
+
+  /**
+   * @openapi
+   * /api/billing/subscription:
+   *   get:
+   *     tags:
+   *       - Billing
+   *     summary: Current subscription, entitlements and usage
+   *     description: |
+   *       Returns the caller's organization (owner-resolved from the session,
+   *       never from the request), its subscription row if any, the resolved
+   *       entitlements (plan, group/member limits, writability, grace end) and
+   *       usage meters. Callers who own no organization yet get Free
+   *       entitlements with empty usage.
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       '200':
+   *         description: Subscription state, entitlements, usage counts
+   */
+  app.get("/subscription", tryCatch(handleGetSubscription));
+
+  /**
+   * @openapi
+   * /api/billing/checkout:
+   *   post:
+   *     tags:
+   *       - Billing
+   *     summary: Create a Paddle checkout transaction
+   *     description: |
+   *       Creates a Paddle transaction for the requested plan and returns its
+   *       id for the Paddle.js overlay. Prices and the organization id are
+   *       resolved server-side only. 409 when an active subscription already
+   *       exists (use change-plan), 503 when billing is not configured.
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - plan
+   *               - billingCycle
+   *             properties:
+   *               plan:
+   *                 type: string
+   *                 enum: [PRO, ENTERPRISE]
+   *               billingCycle:
+   *                 type: string
+   *                 enum: [MONTHLY, YEARLY]
+   *               extraGroupSlots:
+   *                 type: integer
+   *                 minimum: 0
+   *                 maximum: 20
+   *     responses:
+   *       '201':
+   *         description: The Paddle transaction id to open the overlay with
+   *       '409':
+   *         description: Organization already has an active subscription
+   *       '422':
+   *         description: Extra slots exceed the plan's allowance
+   *       '503':
+   *         description: Billing not configured on this environment
+   */
+  app.post(
+    "/checkout",
+    bodyValidationMiddleware(validatePostCheckout),
+    tryCatch(handlePostCheckout)
+  );
+
+  /**
+   * @openapi
+   * /api/billing/portal:
+   *   post:
+   *     tags:
+   *       - Billing
+   *     summary: Create a Paddle customer portal session
+   *     description: |
+   *       Returns a customer-portal URL where the owner manages the payment
+   *       method, invoices and cancellation. 404 until a first checkout has
+   *       created the Paddle customer.
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       '200':
+   *         description: The portal URL
+   *       '404':
+   *         description: No billing account yet
+   *       '503':
+   *         description: Billing not configured on this environment
+   */
+  app.post("/portal", tryCatch(handlePostPortal));
+
+  /**
+   * @openapi
+   * /api/billing/slots:
+   *   patch:
+   *     tags:
+   *       - Billing
+   *     summary: Change the extra group slot quantity
+   *     description: |
+   *       Updates the extra-group-slot line on the existing subscription.
+   *       Increases are prorated immediately; decreases take effect at the
+   *       next billing period. Capped by the plan's `maxExtraSlots`.
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - extraGroupSlots
+   *             properties:
+   *               extraGroupSlots:
+   *                 type: integer
+   *                 minimum: 0
+   *                 maximum: 20
+   *     responses:
+   *       '200':
+   *         description: The new slot quantity
+   *       '409':
+   *         description: No active subscription to modify
+   *       '422':
+   *         description: Requested slots exceed the plan's allowance
+   *       '503':
+   *         description: Billing not configured on this environment
+   */
+  app.patch("/slots", bodyValidationMiddleware(validatePatchSlots), tryCatch(handlePatchSlots));
+
+  /**
+   * @openapi
+   * /api/billing/change-plan:
+   *   post:
+   *     tags:
+   *       - Billing
+   *     summary: Switch plan or billing cycle
+   *     description: |
+   *       Pro ⇄ Enterprise and monthly ⇄ yearly on the existing subscription,
+   *       prorated immediately. Extra slots are kept, clamped to the new
+   *       plan's allowance.
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - plan
+   *               - billingCycle
+   *             properties:
+   *               plan:
+   *                 type: string
+   *                 enum: [PRO, ENTERPRISE]
+   *               billingCycle:
+   *                 type: string
+   *                 enum: [MONTHLY, YEARLY]
+   *     responses:
+   *       '200':
+   *         description: The new plan state
+   *       '409':
+   *         description: No active subscription to modify
+   *       '503':
+   *         description: Billing not configured on this environment
+   */
+  app.post(
+    "/change-plan",
+    bodyValidationMiddleware(validateChangePlan),
+    tryCatch(handlePostChangePlan)
+  );
+
+  return app;
+};

--- a/src/routes/devRouter.ts
+++ b/src/routes/devRouter.ts
@@ -13,6 +13,10 @@ import {
   validatePostDevScenario,
 } from "../controllers/dev/handlePostDevScenario.js";
 import { handlePostDevReset } from "../controllers/dev/handlePostDevReset.js";
+import {
+  handlePostDevSetPlan,
+  validatePostDevSetPlan,
+} from "../controllers/dev/handlePostDevSetPlan.js";
 
 /**
  * Local-only seeding and impersonation surface, mounted by `server.ts` only
@@ -42,6 +46,12 @@ export const devRouter = (): Router => {
   );
 
   app.post("/reset", tryCatch(handlePostDevReset));
+
+  app.post(
+    "/billing/set-plan",
+    bodyValidationMiddleware(validatePostDevSetPlan),
+    tryCatch(handlePostDevSetPlan)
+  );
 
   return app;
 };

--- a/src/routes/groupRouter.ts
+++ b/src/routes/groupRouter.ts
@@ -18,6 +18,55 @@ import { handlePutGroupMirrors } from "../controllers/group/handlePutGroupMirror
 export const groupRouter = (): Router => {
   const app = Router();
 
+  /**
+   * @openapi
+   * /api/group:
+   *   post:
+   *     tags:
+   *       - Groups
+   *     summary: Create a group
+   *     description: |
+   *       Creates a group owned by the caller's organization, adds the caller
+   *       as its first member (admin + approver) and opens their current-year
+   *       quota from the group defaults. The organization is created lazily on
+   *       the caller's first group. An approver may only be named if it is the
+   *       caller, since nobody else is a member yet.
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - groupName
+   *             properties:
+   *               groupName:
+   *                 type: string
+   *                 minLength: 1
+   *                 maxLength: 120
+   *               defaultVacation:
+   *                 type: integer
+   *                 minimum: 0
+   *                 maximum: 99
+   *               defaultHomeOffice:
+   *                 type: integer
+   *                 minimum: 0
+   *                 maximum: 99
+   *               mainApprovalUser:
+   *                 type: string
+   *     responses:
+   *       '201':
+   *         description: The created group
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
+   *       '422':
+   *         description: A named approver is not the caller
+   */
   app.post("/", tryCatch(handlePostGroup));
 
   app.get("/", tryCatch(handleGetGroups));
@@ -58,6 +107,11 @@ export const groupRouter = (): Router => {
    *     responses:
    *       '200':
    *         description: The updated group
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: No permission for related group
    *       '404':
@@ -110,6 +164,11 @@ export const groupRouter = (): Router => {
    *     responses:
    *       '200':
    *         description: The updated group
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: No permission for related group
    *       '404':
@@ -192,6 +251,11 @@ export const groupRouter = (): Router => {
    *     responses:
    *       '200':
    *         description: The member's mirrors into this group after the update
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: Caller is not an admin of the target or of a source group
    *       '422':
@@ -234,6 +298,11 @@ export const groupRouter = (): Router => {
    *     responses:
    *       '200':
    *         description: The updated group
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: No permission for related group
    *       '404':

--- a/src/routes/groupUsersRouter.ts
+++ b/src/routes/groupUsersRouter.ts
@@ -11,6 +11,7 @@ import {
 import { handlePostGroupInvite } from "../controllers/groupUser/handlePostGroupInvite.js";
 import { handleGetGroupInvites } from "../controllers/groupUser/handleGetGroupInvites.js";
 import { handleDeleteGroupInvite } from "../controllers/groupUser/handleDeleteGroupInvite.js";
+import { handleDeleteGroupUser } from "../controllers/groupUser/handleDeleteGroupUser.js";
 
 export const groupUsersRouter = (): Router => {
   const app = Router();
@@ -72,6 +73,11 @@ export const groupUsersRouter = (): Router => {
    *         description: The created membership
    *       '400':
    *         description: Malformed code
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: Invite was issued for a different email address
    *       '404':
@@ -140,6 +146,11 @@ export const groupUsersRouter = (): Router => {
    *     responses:
    *       '201':
    *         description: The created invite plus whether the email went out
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: No permission for related group
    *       '404':
@@ -147,6 +158,47 @@ export const groupUsersRouter = (): Router => {
    *       '409':
    *         description: That person already belongs to the group
    */
+  /**
+   * @openapi
+   * /api/group-user/{groupId}/{userId}:
+   *   delete:
+   *     tags:
+   *       - Group members
+   *     summary: Remove a member from a group
+   *     description: |
+   *       Soft-deletes the membership. Requires admin access on the group. The
+   *       group's manager cannot be removed; there is no manager-transfer route
+   *       yet, so a manager can only leave by deleting the group. If the
+   *       removed member was the main approver, approvals fall back to the
+   *       manager; a temp approver slot is cleared. Deliberately available on
+   *       read-only (over plan limit) groups, since removing members is how an
+   *       owner gets back under their plan's limits.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: groupId
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *       - name: userId
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       '200':
+   *         description: The removed membership
+   *       '403':
+   *         description: No permission for related group
+   *       '404':
+   *         description: Group not found, or user is not a member
+   *       '409':
+   *         description: Target is the group manager, or already removed
+   */
+  app.delete("/:groupId/:userId", tryCatch(handleDeleteGroupUser));
+
   app.get("/:groupId/invites", tryCatch(handleGetGroupInvites));
   app.post(
     "/:groupId/invites",

--- a/src/routes/quotasRouter.ts
+++ b/src/routes/quotasRouter.ts
@@ -111,6 +111,11 @@ export const quotasRouter = (): Router => {
    *     responses:
    *       '200':
    *         description: The stored quota row
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: No permission for related group
    *       '404':

--- a/src/routes/vacationRouter.ts
+++ b/src/routes/vacationRouter.ts
@@ -181,6 +181,11 @@ export const vacationRouter = (): Router => {
    *                 $ref: '#/components/schemas/Vacation'
    *       '401':
    *         description: Unauthorized
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: No access for related group
    *       '422':
@@ -275,6 +280,11 @@ export const vacationRouter = (): Router => {
    *     responses:
    *       '200':
    *         description: Vacation approved
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    */
   app.post(
     "/approve/:id",
@@ -314,6 +324,11 @@ export const vacationRouter = (): Router => {
    *     responses:
    *       '200':
    *         description: All requested vacations approved
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: Not allowed to approve one or more rows
    *       '404':
@@ -353,6 +368,11 @@ export const vacationRouter = (): Router => {
    *     responses:
    *       '200':
    *         description: Vacation rejected
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    */
   app.post(
     "/reject/:id",
@@ -395,6 +415,11 @@ export const vacationRouter = (): Router => {
    *     responses:
    *       '200':
    *         description: Comment added
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: Not allowed to view this vacation
    *       '404':
@@ -434,6 +459,11 @@ export const vacationRouter = (): Router => {
    *     responses:
    *       '200':
    *         description: All requested vacations rejected
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: Not allowed to reject one or more rows
    *       '404':
@@ -478,6 +508,11 @@ export const vacationRouter = (): Router => {
    *     responses:
    *       '200':
    *         description: All requested vacations cancelled
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: Not allowed to cancel one or more rows
    *       '404':
@@ -522,6 +557,11 @@ export const vacationRouter = (): Router => {
    *     responses:
    *       '200':
    *         description: Vacation cancelled
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
    *         description: Not allowed
    *       '404':

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import {
   calendarFeedLimiter,
   credentialsLimiter,
   floodLimiter,
+  paddleWebhookLimiter,
 } from "./middleware/limiter.js";
 import { toNodeHandler } from "better-auth/node";
 import { auth } from "./utils/auth.js";
@@ -28,6 +29,8 @@ import { tryCatch } from "./middleware/tryCatch.js";
 import { handleGetCalendarFeed } from "./controllers/calendarSync/handleGetCalendarFeed.js";
 import { devRouter } from "./routes/devRouter.js";
 import { requestContext } from "./middleware/requestContext.js";
+import { billingRouter } from "./routes/billingRouter.js";
+import { handlePaddleWebhook } from "./controllers/billing/handlePaddleWebhook.js";
 
 export const createServer = () => {
   const app = express();
@@ -60,6 +63,17 @@ export const createServer = () => {
   app.use("/api/auth/sign-up-with-team", express.json());
   app.use("/api/auth", authExtRouter());
 
+  // Paddle webhook. Registered BEFORE the global `express.json()` so it gets
+  // the raw body (HMAC verification needs the exact bytes), and before the
+  // `/api` session block so Paddle's cookie-less calls are not 401'd. It
+  // authenticates by `Paddle-Signature` alone.
+  app.post(
+    "/api/webhooks/paddle",
+    express.raw({ type: "application/json" }),
+    paddleWebhookLimiter,
+    tryCatch(handlePaddleWebhook)
+  );
+
   app.all("/api/auth/{*any}", toNodeHandler(auth)).use(express.json());
 
   // Local seeding/impersonation routes. `config.dev` is undefined unless the
@@ -85,6 +99,7 @@ export const createServer = () => {
   app.use("/api/notifications", notificationRouter());
   app.use("/api/calendar-sync", calendarSyncRouter());
   app.use("/api/reports", reportRouter());
+  app.use("/api/billing", billingRouter());
 
   // Public, token-authenticated iCalendar feed. Deliberately NOT behind
   // `authSession`: calendar clients subscribe with just the secret token in

--- a/src/services/DBServices.ts
+++ b/src/services/DBServices.ts
@@ -12,6 +12,8 @@ import * as notificationServices from "./notification/notificationServices.js";
 import * as calendarSyncServices from "./calendarSync/calendarSyncServices.js";
 import * as reportServices from "./report/reportServices.js";
 import * as quotaRolloverServices from "./quotaRollover/quotaRolloverServices.js";
+import * as organizationServices from "./organization/organizationServices.js";
+import * as subscriptionServices from "./billing/subscriptionServices.js";
 
 export type DBServices = Readonly<{
   vacation: {
@@ -71,6 +73,9 @@ export type DBServices = Readonly<{
     updateGroupWorkingDays: typeof groupServices.updateGroupWorkingDays;
     getApprovalUsers: typeof groupServices.getApprovalUsers;
     getGroupsWhereUserCanApprove: typeof groupServices.getGroupsWhereUserCanApprove;
+    countLiveGroupsForOrganization: typeof groupServices.countLiveGroupsForOrganization;
+    getLiveGroupIdsForOrganizationOrdered: typeof groupServices.getLiveGroupIdsForOrganizationOrdered;
+    getGroupUsageForOrganization: typeof groupServices.getGroupUsageForOrganization;
   };
   groupMirror: {
     getMirrorsIntoGroupForUser: typeof groupMirrorServices.getMirrorsIntoGroupForUser;
@@ -143,6 +148,18 @@ export type DBServices = Readonly<{
     findRolloverCandidates: typeof quotaRolloverServices.findRolloverCandidates;
     rolloverQuotasForYear: typeof quotaRolloverServices.rolloverQuotasForYear;
   };
+  organization: {
+    getOrganizationById: typeof organizationServices.getOrganizationById;
+    getOrganizationForOwner: typeof organizationServices.getOrganizationForOwner;
+    ensureOrganizationForUser: typeof organizationServices.ensureOrganizationForUser;
+    setOrganizationPaddleCustomerId: typeof organizationServices.setOrganizationPaddleCustomerId;
+  };
+  billing: {
+    getSubscriptionForOrganization: typeof subscriptionServices.getSubscriptionForOrganization;
+    getSubscriptionByPaddleId: typeof subscriptionServices.getSubscriptionByPaddleId;
+    upsertSubscription: typeof subscriptionServices.upsertSubscription;
+    recordPaddleEvent: typeof subscriptionServices.recordPaddleEvent;
+  };
 }>;
 
 export const createDBServices = (): DBServices => {
@@ -204,6 +221,9 @@ export const createDBServices = (): DBServices => {
       updateGroupWorkingDays: groupServices.updateGroupWorkingDays,
       getApprovalUsers: groupServices.getApprovalUsers,
       getGroupsWhereUserCanApprove: groupServices.getGroupsWhereUserCanApprove,
+      countLiveGroupsForOrganization: groupServices.countLiveGroupsForOrganization,
+      getLiveGroupIdsForOrganizationOrdered: groupServices.getLiveGroupIdsForOrganizationOrdered,
+      getGroupUsageForOrganization: groupServices.getGroupUsageForOrganization,
     },
     groupMirror: {
       getMirrorsIntoGroupForUser: groupMirrorServices.getMirrorsIntoGroupForUser,
@@ -275,6 +295,18 @@ export const createDBServices = (): DBServices => {
     quotaRollover: {
       findRolloverCandidates: quotaRolloverServices.findRolloverCandidates,
       rolloverQuotasForYear: quotaRolloverServices.rolloverQuotasForYear,
+    },
+    organization: {
+      getOrganizationById: organizationServices.getOrganizationById,
+      getOrganizationForOwner: organizationServices.getOrganizationForOwner,
+      ensureOrganizationForUser: organizationServices.ensureOrganizationForUser,
+      setOrganizationPaddleCustomerId: organizationServices.setOrganizationPaddleCustomerId,
+    },
+    billing: {
+      getSubscriptionForOrganization: subscriptionServices.getSubscriptionForOrganization,
+      getSubscriptionByPaddleId: subscriptionServices.getSubscriptionByPaddleId,
+      upsertSubscription: subscriptionServices.upsertSubscription,
+      recordPaddleEvent: subscriptionServices.recordPaddleEvent,
     },
   };
 };

--- a/src/services/DBServices.ts
+++ b/src/services/DBServices.ts
@@ -64,6 +64,7 @@ export type DBServices = Readonly<{
   };
   group: {
     getGroup: typeof groupServices.getGroup;
+    lockGroup: typeof groupServices.lockGroup;
     getAllGroups: typeof groupServices.getAllGroups;
     createGroup: typeof groupServices.createGroup;
     updateGroupManager: typeof groupServices.updateGroupManager;
@@ -212,6 +213,7 @@ export const createDBServices = (): DBServices => {
     },
     group: {
       getGroup: groupServices.getGroup,
+      lockGroup: groupServices.lockGroup,
       getAllGroups: groupServices.getAllGroups,
       createGroup: groupServices.createGroup,
       updateGroupManager: groupServices.updateGroupManager,

--- a/src/services/billing/billingNotifier.ts
+++ b/src/services/billing/billingNotifier.ts
@@ -1,0 +1,39 @@
+import { emailSender } from "../email/index.js";
+import { logger } from "../../middleware/logger.js";
+import { config } from "../../config.js";
+import type { OrganizationType } from "../organization/types.js";
+
+/**
+ * Best-effort grace email to the organization's billing address. Swallows and
+ * logs its own errors — a mail failure must never fail webhook processing,
+ * which would make Paddle retry the event. Transactional billing mail, so it
+ * deliberately ignores `user_settings.emailNotifications`.
+ */
+export const notifySubscriptionGrace = async (
+  organization: OrganizationType,
+  planName: string,
+  graceEndsAt: Date
+): Promise<void> => {
+  try {
+    await emailSender.sendTemplated({
+      to: organization.billingEmail,
+      template: "subscription-grace",
+      data: {
+        recipientName: organization.name,
+        planName,
+        graceEndsDate: graceEndsAt.toLocaleDateString("en-GB", {
+          day: "numeric",
+          month: "long",
+          year: "numeric",
+          timeZone: "UTC",
+        }),
+        billingUrl: `${config.email.appUrl}/billing/`,
+      },
+    });
+  } catch (error) {
+    logger.error("subscription grace email failed", {
+      organizationId: organization.id,
+      error,
+    });
+  }
+};

--- a/src/services/billing/entitlements.ts
+++ b/src/services/billing/entitlements.ts
@@ -1,0 +1,114 @@
+import {
+  manualPlanOverride,
+  subscriptionPlan,
+  subscriptionStatus,
+} from "../../db/schema/subscription-schema.js";
+import type { Subscription } from "./types.js";
+
+export const PLAN_LIMITS = {
+  FREE: { groups: 3, membersPerGroup: 10, maxExtraSlots: 0 },
+  PRO: { groups: 5, membersPerGroup: 25, maxExtraSlots: 4 },
+  ENTERPRISE: { groups: 20, membersPerGroup: 100, maxExtraSlots: 20 },
+} as const;
+
+export type PlanName = keyof typeof PLAN_LIMITS;
+
+export type Entitlements = {
+  plan: PlanName | "CUSTOM";
+  /** Plan groups + purchased extra slots (or the manual override). */
+  maxGroups: number;
+  maxMembersPerGroup: number;
+  /** False once grace has expired — groups over the limit become read-only. */
+  writable: boolean;
+  graceEndsAt: string | null;
+};
+
+const freeEntitlements = (writable: boolean): Entitlements => ({
+  plan: "FREE",
+  maxGroups: PLAN_LIMITS.FREE.groups,
+  maxMembersPerGroup: PLAN_LIMITS.FREE.membersPerGroup,
+  writable,
+  graceEndsAt: null,
+});
+
+const paidEntitlements = (
+  plan: subscriptionPlan,
+  extraGroupSlots: number,
+  graceEndsAt: Date | null
+): Entitlements => {
+  const limits = plan === subscriptionPlan.Enterprise ? PLAN_LIMITS.ENTERPRISE : PLAN_LIMITS.PRO;
+  // Clamped to the plan's ceiling: the checkout and slot routes enforce it,
+  // but a quantity edited directly in the Paddle dashboard reaches us through
+  // the webhook without ever passing those.
+  const slots = Math.min(Math.max(0, extraGroupSlots), limits.maxExtraSlots);
+  return {
+    plan: plan === subscriptionPlan.Enterprise ? "ENTERPRISE" : "PRO",
+    maxGroups: limits.groups + slots,
+    maxMembersPerGroup: limits.membersPerGroup,
+    writable: true,
+    graceEndsAt: graceEndsAt ? graceEndsAt.toISOString() : null,
+  };
+};
+
+/**
+ * Pure resolver from a subscription row (or its absence, which means Free) to
+ * effective limits. Grace expiry is derived from `now` at read time — there is
+ * deliberately no cron sweep flipping state.
+ */
+export const resolveEntitlements = (sub: Subscription | null, now: Date): Entitlements => {
+  if (!sub) return freeEntitlements(true);
+
+  // Manual override wins over everything while it has not expired:
+  // grandfathering, comped accounts and Enterprise Custom.
+  const overrideActive =
+    sub.manualPlanOverride !== null && (sub.manualPlanUntil === null || sub.manualPlanUntil > now);
+
+  if (overrideActive && sub.manualPlanOverride) {
+    switch (sub.manualPlanOverride) {
+      case manualPlanOverride.Free:
+        // An explicit downgrade-to-free: enforce read-only over Free limits.
+        return freeEntitlements(false);
+      case manualPlanOverride.Pro:
+      case manualPlanOverride.Enterprise: {
+        const limits =
+          sub.manualPlanOverride === manualPlanOverride.Enterprise
+            ? PLAN_LIMITS.ENTERPRISE
+            : PLAN_LIMITS.PRO;
+        return {
+          plan: sub.manualPlanOverride === manualPlanOverride.Enterprise ? "ENTERPRISE" : "PRO",
+          maxGroups: sub.manualMaxGroups ?? limits.groups,
+          maxMembersPerGroup: sub.manualMaxMembersPerGroup ?? limits.membersPerGroup,
+          writable: true,
+          graceEndsAt: null,
+        };
+      }
+      case manualPlanOverride.Custom:
+        return {
+          plan: "CUSTOM",
+          maxGroups: sub.manualMaxGroups ?? PLAN_LIMITS.ENTERPRISE.groups,
+          maxMembersPerGroup:
+            sub.manualMaxMembersPerGroup ?? PLAN_LIMITS.ENTERPRISE.membersPerGroup,
+          writable: true,
+          graceEndsAt: null,
+        };
+    }
+  }
+
+  if (!sub.plan || !sub.status) return freeEntitlements(true);
+
+  switch (sub.status) {
+    case subscriptionStatus.Active:
+    case subscriptionStatus.Trialing:
+      return paidEntitlements(sub.plan, sub.extraGroupSlots, null);
+    case subscriptionStatus.PastDue:
+    case subscriptionStatus.Canceled:
+    case subscriptionStatus.Paused: {
+      // Paid limits survive through the grace window; after it (or when no
+      // grace was granted) the org drops to Free and over-limit groups lock.
+      if (sub.graceEndsAt && sub.graceEndsAt > now) {
+        return paidEntitlements(sub.plan, sub.extraGroupSlots, sub.graceEndsAt);
+      }
+      return freeEntitlements(false);
+    }
+  }
+};

--- a/src/services/billing/guards.ts
+++ b/src/services/billing/guards.ts
@@ -1,0 +1,225 @@
+import AppError from "../../utils/appError.js";
+import type { DbTransaction } from "../../db/db.js";
+import { getSubscriptionForOrganization } from "./subscriptionServices.js";
+import { resolveEntitlements, type Entitlements } from "./entitlements.js";
+import {
+  countLiveGroupsForOrganization,
+  getAllGroups,
+  getGroup,
+  getLiveGroupIdsForOrganizationOrdered,
+} from "../group/groupServices.js";
+import {
+  countActiveMembersInGroup,
+  countOpenInvitesForGroup,
+} from "../groupUser/groupUserServices.js";
+import { lockOrganization } from "../organization/organizationServices.js";
+
+const planLimitError = (params: {
+  message: string;
+  reason: "PLAN_LIMIT" | "READ_ONLY";
+  limit: number;
+  current: number;
+  context?: { [key: string]: unknown };
+}) =>
+  new AppError({
+    message: params.message,
+    logging: true,
+    code: 402,
+    context: params.context,
+    publicContext: { reason: params.reason, limit: params.limit, current: params.current },
+  });
+
+const entitlementsForOrganization = async (organizationId: string, tx?: DbTransaction) => {
+  const sub = await getSubscriptionForOrganization(organizationId, tx);
+  return resolveEntitlements(sub ?? null, new Date());
+};
+
+/**
+ * Throws 402 when the organization already has as many live groups as its plan
+ * allows. Callers inside a transaction get a row lock on the organization
+ * first, which serialises concurrent creates — a bare `count(*)` under READ
+ * COMMITTED lets parallel requests all read the same pre-insert count and all
+ * succeed.
+ */
+export const assertCanCreateGroup = async (
+  organizationId: string,
+  tx?: DbTransaction
+): Promise<void> => {
+  if (tx) await lockOrganization(organizationId, tx);
+
+  const entitlements = await entitlementsForOrganization(organizationId, tx);
+  const current = await countLiveGroupsForOrganization(organizationId, tx);
+  if (current >= entitlements.maxGroups) {
+    throw planLimitError({
+      message: "Your plan's group limit has been reached",
+      reason: "PLAN_LIMIT",
+      limit: entitlements.maxGroups,
+      current,
+      context: { organizationId },
+    });
+  }
+};
+
+/**
+ * Throws 402 when the group is at its per-group headcount cap. Open invites
+ * count against the cap: the invite endpoint is only a UX gate, but the
+ * redemption transaction calls this too, and pending codes must reserve their
+ * seat or parallel redemptions overfill the group.
+ */
+export const assertCanAddMember = async (
+  groupId: string,
+  tx?: DbTransaction,
+  options?: {
+    /**
+     * Set by the redemption path: the invite being redeemed is still open
+     * inside its transaction, and its reserved seat is the one being consumed
+     * — counting it too would block redeeming the last seat.
+     */
+    redeemingOpenInvite?: boolean;
+  }
+): Promise<void> => {
+  const group = await getGroup(groupId, tx);
+  if (!group) {
+    throw new AppError({
+      message: "Group not found",
+      logging: true,
+      code: 404,
+      context: { groupId },
+    });
+  }
+
+  // Same reasoning as assertCanCreateGroup: `count(*)` under READ COMMITTED
+  // gives two concurrent inviters the same pre-insert total, so both would
+  // pass and the group would end up with more outstanding seats than the plan
+  // allows. Serialising on the organization row is what actually prevents it.
+  if (tx) await lockOrganization(group.organizationId, tx);
+
+  const entitlements = await entitlementsForOrganization(group.organizationId, tx);
+  const members = await countActiveMembersInGroup(groupId, tx);
+  const allOpenInvites = await countOpenInvitesForGroup(groupId, tx);
+  const openInvites = options?.redeemingOpenInvite
+    ? Math.max(0, allOpenInvites - 1)
+    : allOpenInvites;
+  const current = members + openInvites;
+  if (current >= entitlements.maxMembersPerGroup) {
+    throw planLimitError({
+      message: "This group is at its member limit",
+      reason: "PLAN_LIMIT",
+      limit: entitlements.maxMembersPerGroup,
+      current,
+      context: { groupId, members, openInvites },
+    });
+  }
+};
+
+/**
+ * Throws 402 once grace has expired and this group is over the plan's limits.
+ * Over-limit groups are chosen deterministically: the oldest N by `createdAt`
+ * stay writable, the rest go read-only. A group whose headcount exceeds the
+ * per-group cap is read-only regardless of its age. Nothing is deleted or
+ * hidden — the group stays viewable.
+ */
+export const assertGroupWritable = async (groupId: string, tx?: DbTransaction): Promise<void> => {
+  const group = await getGroup(groupId, tx);
+  if (!group) {
+    throw new AppError({
+      message: "Group not found",
+      logging: true,
+      code: 404,
+      context: { groupId },
+    });
+  }
+
+  const entitlements = await entitlementsForOrganization(group.organizationId, tx);
+  if (entitlements.writable) return;
+
+  const orderedIds = await getLiveGroupIdsForOrganizationOrdered(group.organizationId, tx);
+  const writableIds = new Set(orderedIds.slice(0, entitlements.maxGroups));
+  if (!writableIds.has(groupId)) {
+    throw planLimitError({
+      message: "This group is read-only on your current plan",
+      reason: "READ_ONLY",
+      limit: entitlements.maxGroups,
+      current: orderedIds.length,
+      context: { groupId, organizationId: group.organizationId },
+    });
+  }
+
+  const members = await countActiveMembersInGroup(groupId, tx);
+  if (members > entitlements.maxMembersPerGroup) {
+    throw planLimitError({
+      message: "This group is read-only on your current plan",
+      reason: "READ_ONLY",
+      limit: entitlements.maxMembersPerGroup,
+      current: members,
+      context: { groupId, organizationId: group.organizationId },
+    });
+  }
+};
+
+/**
+ * Bulk variant. Resolves each organization's entitlements once instead of per
+ * group: a 50-request approval spanning 10 groups runs inside an open
+ * transaction holding row locks, so the round-trips are not free.
+ */
+export const assertGroupsWritable = async (
+  groupIds: string[],
+  tx?: DbTransaction
+): Promise<void> => {
+  const distinct = [...new Set(groupIds)];
+  if (distinct.length === 0) return;
+
+  const groups = await getAllGroups(distinct, tx);
+  const missing = distinct.find((id) => !groups.some((group) => group.id === id));
+  if (missing) {
+    throw new AppError({
+      message: "Group not found",
+      logging: true,
+      code: 404,
+      context: { groupId: missing },
+    });
+  }
+
+  const entitlementsByOrg = new Map<string, Entitlements>();
+  for (const organizationId of new Set(groups.map((group) => group.organizationId))) {
+    entitlementsByOrg.set(organizationId, await entitlementsForOrganization(organizationId, tx));
+  }
+
+  // Only organizations that have actually lapsed need the ordering query.
+  const orderedByOrg = new Map<string, string[]>();
+  for (const [organizationId, entitlements] of entitlementsByOrg) {
+    if (!entitlements.writable) {
+      orderedByOrg.set(
+        organizationId,
+        await getLiveGroupIdsForOrganizationOrdered(organizationId, tx)
+      );
+    }
+  }
+
+  for (const group of groups) {
+    const entitlements = entitlementsByOrg.get(group.organizationId)!;
+    if (entitlements.writable) continue;
+
+    const orderedIds = orderedByOrg.get(group.organizationId)!;
+    if (!new Set(orderedIds.slice(0, entitlements.maxGroups)).has(group.id)) {
+      throw planLimitError({
+        message: "This group is read-only on your current plan",
+        reason: "READ_ONLY",
+        limit: entitlements.maxGroups,
+        current: orderedIds.length,
+        context: { groupId: group.id, organizationId: group.organizationId },
+      });
+    }
+
+    const members = await countActiveMembersInGroup(group.id, tx);
+    if (members > entitlements.maxMembersPerGroup) {
+      throw planLimitError({
+        message: "This group is read-only on your current plan",
+        reason: "READ_ONLY",
+        limit: entitlements.maxMembersPerGroup,
+        current: members,
+        context: { groupId: group.id, organizationId: group.organizationId },
+      });
+    }
+  }
+};

--- a/src/services/billing/paddleCatalog.ts
+++ b/src/services/billing/paddleCatalog.ts
@@ -1,0 +1,67 @@
+import type { PaddleConfig } from "../../config.js";
+import { billingCycle, subscriptionPlan } from "../../db/schema/subscription-schema.js";
+
+export const planPriceId = (
+  prices: PaddleConfig["prices"],
+  plan: subscriptionPlan,
+  cycle: billingCycle
+): string => {
+  if (plan === subscriptionPlan.Enterprise) {
+    return cycle === billingCycle.Yearly ? prices.enterpriseYearly : prices.enterpriseMonthly;
+  }
+  return cycle === billingCycle.Yearly ? prices.proYearly : prices.proMonthly;
+};
+
+/** Paddle requires all items on one subscription to share a billing period. */
+export const slotPriceId = (prices: PaddleConfig["prices"], cycle: billingCycle): string =>
+  cycle === billingCycle.Yearly ? prices.extraGroupYearly : prices.extraGroupMonthly;
+
+export type DerivedPlanState = {
+  plan: subscriptionPlan;
+  billingCycle: billingCycle;
+  extraGroupSlots: number;
+};
+
+/**
+ * Re-derives plan, cycle and slot count from a Paddle subscription's items by
+ * matching our six price ids — the webhook's source of truth. Returns
+ * undefined when no known plan price is present (a foreign subscription).
+ */
+export const derivePlanFromItems = (
+  prices: PaddleConfig["prices"],
+  items: { priceId: string | undefined; quantity: number }[]
+): DerivedPlanState | undefined => {
+  let plan: subscriptionPlan | undefined;
+  let cycle: billingCycle | undefined;
+  let extraGroupSlots = 0;
+
+  for (const item of items) {
+    switch (item.priceId) {
+      case prices.proMonthly:
+        plan = subscriptionPlan.Pro;
+        cycle = billingCycle.Monthly;
+        break;
+      case prices.proYearly:
+        plan = subscriptionPlan.Pro;
+        cycle = billingCycle.Yearly;
+        break;
+      case prices.enterpriseMonthly:
+        plan = subscriptionPlan.Enterprise;
+        cycle = billingCycle.Monthly;
+        break;
+      case prices.enterpriseYearly:
+        plan = subscriptionPlan.Enterprise;
+        cycle = billingCycle.Yearly;
+        break;
+      case prices.extraGroupMonthly:
+      case prices.extraGroupYearly:
+        extraGroupSlots += item.quantity;
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (!plan || !cycle) return undefined;
+  return { plan, billingCycle: cycle, extraGroupSlots };
+};

--- a/src/services/billing/subscriptionServices.ts
+++ b/src/services/billing/subscriptionServices.ts
@@ -40,6 +40,18 @@ export const upsertSubscription = async (
   patch: SubscriptionPatch,
   tx?: DbTransaction
 ): Promise<Subscription | undefined> => {
+  // Drizzle rejects an empty `set`, and an empty patch has nothing to write
+  // anyway — but the row must still exist afterwards, so fall back to a plain
+  // insert that no-ops on conflict.
+  if (Object.keys(patch).length === 0) {
+    await (tx ?? db)
+      .insert(subscriptions)
+      .values({ id: generateRandomUUID(), organizationId })
+      .onConflictDoNothing({ target: subscriptions.organizationId });
+
+    return getSubscriptionForOrganization(organizationId, tx);
+  }
+
   const [row] = await (tx ?? db)
     .insert(subscriptions)
     .values({ id: generateRandomUUID(), organizationId, ...patch })

--- a/src/services/billing/subscriptionServices.ts
+++ b/src/services/billing/subscriptionServices.ts
@@ -1,0 +1,71 @@
+import { db, type DbTransaction } from "../../db/db.js";
+import { subscriptions } from "../../db/schema/subscription-schema.js";
+import { paddleEvents } from "../../db/schema/paddle-event-schema.js";
+import { eq } from "drizzle-orm";
+import { generateRandomUUID } from "../../utils/generateUUID.js";
+import type { Subscription, SubscriptionPatch } from "./types.js";
+
+export const getSubscriptionForOrganization = async (
+  organizationId: string,
+  tx?: DbTransaction
+): Promise<Subscription | undefined> => {
+  const [row] = await (tx ?? db)
+    .select()
+    .from(subscriptions)
+    .where(eq(subscriptions.organizationId, organizationId))
+    .limit(1);
+
+  return row;
+};
+
+export const getSubscriptionByPaddleId = async (
+  paddleSubscriptionId: string,
+  tx?: DbTransaction
+): Promise<Subscription | undefined> => {
+  const [row] = await (tx ?? db)
+    .select()
+    .from(subscriptions)
+    .where(eq(subscriptions.paddleSubscriptionId, paddleSubscriptionId))
+    .limit(1);
+
+  return row;
+};
+
+/**
+ * One row per organization (unique index) — always an upsert, so webhook
+ * events arriving in any order converge on the same row.
+ */
+export const upsertSubscription = async (
+  organizationId: string,
+  patch: SubscriptionPatch,
+  tx?: DbTransaction
+): Promise<Subscription | undefined> => {
+  const [row] = await (tx ?? db)
+    .insert(subscriptions)
+    .values({ id: generateRandomUUID(), organizationId, ...patch })
+    .onConflictDoUpdate({
+      target: subscriptions.organizationId,
+      set: patch,
+    })
+    .returning();
+
+  return row;
+};
+
+/**
+ * Idempotency gate for the webhook: returns false when the event id was seen
+ * before, in which case the caller must answer 200 without reprocessing.
+ */
+export const recordPaddleEvent = async (
+  eventId: string,
+  eventType: string,
+  tx?: DbTransaction
+): Promise<boolean> => {
+  const [row] = await (tx ?? db)
+    .insert(paddleEvents)
+    .values({ eventId, eventType })
+    .onConflictDoNothing()
+    .returning();
+
+  return Boolean(row);
+};

--- a/src/services/billing/tests/entitlements.test.ts
+++ b/src/services/billing/tests/entitlements.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "vitest";
+import { PLAN_LIMITS, resolveEntitlements } from "../entitlements.js";
+import type { Subscription } from "../types.js";
+import {
+  billingCycle,
+  manualPlanOverride,
+  subscriptionPlan,
+  subscriptionStatus,
+} from "../../../db/schema/subscription-schema.js";
+
+const NOW = new Date("2026-08-11T12:00:00Z");
+const PAST = new Date("2026-08-01T12:00:00Z");
+const FUTURE = new Date("2026-08-20T12:00:00Z");
+
+const makeSub = (patch: Partial<Subscription>): Subscription => ({
+  id: "sub-1",
+  organizationId: "org-1",
+  paddleSubscriptionId: "psub-1",
+  paddleCustomerId: "pcus-1",
+  plan: subscriptionPlan.Pro,
+  status: subscriptionStatus.Active,
+  billingCycle: billingCycle.Monthly,
+  extraGroupSlots: 0,
+  currentPeriodEnd: FUTURE,
+  graceEndsAt: null,
+  cancelAt: null,
+  manualPlanOverride: null,
+  manualMaxGroups: null,
+  manualMaxMembersPerGroup: null,
+  manualPlanUntil: null,
+  lastEventAt: null,
+  createdAt: PAST,
+  updatedAt: PAST,
+  ...patch,
+});
+
+describe("resolveEntitlements", () => {
+  test("no row means Free limits, writable", () => {
+    expect(resolveEntitlements(null, NOW)).toEqual({
+      plan: "FREE",
+      maxGroups: PLAN_LIMITS.FREE.groups,
+      maxMembersPerGroup: PLAN_LIMITS.FREE.membersPerGroup,
+      writable: true,
+      graceEndsAt: null,
+    });
+  });
+
+  describe("active / trialing", () => {
+    test.each([subscriptionStatus.Active, subscriptionStatus.Trialing])(
+      "%s PRO gives Pro limits",
+      (status) => {
+        const result = resolveEntitlements(makeSub({ status }), NOW);
+        expect(result).toEqual({
+          plan: "PRO",
+          maxGroups: PLAN_LIMITS.PRO.groups,
+          maxMembersPerGroup: PLAN_LIMITS.PRO.membersPerGroup,
+          writable: true,
+          graceEndsAt: null,
+        });
+      }
+    );
+
+    test("extra group slots add to maxGroups", () => {
+      const result = resolveEntitlements(makeSub({ extraGroupSlots: 4 }), NOW);
+      expect(result.maxGroups).toBe(PLAN_LIMITS.PRO.groups + 4);
+    });
+
+    test("negative extraGroupSlots never reduces the plan allowance", () => {
+      const result = resolveEntitlements(makeSub({ extraGroupSlots: -2 }), NOW);
+      expect(result.maxGroups).toBe(PLAN_LIMITS.PRO.groups);
+    });
+
+    test("slots are clamped to the plan ceiling even if Paddle reports more", () => {
+      // A quantity edited straight in the Paddle dashboard bypasses the
+      // checkout/slot routes, so the resolver has to hold the line.
+      const result = resolveEntitlements(makeSub({ extraGroupSlots: 50 }), NOW);
+      expect(result.maxGroups).toBe(PLAN_LIMITS.PRO.groups + PLAN_LIMITS.PRO.maxExtraSlots);
+    });
+
+    test("active ENTERPRISE gives Enterprise limits", () => {
+      const result = resolveEntitlements(
+        makeSub({ plan: subscriptionPlan.Enterprise, extraGroupSlots: 2 }),
+        NOW
+      );
+      expect(result).toEqual({
+        plan: "ENTERPRISE",
+        maxGroups: PLAN_LIMITS.ENTERPRISE.groups + 2,
+        maxMembersPerGroup: PLAN_LIMITS.ENTERPRISE.membersPerGroup,
+        writable: true,
+        graceEndsAt: null,
+      });
+    });
+
+    test("grace timestamp left over from a recovered payment is not exposed", () => {
+      const result = resolveEntitlements(makeSub({ graceEndsAt: FUTURE }), NOW);
+      expect(result.graceEndsAt).toBeNull();
+    });
+  });
+
+  describe("lapsed statuses", () => {
+    const lapsed = [
+      subscriptionStatus.PastDue,
+      subscriptionStatus.Canceled,
+      subscriptionStatus.Paused,
+    ];
+
+    test.each(lapsed)(
+      "%s with future grace keeps paid limits and exposes graceEndsAt",
+      (status) => {
+        const result = resolveEntitlements(
+          makeSub({ status, graceEndsAt: FUTURE, extraGroupSlots: 1 }),
+          NOW
+        );
+        expect(result).toEqual({
+          plan: "PRO",
+          maxGroups: PLAN_LIMITS.PRO.groups + 1,
+          maxMembersPerGroup: PLAN_LIMITS.PRO.membersPerGroup,
+          writable: true,
+          graceEndsAt: FUTURE.toISOString(),
+        });
+      }
+    );
+
+    test.each(lapsed)("%s with expired grace drops to Free and locks writes", (status) => {
+      const result = resolveEntitlements(makeSub({ status, graceEndsAt: PAST }), NOW);
+      expect(result).toEqual({
+        plan: "FREE",
+        maxGroups: PLAN_LIMITS.FREE.groups,
+        maxMembersPerGroup: PLAN_LIMITS.FREE.membersPerGroup,
+        writable: false,
+        graceEndsAt: null,
+      });
+    });
+
+    test.each(lapsed)("%s with no grace at all is treated as expired", (status) => {
+      const result = resolveEntitlements(makeSub({ status, graceEndsAt: null }), NOW);
+      expect(result.plan).toBe("FREE");
+      expect(result.writable).toBe(false);
+    });
+
+    test("grace boundary: exactly now counts as expired", () => {
+      const result = resolveEntitlements(
+        makeSub({ status: subscriptionStatus.PastDue, graceEndsAt: NOW }),
+        NOW
+      );
+      expect(result.writable).toBe(false);
+    });
+  });
+
+  describe("manual override", () => {
+    test("FREE override enforces Free limits read-only over the cap", () => {
+      const result = resolveEntitlements(
+        makeSub({ manualPlanOverride: manualPlanOverride.Free }),
+        NOW
+      );
+      expect(result).toEqual({
+        plan: "FREE",
+        maxGroups: PLAN_LIMITS.FREE.groups,
+        maxMembersPerGroup: PLAN_LIMITS.FREE.membersPerGroup,
+        writable: false,
+        graceEndsAt: null,
+      });
+    });
+
+    test("PRO override wins over an expired subscription (grandfathering)", () => {
+      const result = resolveEntitlements(
+        makeSub({
+          status: subscriptionStatus.Canceled,
+          graceEndsAt: PAST,
+          manualPlanOverride: manualPlanOverride.Pro,
+        }),
+        NOW
+      );
+      expect(result).toEqual({
+        plan: "PRO",
+        maxGroups: PLAN_LIMITS.PRO.groups,
+        maxMembersPerGroup: PLAN_LIMITS.PRO.membersPerGroup,
+        writable: true,
+        graceEndsAt: null,
+      });
+    });
+
+    test("ENTERPRISE override uses Enterprise limits", () => {
+      const result = resolveEntitlements(
+        makeSub({ manualPlanOverride: manualPlanOverride.Enterprise, plan: null, status: null }),
+        NOW
+      );
+      expect(result.plan).toBe("ENTERPRISE");
+      expect(result.maxGroups).toBe(PLAN_LIMITS.ENTERPRISE.groups);
+    });
+
+    test("manual limit columns override the plan defaults", () => {
+      const result = resolveEntitlements(
+        makeSub({
+          manualPlanOverride: manualPlanOverride.Pro,
+          manualMaxGroups: 7,
+          manualMaxMembersPerGroup: 30,
+        }),
+        NOW
+      );
+      expect(result.maxGroups).toBe(7);
+      expect(result.maxMembersPerGroup).toBe(30);
+    });
+
+    test("CUSTOM override uses the manual limits", () => {
+      const result = resolveEntitlements(
+        makeSub({
+          manualPlanOverride: manualPlanOverride.Custom,
+          manualMaxGroups: 50,
+          manualMaxMembersPerGroup: 500,
+        }),
+        NOW
+      );
+      expect(result).toEqual({
+        plan: "CUSTOM",
+        maxGroups: 50,
+        maxMembersPerGroup: 500,
+        writable: true,
+        graceEndsAt: null,
+      });
+    });
+
+    test("CUSTOM without manual limits falls back to Enterprise limits", () => {
+      const result = resolveEntitlements(
+        makeSub({ manualPlanOverride: manualPlanOverride.Custom }),
+        NOW
+      );
+      expect(result.maxGroups).toBe(PLAN_LIMITS.ENTERPRISE.groups);
+      expect(result.maxMembersPerGroup).toBe(PLAN_LIMITS.ENTERPRISE.membersPerGroup);
+    });
+
+    test("override active while manualPlanUntil is in the future", () => {
+      const result = resolveEntitlements(
+        makeSub({
+          status: subscriptionStatus.Canceled,
+          manualPlanOverride: manualPlanOverride.Pro,
+          manualPlanUntil: FUTURE,
+        }),
+        NOW
+      );
+      expect(result.plan).toBe("PRO");
+      expect(result.writable).toBe(true);
+    });
+
+    test("expired manualPlanUntil falls through to subscription state", () => {
+      const result = resolveEntitlements(
+        makeSub({
+          status: subscriptionStatus.Canceled,
+          graceEndsAt: PAST,
+          manualPlanOverride: manualPlanOverride.Pro,
+          manualPlanUntil: PAST,
+        }),
+        NOW
+      );
+      expect(result.plan).toBe("FREE");
+      expect(result.writable).toBe(false);
+    });
+  });
+
+  test("row without plan or status (checkout in flight) stays Free and writable", () => {
+    expect(resolveEntitlements(makeSub({ plan: null, status: null }), NOW)).toEqual({
+      plan: "FREE",
+      maxGroups: PLAN_LIMITS.FREE.groups,
+      maxMembersPerGroup: PLAN_LIMITS.FREE.membersPerGroup,
+      writable: true,
+      graceEndsAt: null,
+    });
+  });
+});

--- a/src/services/billing/tests/guards.test.ts
+++ b/src/services/billing/tests/guards.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockGetSubscription,
+  mockGetGroup,
+  mockGetAllGroups,
+  mockCountGroups,
+  mockOrderedGroupIds,
+  mockCountMembers,
+  mockCountInvites,
+  mockLockOrganization,
+} = vi.hoisted(() => ({
+  mockGetSubscription: vi.fn(),
+  mockGetGroup: vi.fn(),
+  mockGetAllGroups: vi.fn(),
+  mockCountGroups: vi.fn(),
+  mockOrderedGroupIds: vi.fn(),
+  mockCountMembers: vi.fn(),
+  mockCountInvites: vi.fn(),
+  mockLockOrganization: vi.fn(),
+}));
+
+vi.mock("../subscriptionServices.js", () => ({
+  getSubscriptionForOrganization: mockGetSubscription,
+}));
+
+vi.mock("../../group/groupServices.js", () => ({
+  getGroup: mockGetGroup,
+  getAllGroups: mockGetAllGroups,
+  countLiveGroupsForOrganization: mockCountGroups,
+  getLiveGroupIdsForOrganizationOrdered: mockOrderedGroupIds,
+}));
+
+vi.mock("../../groupUser/groupUserServices.js", () => ({
+  countActiveMembersInGroup: mockCountMembers,
+  countOpenInvitesForGroup: mockCountInvites,
+}));
+
+vi.mock("../../organization/organizationServices.js", () => ({
+  lockOrganization: mockLockOrganization,
+}));
+
+import {
+  assertCanAddMember,
+  assertCanCreateGroup,
+  assertGroupsWritable,
+  assertGroupWritable,
+} from "../guards.js";
+import { subscriptionPlan, subscriptionStatus } from "../../../db/schema/subscription-schema.js";
+
+const GROUP = { id: "group-1", organizationId: "org-1" };
+
+const lapsedProSub = {
+  plan: subscriptionPlan.Pro,
+  status: subscriptionStatus.Canceled,
+  extraGroupSlots: 0,
+  graceEndsAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+  manualPlanOverride: null,
+  manualPlanUntil: null,
+  manualMaxGroups: null,
+  manualMaxMembersPerGroup: null,
+};
+
+describe("assertCanCreateGroup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSubscription.mockResolvedValue(undefined);
+  });
+
+  it("allows creation below the Free group limit", async () => {
+    mockCountGroups.mockResolvedValue(2);
+    await expect(assertCanCreateGroup("org-1")).resolves.toBeUndefined();
+  });
+
+  it("402s with PLAN_LIMIT context at the Free group limit", async () => {
+    mockCountGroups.mockResolvedValue(3);
+    await expect(assertCanCreateGroup("org-1")).rejects.toMatchObject({
+      code: 402,
+      errors: [
+        expect.objectContaining({ publicContext: { reason: "PLAN_LIMIT", limit: 3, current: 3 } }),
+      ],
+    });
+  });
+
+  it("row-locks the organization when running inside a transaction", async () => {
+    mockCountGroups.mockResolvedValue(0);
+    const tx = {} as never;
+
+    await assertCanCreateGroup("org-1", tx);
+
+    // Without the lock, parallel creates all read the same pre-insert count.
+    expect(mockLockOrganization).toHaveBeenCalledWith("org-1", tx);
+  });
+
+  it("does not attempt a lock outside a transaction", async () => {
+    mockCountGroups.mockResolvedValue(0);
+    await assertCanCreateGroup("org-1");
+    expect(mockLockOrganization).not.toHaveBeenCalled();
+  });
+
+  it("uses paid limits plus extra slots when subscribed", async () => {
+    mockGetSubscription.mockResolvedValue({
+      ...lapsedProSub,
+      status: subscriptionStatus.Active,
+      graceEndsAt: null,
+      extraGroupSlots: 2,
+    });
+    mockCountGroups.mockResolvedValue(6);
+    await expect(assertCanCreateGroup("org-1")).resolves.toBeUndefined();
+
+    mockCountGroups.mockResolvedValue(7);
+    await expect(assertCanCreateGroup("org-1")).rejects.toMatchObject({ code: 402 });
+  });
+});
+
+describe("assertCanAddMember", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSubscription.mockResolvedValue(undefined);
+    mockGetGroup.mockResolvedValue(GROUP);
+    mockCountInvites.mockResolvedValue(0);
+  });
+
+  it("404s when the group does not exist", async () => {
+    mockGetGroup.mockResolvedValue(undefined);
+    await expect(assertCanAddMember("nope")).rejects.toMatchObject({ code: 404 });
+  });
+
+  it("allows adding below the Free member limit", async () => {
+    mockCountMembers.mockResolvedValue(9);
+    await expect(assertCanAddMember("group-1")).resolves.toBeUndefined();
+  });
+
+  it("counts open invites against the cap", async () => {
+    mockCountMembers.mockResolvedValue(9);
+    mockCountInvites.mockResolvedValue(1);
+    await expect(assertCanAddMember("group-1")).rejects.toMatchObject({
+      code: 402,
+      errors: [
+        expect.objectContaining({
+          publicContext: { reason: "PLAN_LIMIT", limit: 10, current: 10 },
+        }),
+      ],
+    });
+  });
+
+  it("does not count the invite being redeemed against its own seat", async () => {
+    mockCountMembers.mockResolvedValue(9);
+    mockCountInvites.mockResolvedValue(1);
+    await expect(
+      assertCanAddMember("group-1", undefined, { redeemingOpenInvite: true })
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("assertGroupWritable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGroup.mockResolvedValue(GROUP);
+    mockCountMembers.mockResolvedValue(5);
+  });
+
+  it("passes untouched while entitlements are writable", async () => {
+    mockGetSubscription.mockResolvedValue(undefined);
+    await expect(assertGroupWritable("group-1")).resolves.toBeUndefined();
+    expect(mockOrderedGroupIds).not.toHaveBeenCalled();
+  });
+
+  it("locks groups beyond the oldest N once grace has expired", async () => {
+    mockGetSubscription.mockResolvedValue(lapsedProSub);
+    mockOrderedGroupIds.mockResolvedValue(["old-1", "old-2", "old-3", "group-1", "new-2"]);
+    await expect(assertGroupWritable("group-1")).rejects.toMatchObject({
+      code: 402,
+      errors: [
+        expect.objectContaining({ publicContext: { reason: "READ_ONLY", limit: 3, current: 5 } }),
+      ],
+    });
+  });
+
+  it("keeps the oldest N groups writable after lapse", async () => {
+    mockGetSubscription.mockResolvedValue(lapsedProSub);
+    mockOrderedGroupIds.mockResolvedValue(["group-1", "new-1", "new-2", "new-3"]);
+    await expect(assertGroupWritable("group-1")).resolves.toBeUndefined();
+  });
+
+  it("locks a surviving group whose headcount exceeds the Free cap", async () => {
+    mockGetSubscription.mockResolvedValue(lapsedProSub);
+    mockOrderedGroupIds.mockResolvedValue(["group-1"]);
+    mockCountMembers.mockResolvedValue(12);
+    await expect(assertGroupWritable("group-1")).rejects.toMatchObject({
+      code: 402,
+      errors: [
+        expect.objectContaining({ publicContext: { reason: "READ_ONLY", limit: 10, current: 12 } }),
+      ],
+    });
+  });
+});
+
+describe("assertGroupsWritable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCountMembers.mockResolvedValue(1);
+  });
+
+  it("resolves each organization's entitlements once, not once per group", async () => {
+    mockGetSubscription.mockResolvedValue(undefined);
+    mockGetAllGroups.mockResolvedValue([
+      { id: "group-1", organizationId: "org-1" },
+      { id: "group-2", organizationId: "org-1" },
+      { id: "group-3", organizationId: "org-1" },
+    ]);
+
+    await assertGroupsWritable(["group-1", "group-2", "group-3", "group-1"]);
+
+    expect(mockGetAllGroups).toHaveBeenCalledTimes(1);
+    expect(mockGetSubscription).toHaveBeenCalledTimes(1);
+    // Writable orgs never need the ordering query.
+    expect(mockOrderedGroupIds).not.toHaveBeenCalled();
+  });
+
+  it("404s when one of the ids is not a live group", async () => {
+    mockGetSubscription.mockResolvedValue(undefined);
+    mockGetAllGroups.mockResolvedValue([{ id: "group-1", organizationId: "org-1" }]);
+
+    await expect(assertGroupsWritable(["group-1", "ghost"])).rejects.toMatchObject({ code: 404 });
+  });
+
+  it("locks the over-limit group in a lapsed batch", async () => {
+    mockGetSubscription.mockResolvedValue(lapsedProSub);
+    mockGetAllGroups.mockResolvedValue([
+      { id: "old-1", organizationId: "org-1" },
+      { id: "group-9", organizationId: "org-1" },
+    ]);
+    mockOrderedGroupIds.mockResolvedValue(["old-1", "old-2", "old-3", "group-9"]);
+
+    await expect(assertGroupsWritable(["old-1", "group-9"])).rejects.toMatchObject({
+      code: 402,
+      errors: [
+        expect.objectContaining({
+          publicContext: expect.objectContaining({ reason: "READ_ONLY" }),
+        }),
+      ],
+    });
+  });
+
+  it("returns immediately for an empty batch", async () => {
+    await assertGroupsWritable([]);
+    expect(mockGetAllGroups).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/billing/types.ts
+++ b/src/services/billing/types.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import type {
+  billingCycle,
+  manualPlanOverride,
+  subscriptionPlan,
+  subscriptionStatus,
+} from "../../db/schema/subscription-schema.js";
+
+export type Subscription = {
+  id: string;
+  organizationId: string;
+  paddleSubscriptionId: string | null;
+  paddleCustomerId: string | null;
+  plan: subscriptionPlan | null;
+  status: subscriptionStatus | null;
+  billingCycle: billingCycle | null;
+  extraGroupSlots: number;
+  currentPeriodEnd: Date | null;
+  graceEndsAt: Date | null;
+  cancelAt: Date | null;
+  manualPlanOverride: manualPlanOverride | null;
+  manualMaxGroups: number | null;
+  manualMaxMembersPerGroup: number | null;
+  manualPlanUntil: Date | null;
+  lastEventAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/** Any subset of the mutable subscription state; unmentioned fields keep their stored value. */
+export type SubscriptionPatch = Partial<
+  Omit<Subscription, "id" | "organizationId" | "createdAt" | "updatedAt">
+>;
+
+export const validatePostCheckout = z.object({
+  plan: z.enum(["PRO", "ENTERPRISE"]),
+  billingCycle: z.enum(["MONTHLY", "YEARLY"]),
+  extraGroupSlots: z.number().int().min(0).max(20).optional().default(0),
+});
+
+export type ValidatedPostCheckoutType = z.infer<typeof validatePostCheckout>;
+
+export const validatePatchSlots = z.object({
+  extraGroupSlots: z.number().int().min(0).max(20),
+});
+
+export type ValidatedPatchSlotsType = z.infer<typeof validatePatchSlots>;
+
+export const validateChangePlan = z.object({
+  plan: z.enum(["PRO", "ENTERPRISE"]),
+  billingCycle: z.enum(["MONTHLY", "YEARLY"]),
+});
+
+export type ValidatedChangePlanType = z.infer<typeof validateChangePlan>;

--- a/src/services/dev/devSeedServices.ts
+++ b/src/services/dev/devSeedServices.ts
@@ -4,6 +4,8 @@ import { hashPassword } from "better-auth/crypto";
 import { db } from "../../db/db.js";
 import { account, user } from "../../db/schema/auth-schema.js";
 import { groups } from "../../db/schema/group-schema.js";
+import { organizations } from "../../db/schema/organization-schema.js";
+import { subscriptions } from "../../db/schema/subscription-schema.js";
 import { changesSchema } from "../../db/schema/changes-schema.js";
 import { vacation, vacationType } from "../../db/schema/vacation-schema.js";
 import { vacationEvents, vacationEventType } from "../../db/schema/vacation-event-schema.js";
@@ -112,8 +114,11 @@ export const seedTeam = async (input: {
   teamName: string;
   managerUserId: string;
 }): Promise<{ id: string; groupName: string }> => {
+  const organization = await services.organization.ensureOrganizationForUser(input.managerUserId);
+
   const group = await services.group.createGroup({
     id: generateRandomUUID(),
+    organizationId: organization.id,
     groupName: input.teamName,
     managerUserId: input.managerUserId,
     mainApprovalUser: input.managerUserId,
@@ -199,9 +204,9 @@ export const addVacation = async (input: {
       vacationType: input.type ?? vacationType.Vacation,
       note: input.note,
       approvedAt: input.state === "approved" ? now : null,
-      approvedBy: input.state === "approved" ? input.actorUserId ?? null : null,
+      approvedBy: input.state === "approved" ? (input.actorUserId ?? null) : null,
       rejectedAt: input.state === "rejected" ? now : null,
-      rejectedBy: input.state === "rejected" ? input.actorUserId ?? null : null,
+      rejectedBy: input.state === "rejected" ? (input.actorUserId ?? null) : null,
       rejectionReason: input.state === "rejected" ? "Team coverage on that day" : null,
       createdAt: now,
       updatedAt: now,
@@ -289,6 +294,18 @@ export const resetDevData = async (): Promise<ResetSummary> => {
         )
       )
       .returning({ id: groups.id });
+
+    // Organizations reference dev users without a cascade, and subscriptions
+    // reference organizations — both must go before the user rows.
+    const devOrgs = await tx
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(inArray(organizations.ownerUserId, ids));
+    const orgIds = devOrgs.map((row) => row.id);
+    if (orgIds.length > 0) {
+      await tx.delete(subscriptions).where(inArray(subscriptions.organizationId, orgIds));
+      await tx.delete(organizations).where(inArray(organizations.id, orgIds));
+    }
 
     const deletedUsers = await tx
       .delete(user)

--- a/src/services/email/emailSender.ts
+++ b/src/services/email/emailSender.ts
@@ -101,6 +101,20 @@ export interface GroupInviteData {
 }
 
 /**
+ * `subscription-grace`: sent to the organization's billing email when a
+ * payment fails or a subscription is canceled — full limits continue for the
+ * grace window, then over-limit groups go read-only. Account/billing mail, so
+ * it ignores `user_settings.emailNotifications`.
+ */
+export interface SubscriptionGraceData {
+  recipientName: string;
+  planName: string;
+  /** Human-readable date the grace window ends, e.g. "25 August 2026". */
+  graceEndsDate: string;
+  billingUrl: string;
+}
+
+/**
  * A templated email to send. `template` is the logical template name; the
  * adapter maps it to the concrete, stage-suffixed SES template name. The
  * union keeps each template's variables tied to its name.
@@ -112,7 +126,8 @@ export type TemplatedEmail =
   | { to: string; template: "vacation-rejected"; data: VacationRejectedData }
   | { to: string; template: "vacation-cancelled"; data: VacationCancelledData }
   | { to: string; template: "vacation-comment"; data: VacationCommentData }
-  | { to: string; template: "group-invite"; data: GroupInviteData };
+  | { to: string; template: "group-invite"; data: GroupInviteData }
+  | { to: string; template: "subscription-grace"; data: SubscriptionGraceData };
 
 export type EmailTemplateName = TemplatedEmail["template"];
 

--- a/src/services/email/index.ts
+++ b/src/services/email/index.ts
@@ -15,6 +15,7 @@ export type {
   VacationRejectedData,
   VacationCommentData,
   GroupInviteData,
+  SubscriptionGraceData,
 } from "./emailSender.js";
 
 /**

--- a/src/services/group/groupServices.ts
+++ b/src/services/group/groupServices.ts
@@ -1,7 +1,7 @@
 import type { GroupInsertType, GroupType } from "./types.js";
 import { db, type DbTransaction } from "../../db/db.js";
 import { groups } from "../../db/schema/group-schema.js";
-import { and, eq, inArray, isNull, or } from "drizzle-orm";
+import { and, asc, count, eq, inArray, isNull, or } from "drizzle-orm";
 import { user } from "../../db/schema/auth-schema.js";
 import { groupUsers } from "../../db/schema/group-users-schema.js";
 import { alias } from "drizzle-orm/pg-core";
@@ -18,8 +18,12 @@ export const getGroup = async (
   return row;
 };
 
-export const getAllGroups = async (groupIds: string[]): Promise<GroupType[]> => {
-  return db
+export const getAllGroups = async (
+  groupIds: string[],
+  tx?: DbTransaction
+): Promise<GroupType[]> => {
+  if (groupIds.length === 0) return [];
+  return (tx ?? db)
     .select()
     .from(groups)
     .where(and(inArray(groups.id, groupIds), isNull(groups.deletedAt)));
@@ -184,4 +188,56 @@ export const getApprovalUsers = async (
     .leftJoin(tempApprovalUser, eq(groups.tempApprovalUser, tempApprovalUser.id));
 
   return row ?? undefined;
+};
+
+export const countLiveGroupsForOrganization = async (
+  organizationId: string,
+  tx?: DbTransaction
+): Promise<number> => {
+  const [row] = await (tx ?? db)
+    .select({ value: count() })
+    .from(groups)
+    .where(and(eq(groups.organizationId, organizationId), isNull(groups.deletedAt)));
+  return Number(row?.value ?? 0);
+};
+
+/**
+ * Live group ids of an organization, oldest first — the deterministic order
+ * the billing guards use to decide which groups stay writable once a lapsed
+ * plan's grace has expired: the oldest N keep working, the rest go read-only.
+ */
+export const getLiveGroupIdsForOrganizationOrdered = async (
+  organizationId: string,
+  tx?: DbTransaction
+): Promise<string[]> => {
+  const rows = await (tx ?? db)
+    .select({ id: groups.id })
+    .from(groups)
+    .where(and(eq(groups.organizationId, organizationId), isNull(groups.deletedAt)))
+    .orderBy(asc(groups.createdAt), asc(groups.id));
+  return rows.map((row) => row.id);
+};
+
+/**
+ * Live groups of an organization with their active member counts, oldest
+ * first — the billing screen's usage meters.
+ */
+export const getGroupUsageForOrganization = async (
+  organizationId: string,
+  tx?: DbTransaction
+): Promise<{ id: string; groupName: string; members: number; createdAt: Date }[]> => {
+  const rows = await (tx ?? db)
+    .select({
+      id: groups.id,
+      groupName: groups.groupName,
+      members: count(groupUsers.id),
+      createdAt: groups.createdAt,
+    })
+    .from(groups)
+    .leftJoin(groupUsers, and(eq(groupUsers.groupId, groups.id), isNull(groupUsers.deletedAt)))
+    .where(and(eq(groups.organizationId, organizationId), isNull(groups.deletedAt)))
+    .groupBy(groups.id)
+    .orderBy(asc(groups.createdAt), asc(groups.id));
+
+  return rows.map((row) => ({ ...row, members: Number(row.members) }));
 };

--- a/src/services/group/groupServices.ts
+++ b/src/services/group/groupServices.ts
@@ -18,6 +18,24 @@ export const getGroup = async (
   return row;
 };
 
+/**
+ * `getGroup` under a row lock, for callers that recompute a column from the
+ * value they just read — a plain read under READ COMMITTED lets a concurrent
+ * writer commit in between and lose its change.
+ */
+export const lockGroup = async (
+  groupId: string,
+  tx: DbTransaction
+): Promise<GroupType | undefined> => {
+  const [row] = await tx
+    .select()
+    .from(groups)
+    .where(and(eq(groups.id, groupId), isNull(groups.deletedAt)))
+    .for("update");
+
+  return row;
+};
+
 export const getAllGroups = async (
   groupIds: string[],
   tx?: DbTransaction

--- a/src/services/group/types.ts
+++ b/src/services/group/types.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export type GroupType = {
   id: string;
+  organizationId: string;
   groupName: string;
   defaultVacationDays: number;
   defaultHomeOfficeDays: number;
@@ -16,6 +17,7 @@ export type GroupType = {
 
 export type GroupInsertType = {
   id: string;
+  organizationId: string;
   groupName: string;
   managerUserId: string;
   defaultVacationDays?: number;

--- a/src/services/groupUser/groupUserServices.ts
+++ b/src/services/groupUser/groupUserServices.ts
@@ -1,6 +1,6 @@
 import { db, type DbTransaction } from "../../db/db.js";
 import { groupUsers } from "../../db/schema/group-users-schema.js";
-import { and, asc, countDistinct, desc, eq, gt, inArray, isNull } from "drizzle-orm";
+import { and, asc, count, countDistinct, desc, eq, gt, inArray, isNull } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import type {
   GroupUser,
@@ -65,8 +65,11 @@ export const updateGroupUserPermissions = async (
   return row;
 };
 
-export const deleteGroupUser = async (id: string): Promise<GroupUser | undefined> => {
-  const [row] = await db
+export const deleteGroupUser = async (
+  id: string,
+  tx?: DbTransaction
+): Promise<GroupUser | undefined> => {
+  const [row] = await (tx ?? db)
     .update(groupUsers)
     .set({
       deletedAt: new Date(),
@@ -288,4 +291,38 @@ export const useInviteLink = async (
     .returning();
 
   return row;
+};
+
+export const countActiveMembersInGroup = async (
+  groupId: string,
+  tx?: DbTransaction
+): Promise<number> => {
+  const [row] = await (tx ?? db)
+    .select({ value: count() })
+    .from(groupUsers)
+    .where(and(eq(groupUsers.groupId, groupId), isNull(groupUsers.deletedAt)));
+  return Number(row?.value ?? 0);
+};
+
+/**
+ * Open (redeemable) invites for a group. The billing member-cap guard counts
+ * these alongside live members, otherwise parallel redemptions overfill a
+ * group past its plan limit.
+ */
+export const countOpenInvitesForGroup = async (
+  groupId: string,
+  tx?: DbTransaction
+): Promise<number> => {
+  const [row] = await (tx ?? db)
+    .select({ value: count() })
+    .from(inviteLink)
+    .where(
+      and(
+        eq(inviteLink.groupId, groupId),
+        isNull(inviteLink.usedAt),
+        isNull(inviteLink.revokedAt),
+        gt(inviteLink.expiresAt, new Date())
+      )
+    );
+  return Number(row?.value ?? 0);
 };

--- a/src/services/organization/organizationServices.ts
+++ b/src/services/organization/organizationServices.ts
@@ -1,0 +1,121 @@
+import { db, type DbTransaction } from "../../db/db.js";
+import { organizations } from "../../db/schema/organization-schema.js";
+import { eq } from "drizzle-orm";
+import { getUserById } from "../user/userServices.js";
+import { generateRandomUUID } from "../../utils/generateUUID.js";
+import AppError from "../../utils/appError.js";
+import type { OrganizationType } from "./types.js";
+
+export const getOrganizationById = async (
+  organizationId: string,
+  tx?: DbTransaction
+): Promise<OrganizationType | undefined> => {
+  const [row] = await (tx ?? db)
+    .select()
+    .from(organizations)
+    .where(eq(organizations.id, organizationId))
+    .limit(1);
+
+  return row;
+};
+
+export const getOrganizationForOwner = async (
+  ownerUserId: string,
+  tx?: DbTransaction
+): Promise<OrganizationType | undefined> => {
+  const [row] = await (tx ?? db)
+    .select()
+    .from(organizations)
+    .where(eq(organizations.ownerUserId, ownerUserId))
+    .limit(1);
+
+  return row;
+};
+
+/**
+ * Lazily creates the user's organization on first need (group creation).
+ * Users with no groups get no row. Safe under concurrency: the unique index
+ * on `owner_user_id` makes the insert a no-op for the loser, who re-selects.
+ */
+export const ensureOrganizationForUser = async (
+  userId: string,
+  tx?: DbTransaction
+): Promise<OrganizationType> => {
+  const existing = await getOrganizationForOwner(userId, tx);
+  if (existing) return existing;
+
+  const owner = await getUserById(userId, tx);
+  if (!owner) {
+    throw new AppError({
+      message: "User not found",
+      logging: true,
+      code: 404,
+      context: { userId },
+    });
+  }
+
+  const [created] = await (tx ?? db)
+    .insert(organizations)
+    .values({
+      id: generateRandomUUID(),
+      name: owner.name,
+      ownerUserId: userId,
+      billingEmail: owner.email,
+    })
+    .onConflictDoNothing({ target: organizations.ownerUserId })
+    .returning();
+
+  if (created) return created;
+
+  const raced = await getOrganizationForOwner(userId, tx);
+  if (!raced) {
+    throw new AppError({
+      message: "Failed to create organization",
+      logging: true,
+      code: 500,
+      context: { userId },
+    });
+  }
+  return raced;
+};
+
+export const setOrganizationPaddleCustomerId = async (
+  organizationId: string,
+  paddleCustomerId: string,
+  tx?: DbTransaction
+): Promise<OrganizationType | undefined> => {
+  const [row] = await (tx ?? db)
+    .update(organizations)
+    .set({ paddleCustomerId })
+    .where(eq(organizations.id, organizationId))
+    .returning();
+
+  return row;
+};
+
+/**
+ * Row-locks the organization for the rest of the transaction. The group cap is
+ * a plain `count(*)`, so without this two concurrent creates both see the
+ * pre-insert count and both succeed, leaving the org permanently over its plan.
+ */
+export const lockOrganization = async (
+  organizationId: string,
+  tx: DbTransaction
+): Promise<void> => {
+  const [row] = await tx
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.id, organizationId))
+    .for("update");
+
+  // `FOR UPDATE` matching no row locks nothing and returns silently, which
+  // would quietly turn every caller's count-then-act back into a race.
+  if (!row) {
+    throw new AppError({
+      message: "Organization not found",
+      logging: true,
+      code: 500,
+      context: { organizationId },
+    });
+  }
+};

--- a/src/services/organization/types.ts
+++ b/src/services/organization/types.ts
@@ -1,0 +1,9 @@
+export type OrganizationType = {
+  id: string;
+  name: string;
+  ownerUserId: string;
+  billingEmail: string;
+  paddleCustomerId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/tests/e2e/billing.e2e.test.ts
+++ b/src/tests/e2e/billing.e2e.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "../../db/db.js";
+import { groups } from "../../db/schema/group-schema.js";
+import { groupUsers } from "../../db/schema/group-users-schema.js";
+import { inviteLink } from "../../db/schema/invite-link-schema.js";
+import {
+  subscriptionPlan,
+  subscriptionStatus,
+  manualPlanOverride,
+} from "../../db/schema/subscription-schema.js";
+import { createTestUser, cleanupTestData } from "./helpers/testSetup.js";
+import { ensureOrganizationForUser } from "../../services/organization/organizationServices.js";
+import {
+  recordPaddleEvent,
+  upsertSubscription,
+} from "../../services/billing/subscriptionServices.js";
+import {
+  assertCanAddMember,
+  assertCanCreateGroup,
+  assertGroupWritable,
+} from "../../services/billing/guards.js";
+
+/**
+ * The plan-limit guards live in SQL counts plus the pure resolver; this suite
+ * verifies the whole stack against a real database.
+ */
+describe("billing limits", () => {
+  let owner: { id: string };
+  let member: { id: string };
+
+  const insertGroup = async (organizationId: string, name: string, createdAt: Date) => {
+    const id = uuidv4();
+    await db.insert(groups).values({
+      id,
+      organizationId,
+      groupName: name,
+      managerUserId: owner.id,
+      createdAt,
+      updatedAt: createdAt,
+    });
+    return id;
+  };
+
+  const addMember = (userId: string, groupId: string) =>
+    db.insert(groupUsers).values({
+      id: uuidv4(),
+      userId,
+      groupId,
+      viewAccess: true,
+      adminAccess: false,
+      controlledUser: true,
+    });
+
+  const addOpenInvite = (groupId: string, email: string) =>
+    db.insert(inviteLink).values({
+      id: uuidv4(),
+      groupId,
+      code: `CODE-${uuidv4().slice(0, 8)}`,
+      email,
+      invitedByUserId: owner.id,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    });
+
+  beforeAll(async () => {
+    await cleanupTestData();
+    owner = await createTestUser("billing-owner@test.com", "Billing Owner", "password123");
+    member = await createTestUser("billing-member@test.com", "Billing Member", "password123");
+  });
+
+  afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  it("creates exactly one organization per user, however often it is asked", async () => {
+    const first = await ensureOrganizationForUser(owner.id);
+    const second = await ensureOrganizationForUser(owner.id);
+    expect(second.id).toBe(first.id);
+    expect(first.ownerUserId).toBe(owner.id);
+    expect(first.billingEmail).toBe("billing-owner@test.com");
+  });
+
+  it("blocks the fourth group on the Free plan with a 402", async () => {
+    const organization = await ensureOrganizationForUser(owner.id);
+    const base = Date.now();
+    await insertGroup(organization.id, "Free 1", new Date(base - 4000));
+    await insertGroup(organization.id, "Free 2", new Date(base - 3000));
+    await insertGroup(organization.id, "Free 3", new Date(base - 2000));
+
+    await expect(assertCanCreateGroup(organization.id)).rejects.toMatchObject({
+      code: 402,
+      errors: [
+        expect.objectContaining({
+          publicContext: { reason: "PLAN_LIMIT", limit: 3, current: 3 },
+        }),
+      ],
+    });
+  });
+
+  it("lifts the cap when a Pro subscription with slots is active", async () => {
+    const organization = await ensureOrganizationForUser(owner.id);
+    await upsertSubscription(organization.id, {
+      plan: subscriptionPlan.Pro,
+      status: subscriptionStatus.Active,
+      extraGroupSlots: 1,
+    });
+
+    await expect(assertCanCreateGroup(organization.id)).resolves.toBeUndefined();
+  });
+
+  it("counts live members plus open invites against the member cap", async () => {
+    const organization = await ensureOrganizationForUser(owner.id);
+    // CUSTOM override with a 2-person cap keeps the fixture small.
+    await upsertSubscription(organization.id, {
+      manualPlanOverride: manualPlanOverride.Custom,
+      manualMaxGroups: 10,
+      manualMaxMembersPerGroup: 2,
+    });
+
+    const groupId = await insertGroup(organization.id, "Capped", new Date());
+    await addMember(owner.id, groupId);
+
+    await expect(assertCanAddMember(groupId)).resolves.toBeUndefined();
+
+    await addOpenInvite(groupId, "pending@test.com");
+    await expect(assertCanAddMember(groupId)).rejects.toMatchObject({ code: 402 });
+
+    // The redemption path must not count the invite being redeemed.
+    await expect(
+      assertCanAddMember(groupId, undefined, { redeemingOpenInvite: true })
+    ).resolves.toBeUndefined();
+  });
+
+  it("locks only the newest groups once grace has expired", async () => {
+    const organization = await ensureOrganizationForUser(owner.id);
+    await upsertSubscription(organization.id, {
+      manualPlanOverride: null,
+      manualMaxGroups: null,
+      manualMaxMembersPerGroup: null,
+      plan: subscriptionPlan.Pro,
+      status: subscriptionStatus.Canceled,
+      extraGroupSlots: 0,
+      graceEndsAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    const groupIds = await db.select({ id: groups.id, createdAt: groups.createdAt }).from(groups);
+    const sorted = groupIds.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+
+    // Free allows 3 groups: the three oldest stay writable, the rest lock.
+    await expect(assertGroupWritable(sorted[0]!.id)).resolves.toBeUndefined();
+    await expect(assertGroupWritable(sorted[sorted.length - 1]!.id)).rejects.toMatchObject({
+      code: 402,
+      errors: [
+        expect.objectContaining({
+          publicContext: expect.objectContaining({ reason: "READ_ONLY" }),
+        }),
+      ],
+    });
+  });
+
+  it("keeps paid limits writable inside the grace window", async () => {
+    const organization = await ensureOrganizationForUser(owner.id);
+    await upsertSubscription(organization.id, {
+      status: subscriptionStatus.PastDue,
+      graceEndsAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    });
+
+    const [anyGroup] = await db.select({ id: groups.id }).from(groups).limit(1);
+    await expect(assertGroupWritable(anyGroup!.id)).resolves.toBeUndefined();
+  });
+
+  it("records each Paddle event id exactly once", async () => {
+    const eventId = `evt-${uuidv4()}`;
+    expect(await recordPaddleEvent(eventId, "subscription.updated")).toBe(true);
+    expect(await recordPaddleEvent(eventId, "subscription.updated")).toBe(false);
+  });
+
+  it("grants a member no organization until they create a group", async () => {
+    const { getOrganizationForOwner } =
+      await import("../../services/organization/organizationServices.js");
+    expect(await getOrganizationForOwner(member.id)).toBeUndefined();
+  });
+});

--- a/src/tests/e2e/billing.e2e.test.ts
+++ b/src/tests/e2e/billing.e2e.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { v4 as uuidv4 } from "uuid";
+import { asc, eq } from "drizzle-orm";
 import { db } from "../../db/db.js";
 import { groups } from "../../db/schema/group-schema.js";
 import { groupUsers } from "../../db/schema/group-users-schema.js";
@@ -143,8 +144,11 @@ describe("billing limits", () => {
       graceEndsAt: new Date(Date.now() - 60 * 60 * 1000),
     });
 
-    const groupIds = await db.select({ id: groups.id, createdAt: groups.createdAt }).from(groups);
-    const sorted = groupIds.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    const sorted = await db
+      .select({ id: groups.id, createdAt: groups.createdAt })
+      .from(groups)
+      .where(eq(groups.organizationId, organization.id))
+      .orderBy(asc(groups.createdAt));
 
     // Free allows 3 groups: the three oldest stay writable, the rest lock.
     await expect(assertGroupWritable(sorted[0]!.id)).resolves.toBeUndefined();
@@ -165,7 +169,12 @@ describe("billing limits", () => {
       graceEndsAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
     });
 
-    const [anyGroup] = await db.select({ id: groups.id }).from(groups).limit(1);
+    const [anyGroup] = await db
+      .select({ id: groups.id })
+      .from(groups)
+      .where(eq(groups.organizationId, organization.id))
+      .orderBy(asc(groups.createdAt))
+      .limit(1);
     await expect(assertGroupWritable(anyGroup!.id)).resolves.toBeUndefined();
   });
 
@@ -176,8 +185,9 @@ describe("billing limits", () => {
   });
 
   it("grants a member no organization until they create a group", async () => {
-    const { getOrganizationForOwner } =
-      await import("../../services/organization/organizationServices.js");
+    const { getOrganizationForOwner } = await import(
+      "../../services/organization/organizationServices.js"
+    );
     expect(await getOrganizationForOwner(member.id)).toBeUndefined();
   });
 });

--- a/src/tests/e2e/helpers/reportFixtures.ts
+++ b/src/tests/e2e/helpers/reportFixtures.ts
@@ -11,6 +11,9 @@ import { reportExports } from "../../../db/schema/report-export-schema.js";
 import { vacationEvents } from "../../../db/schema/vacation-event-schema.js";
 import { notifications } from "../../../db/schema/notification-schema.js";
 import { session } from "../../../db/schema/auth-schema.js";
+import { organizations } from "../../../db/schema/organization-schema.js";
+import { subscriptions } from "../../../db/schema/subscription-schema.js";
+import { ensureOrganizationForUser } from "../../../services/organization/organizationServices.js";
 
 /**
  * Fixtures for the report e2e suite. Deliberately independent of
@@ -33,8 +36,10 @@ export async function makeUser(name: string): Promise<{ id: string; name: string
 
 export async function makeGroup(groupName: string, managerUserId: string): Promise<string> {
   const id = uuidv4();
+  const organization = await ensureOrganizationForUser(managerUserId);
   await db.insert(groups).values({
     id,
+    organizationId: organization.id,
     groupName,
     managerUserId,
     createdAt: new Date(),
@@ -171,6 +176,8 @@ export async function resetReportData(): Promise<void> {
   await db.delete(notifications);
   await db.delete(session);
   await db.delete(groups);
+  await db.delete(subscriptions);
+  await db.delete(organizations);
   await db.delete(user);
 }
 

--- a/src/tests/e2e/helpers/testSetup.ts
+++ b/src/tests/e2e/helpers/testSetup.ts
@@ -8,6 +8,10 @@ import { groupUsers } from "../../../db/schema/group-users-schema.js";
 import { session } from "../../../db/schema/auth-schema.js";
 import { v4 as uuidv4 } from "uuid";
 import { eq } from "drizzle-orm";
+import { organizations } from "../../../db/schema/organization-schema.js";
+import { subscriptions } from "../../../db/schema/subscription-schema.js";
+import { paddleEvents } from "../../../db/schema/paddle-event-schema.js";
+import { ensureOrganizationForUser } from "../../../services/organization/organizationServices.js";
 
 export interface TestUser {
   id: string;
@@ -79,8 +83,11 @@ export async function createTestGroup(
 ): Promise<TestGroup> {
   const groupId = uuidv4();
 
+  const organization = await ensureOrganizationForUser(managerUserId);
+
   await db.insert(groups).values({
     id: groupId,
+    organizationId: organization.id,
     groupName,
     managerUserId,
     mainApprovalUser: mainApprovalUser || null,
@@ -124,6 +131,9 @@ export async function cleanupTestData() {
     await db.delete(groupUsers);
     await db.delete(session);
     await db.delete(groups);
+    await db.delete(subscriptions);
+    await db.delete(organizations);
+    await db.delete(paddleEvents);
     await db.delete(user);
 
     // Clear cache

--- a/src/utils/paddle.ts
+++ b/src/utils/paddle.ts
@@ -1,0 +1,22 @@
+import { Environment, Paddle } from "@paddle/paddle-node-sdk";
+import { config, type PaddleConfig } from "../config.js";
+import AppError from "./appError.js";
+
+const client: Paddle | undefined = config.paddle
+  ? new Paddle(config.paddle.apiKey, {
+      environment:
+        config.paddle.environment === "production" ? Environment.production : Environment.sandbox,
+    })
+  : undefined;
+
+/** 503s when Paddle is not configured, so half-set-up environments fail loudly. */
+export const requirePaddle = (): { paddle: Paddle; paddleConfig: PaddleConfig } => {
+  if (!client || !config.paddle) {
+    throw new AppError({
+      message: "Billing is not configured on this environment",
+      logging: true,
+      code: 503,
+    });
+  }
+  return { paddle: client, paddleConfig: config.paddle };
+};

--- a/terraform/apprunner.tf
+++ b/terraform/apprunner.tf
@@ -62,7 +62,22 @@ resource "aws_apprunner_service" "main" {
           # enabled. The matching client secret is injected below via Secrets
           # Manager. better-auth builds the callback as
           # {BETTER_AUTH_URL}/api/auth/callback/google.
-          var.google_client_id != "" ? { GOOGLE_CLIENT_ID = var.google_client_id } : {}
+          var.google_client_id != "" ? { GOOGLE_CLIENT_ID = var.google_client_id } : {},
+
+          # Paddle price IDs are public catalog identifiers, not secrets, so
+          # they ride as plain env vars. The API key and webhook secret go
+          # through Secrets Manager below. Omitted entirely when billing is
+          # disabled, which leaves config.paddle undefined and /api/billing/*
+          # returning 503.
+          var.paddle_api_key != "" ? {
+            PADDLE_ENV                       = var.paddle_environment
+            PADDLE_PRICE_PRO_MONTHLY         = var.paddle_prices.pro_monthly
+            PADDLE_PRICE_PRO_YEARLY          = var.paddle_prices.pro_yearly
+            PADDLE_PRICE_ENTERPRISE_MONTHLY  = var.paddle_prices.enterprise_monthly
+            PADDLE_PRICE_ENTERPRISE_YEARLY   = var.paddle_prices.enterprise_yearly
+            PADDLE_PRICE_EXTRA_GROUP_MONTHLY = var.paddle_prices.extra_group_monthly
+            PADDLE_PRICE_EXTRA_GROUP_YEARLY  = var.paddle_prices.extra_group_yearly
+          } : {}
         )
 
         # Resolved at instance start via the instance role; each env var
@@ -74,6 +89,10 @@ resource "aws_apprunner_service" "main" {
           },
           var.google_client_id != "" ? {
             GOOGLE_CLIENT_SECRET = aws_secretsmanager_secret.google_client_secret[0].arn
+          } : {},
+          var.paddle_api_key != "" ? {
+            PADDLE_API_KEY        = aws_secretsmanager_secret.paddle_api_key[0].arn
+            PADDLE_WEBHOOK_SECRET = aws_secretsmanager_secret.paddle_webhook_secret[0].arn
           } : {}
         )
       }

--- a/terraform/apprunner.tf
+++ b/terraform/apprunner.tf
@@ -122,6 +122,8 @@ resource "aws_apprunner_service" "main" {
     aws_secretsmanager_secret_version.database_url,
     aws_secretsmanager_secret_version.better_auth_secret,
     aws_secretsmanager_secret_version.google_client_secret,
+    aws_secretsmanager_secret_version.paddle_api_key,
+    aws_secretsmanager_secret_version.paddle_webhook_secret,
     aws_iam_role_policy.apprunner_secrets,
     aws_db_instance.main
   ]

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -73,7 +73,9 @@ resource "aws_iam_role_policy" "apprunner_secrets" {
             aws_secretsmanager_secret.database_url.arn,
             aws_secretsmanager_secret.better_auth_secret.arn
           ],
-          aws_secretsmanager_secret.google_client_secret[*].arn
+          aws_secretsmanager_secret.google_client_secret[*].arn,
+          aws_secretsmanager_secret.paddle_api_key[*].arn,
+          aws_secretsmanager_secret.paddle_webhook_secret[*].arn
         )
       }
     ]

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -90,3 +90,64 @@ resource "aws_secretsmanager_secret_version" "google_client_secret" {
   secret_id     = aws_secretsmanager_secret.google_client_secret[0].id
   secret_string = var.google_client_secret
 }
+
+# Paddle API key and webhook signing secret. Only provisioned when billing is
+# enabled (paddle_api_key set), matching the google_client_secret pattern
+# above, so an empty secret_string never reaches Secrets Manager. The six
+# price IDs are not secrets and are injected as plain env vars in apprunner.tf.
+resource "aws_secretsmanager_secret" "paddle_api_key" {
+  count                   = var.paddle_api_key != "" ? 1 : 0
+  name                    = "${var.project_name}-${var.environment}-paddle-api-key"
+  description             = "Paddle API key for ${var.project_name}"
+  recovery_window_in_days = 0
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-paddle-api-key"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "paddle_api_key" {
+  count         = var.paddle_api_key != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.paddle_api_key[0].id
+  secret_string = var.paddle_api_key
+
+  # Fail at plan/apply rather than letting App Runner start a container that
+  # throws in config.ts — a boot loop is far harder to diagnose than this.
+  lifecycle {
+    precondition {
+      condition     = var.paddle_webhook_secret != ""
+      error_message = "paddle_webhook_secret is required when paddle_api_key is set."
+    }
+
+    precondition {
+      condition = alltrue([
+        for id in values(var.paddle_prices) : id != ""
+      ])
+      error_message = "All six paddle_prices IDs are required when paddle_api_key is set."
+    }
+
+    # Sandbox credentials must never reach the production environment; the
+    # backend enforces the same rule at boot.
+    precondition {
+      condition     = !(var.environment == "production" && var.paddle_environment == "sandbox")
+      error_message = "paddle_environment must be \"production\" when environment is \"production\"."
+    }
+  }
+}
+
+resource "aws_secretsmanager_secret" "paddle_webhook_secret" {
+  count                   = var.paddle_api_key != "" ? 1 : 0
+  name                    = "${var.project_name}-${var.environment}-paddle-webhook-secret"
+  description             = "Paddle webhook signing secret for ${var.project_name}"
+  recovery_window_in_days = 0
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-paddle-webhook-secret"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "paddle_webhook_secret" {
+  count         = var.paddle_api_key != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.paddle_webhook_secret[0].id
+  secret_string = var.paddle_webhook_secret
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -49,3 +49,32 @@ better_auth_secret = ""
 # committing them here.
 google_client_id     = ""
 google_client_secret = ""
+
+# Paddle billing. Leave paddle_api_key empty to disable billing entirely: no
+# Paddle secrets are created, no Paddle env vars are injected, and the
+# backend's /api/billing/* routes return 503.
+#
+# Once paddle_api_key is set, ALL of the following are required — terraform
+# fails at plan time otherwise (see the preconditions in secrets.tf), rather
+# than letting App Runner boot-loop on a config error.
+#
+# Sandbox and production are separate Paddle accounts with separate catalogs,
+# so production price IDs are NOT the same as your sandbox ones.
+paddle_api_key        = ""
+paddle_webhook_secret = ""
+
+# "sandbox" or "production". Terraform refuses to combine "sandbox" with
+# environment = "production", and the backend enforces the same rule at boot.
+paddle_environment = "production"
+
+# All six keys must be present when billing is enabled — this is a typed
+# object, so a partial map is a plan error. Price IDs are public identifiers,
+# not secrets, and are injected as plain env vars.
+paddle_prices = {
+  pro_monthly         = ""
+  pro_yearly          = ""
+  enterprise_monthly  = ""
+  enterprise_yearly   = ""
+  extra_group_monthly = ""
+  extra_group_yearly  = ""
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -169,6 +169,59 @@ variable "better_auth_rotation_days" {
   default     = 90
 }
 
+# Paddle Billing Configuration
+#
+# Billing is opt-in: leave paddle_api_key empty and no Paddle resources are
+# created, no Paddle env vars are injected, and the backend's /api/billing/*
+# routes return 503. Set it and the remaining Paddle variables become required
+# — the backend refuses to boot with a half-configured Paddle block.
+variable "paddle_api_key" {
+  description = "Paddle API key (stored in Secrets Manager). Empty disables billing entirely."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "paddle_webhook_secret" {
+  description = "Paddle webhook signing secret (stored in Secrets Manager). Required if paddle_api_key is set."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "paddle_environment" {
+  description = "Paddle environment: 'sandbox' or 'production'. The backend refuses to boot on 'sandbox' when NODE_ENV=production."
+  type        = string
+  default     = "production"
+
+  validation {
+    condition     = contains(["sandbox", "production"], var.paddle_environment)
+    error_message = "paddle_environment must be either \"sandbox\" or \"production\"."
+  }
+}
+
+# Price IDs are NOT secrets — they identify catalog prices and are visible in
+# any checkout — so they ride as plain env vars rather than Secrets Manager.
+variable "paddle_prices" {
+  description = "Paddle price IDs for the six EUR catalog prices. All required if paddle_api_key is set."
+  type = object({
+    pro_monthly         = string
+    pro_yearly          = string
+    enterprise_monthly  = string
+    enterprise_yearly   = string
+    extra_group_monthly = string
+    extra_group_yearly  = string
+  })
+  default = {
+    pro_monthly         = ""
+    pro_yearly          = ""
+    enterprise_monthly  = ""
+    enterprise_yearly   = ""
+    extra_group_monthly = ""
+    extra_group_yearly  = ""
+  }
+}
+
 # Google OAuth Configuration
 variable "google_client_id" {
   description = "Google OAuth client ID (public; injected as a plain env var). Leave empty to disable Google sign-in."


### PR DESCRIPTION
Backend half of Paddle subscription billing, per [`todo/subscription-billing-paddle.md`](../../todo/subscription-billing-paddle.md).

Companion PRs — **merge this one first**, the frontend needs these endpoints:
- Frontend: Daniel88dev/flexi-day#54
- Emails: Daniel88dev/flexi-day-emails#29

## What changed

- **Organization layer** (migration `0012`) above `groups` as the billing owner, backfilled one org per existing group manager. Chosen over per-user or per-group billing so "who pays" is decoupled from "who manages a group".
- **`subscriptions`** — one row per org, absence means Free (the `user_settings` precedent). `manual*` columns cover grandfathering, comped accounts and Enterprise Custom without a future migration.
- **`resolveEntitlements`** — pure, no DB, exhaustively unit-tested. Grace expiry is derived at read time; there is deliberately no cron sweep.
- **402 guards** on group creation, invites, invite redemption, vacation create/approve/reject/cancel/comment, quota writes and group settings. `publicContext: { reason, limit, current }` lets the frontend render the right prompt.
- **Paddle**: five `/api/billing/*` routes plus the webhook.
- **`DELETE /api/group-user/:groupId/:userId`** — did not exist; it is how a downgraded owner gets back under a limit, so it is deliberately not gated on writability.
- **Terraform** — API key and webhook secret via Secrets Manager, opt-in and plan-time validated.

## Review findings fixed

Three review rounds; two blockers were in my own earlier fixes.

- Webhook committed the idempotency row before processing, so any failure dropped the event permanently. Record + process now share one transaction.
- `upsertSubscription` was missing its `tx`, escaping that transaction and checking out a second pooled connection.
- `getGroup` in the redemption transaction did the same — at concurrency ≥ pool size (10) that wedges the pool permanently.
- Concurrent group creation and invite issuing could both pass the same `count(*)`; both now row-lock the organization first, always before `invite_link`, so invite-resend and invite-redemption share one lock order (they deadlocked otherwise).
- Read-only enforcement was missing on group settings, mirrors and comments; `groups.organization_id` and `subscriptions.paddle_subscription_id` had no index; 402 was undocumented in the OpenAPI blocks.

## Verified

`npm test` 410 passing · `npm run test:e2e` 102 passing · `npm run lint` 0 errors · `npm run build` clean · `terraform validate` + `fmt` clean.

Browser-verified against the running stack: grace banner, read-only banner, group cap, member cap, member removal (4→3 with the plan meter updating), all requests 200/204.

## Reproduce

```bash
npm run db:up && npm run db:migrate && npm run dev:be
npm run dev:scenario
curl -X POST localhost:8080/api/dev/billing/set-plan -H "x-dev-token: $DEV_TOOLS_TOKEN" \
  -H "Content-Type: application/json" -d '{"email":"owner@dev.local","state":"GRACE"}'
```

States: `FREE | PRO | ENTERPRISE | CUSTOM | GRACE | EXPIRED | CLEAR`.

## Deploying

No grandfathering migration is needed: there are no production accounts yet beyond the owner's own
test data (2 groups, 2 users), which sits inside the Free limits of 3 groups / 10 people per group.
Enforcement is therefore a no-op on the existing data, and every future signup starts on Free by
design.

Without `PADDLE_API_KEY` set, the integration stays dormant and degrades cleanly:
`GET /api/billing/subscription` reads only the database and still renders the billing page, while
checkout / portal / slots / change-plan return 503 and the frontend disables Subscribe.

Still outstanding before charging real money: Paddle production account verification, the six
production price IDs, and the webhook destination. Separately, there is no manager-transfer route,
so a group manager cannot be removed from their own group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription billing with plan selection, checkout, customer portal access, plan changes, and extra-slot management.
  * Added subscription and usage details, plan entitlements, member/group limits, and grace-period handling.
  * Added organization support and automatic organization setup for existing and new groups.
  * Added member removal with approval-assignment safeguards.
* **Bug Fixes**
  * Prevented changes to read-only groups and enforced plan limits across groups, members, quotas, invitations, and vacation actions.
  * Improved concurrent invitation and membership handling.
* **Documentation**
  * Expanded billing, plan-limit, and read-only response documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
