### PR TITLE
feat: delegated organization admins over an org's groups

### DIFF
--- a/src/controllers/billing/tests/guardWiring.test.ts
+++ b/src/controllers/billing/tests/guardWiring.test.ts
@@ -77,6 +77,23 @@ vi.mock("../../../db/db.js", () => ({
   db: { transaction: (cb: (tx: unknown) => unknown) => cb({}) },
 }));
 
+// `assertGroupAdmin` reaches for the service modules directly rather than
+// through createDBServices, so both routes must resolve to the same mock.
+vi.mock("../../../services/groupUser/groupUserServices.js", () => ({
+  getGroupUser: services.getGroupUser,
+  getAdminGroupIdsForUser: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../services/group/groupServices.js", () => ({
+  getGroup: vi.fn().mockResolvedValue({ id: "group", organizationId: "org" }),
+  getLiveGroupIdsForOrganizations: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../services/organization/organizationServices.js", () => ({
+  isOrganizationAdmin: vi.fn().mockResolvedValue(false),
+  getAdminOrganizationsForUser: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("../../../middleware/authSession.js", () => ({
   getAuth: () => ({
     userId: "user-1",

--- a/src/controllers/group/handleGetGroup.ts
+++ b/src/controllers/group/handleGetGroup.ts
@@ -1,0 +1,54 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { createDBServices } from "../../services/DBServices.js";
+import { getAuth } from "../../middleware/authSession.js";
+import AppError from "../../utils/appError.js";
+import { resolveGroupAccess } from "../groupUser/utils.js";
+import { resolveOrganizationBadges } from "../../services/organization/organizationBadge.js";
+
+const services = createDBServices();
+
+/**
+ * One group with the caller's effective rights over it. Unlike `GET /api/group`
+ * this reaches groups the caller only administers through the organization, so
+ * an org admin can open a team's detail screen without being a member of it —
+ * which is also why the group screens read their permissions from here rather
+ * than inferring them from the member list.
+ */
+export const handleGetGroup = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const groupId = z.uuid().parse(req.params.groupId);
+
+  const group = await services.group.getGroup(groupId);
+  if (!group) {
+    throw new AppError({
+      message: "Group not found",
+      logging: true,
+      code: 404,
+      context: { userId: auth.userId, groupId },
+    });
+  }
+
+  // Reports exactly what the mutation endpoints will allow — the group screens
+  // drive their controls off this, so an optimistic answer here would render
+  // buttons that 403.
+  const access = await resolveGroupAccess(auth.userId, group);
+
+  if (!access.canView && !access.canAdmin) {
+    throw new AppError({
+      message: "No access for related group",
+      logging: true,
+      code: 403,
+      context: { userId: auth.userId, groupId },
+    });
+  }
+
+  const badges = await resolveOrganizationBadges([group.organizationId]);
+
+  return res.status(200).json({
+    ...group,
+    organization: badges.get(group.organizationId) ?? null,
+    access,
+  });
+};

--- a/src/controllers/group/handleGetGroupMirrors.ts
+++ b/src/controllers/group/handleGetGroupMirrors.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
+import { getAdministrableGroupIds, resolveGroupAdmin } from "../groupUser/utils.js";
 import AppError from "../../utils/appError.js";
 import { buildUserSummary } from "../../utils/userPresentation.js";
 import type { MirrorCandidate, MirrorMember } from "../../services/groupMirror/types.js";
@@ -17,8 +18,12 @@ export const handleGetGroupMirrors = async (req: Request, res: Response) => {
 
   const groupId = z.uuid().parse(req.params.groupId);
 
+  const { canAdmin } = await resolveGroupAdmin(auth.userId, groupId);
   const membership = await services.groupUser.getGroupUser(auth.userId, groupId);
-  if (!membership) {
+
+  // An org admin has no membership here, so admin rights are checked first —
+  // the self view below only makes sense for someone who is actually a member.
+  if (!canAdmin && !membership) {
     throw new AppError({
       message: "No access for related group",
       logging: true,
@@ -27,7 +32,7 @@ export const handleGetGroupMirrors = async (req: Request, res: Response) => {
     });
   }
 
-  if (!membership.adminAccess) {
+  if (!canAdmin) {
     const mirrors = await services.groupMirror.getMirrorsIntoGroupForUser(auth.userId, groupId);
     const self: MirrorMember = {
       userId: auth.userId,
@@ -46,9 +51,21 @@ export const handleGetGroupMirrors = async (req: Request, res: Response) => {
   const members = await services.groupUser.getGroupUsers(groupId);
   const memberIds = members.map((member) => member.userId);
 
-  const adminGroupIds = (await services.groupUser.getAdminGroupIdsForUser(auth.userId)).filter(
-    (id) => id !== groupId
-  );
+  const group = await services.group.getGroup(groupId);
+  if (!group) {
+    throw new AppError({
+      message: "Group not found",
+      logging: true,
+      code: 404,
+      context: { url: req.url, userId: auth.userId, groupId },
+    });
+  }
+
+  // Same organization scope the write path enforces, so the picker never
+  // offers a source the PUT would reject.
+  const adminGroupIds = (
+    await getAdministrableGroupIds(auth.userId, { organizationId: group.organizationId })
+  ).filter((id) => id !== groupId);
 
   const [sourceGroups, membershipPairs, mirrorPairs] = await Promise.all([
     services.group.getAllGroups(adminGroupIds),

--- a/src/controllers/group/handleGetGroups.ts
+++ b/src/controllers/group/handleGetGroups.ts
@@ -1,9 +1,17 @@
 import { createDBServices } from "../../services/DBServices.js";
 import type { Request, Response } from "express";
 import { getAuth } from "../../middleware/authSession.js";
+import { resolveOrganizationBadges } from "../../services/organization/organizationBadge.js";
 
 const services = createDBServices();
 
+/**
+ * The caller's own groups — the ones they book leave in. Deliberately
+ * membership-only: this list also drives the dashboard, the calendar and the
+ * request dialog, so groups the caller merely administers through their
+ * organization must not appear here. Those are reached from
+ * `/api/organization`.
+ */
 export const handleGetGroups = async (req: Request, res: Response) => {
   const auth = getAuth(req);
 
@@ -13,5 +21,11 @@ export const handleGetGroups = async (req: Request, res: Response) => {
 
   const result = await services.group.getAllGroups(groups);
 
-  return res.status(200).json(result);
+  const badges = await resolveOrganizationBadges(result.map((group) => group.organizationId));
+
+  return res
+    .status(200)
+    .json(
+      result.map((group) => ({ ...group, organization: badges.get(group.organizationId) ?? null }))
+    );
 };

--- a/src/controllers/group/handlePutGroupApprovers.ts
+++ b/src/controllers/group/handlePutGroupApprovers.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
 import { getAuth } from "../../middleware/authSession.js";
+import { resolveGroupAdmin } from "../groupUser/utils.js";
 import type { ValidatedPutGroupApproversType } from "../../services/group/types.js";
 import AppError from "../../utils/appError.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
@@ -19,9 +20,8 @@ export const handlePutGroupApprovers = async (req: Request, res: Response) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const data: ValidatedPutGroupApproversType = req.body;
 
-  const access = await services.groupUser.getGroupUser(auth.userId, groupId);
-
-  if (!access || !access.adminAccess) {
+  const { canAdmin, viaOrgAdmin } = await resolveGroupAdmin(auth.userId, groupId);
+  if (!canAdmin) {
     throw new AppError({
       message: "No permission for related group",
       logging: true,
@@ -35,6 +35,19 @@ export const handlePutGroupApprovers = async (req: Request, res: Response) => {
   const candidates = [data.mainApprovalUser, data.tempApprovalUser].filter(
     (id): id is string => id !== null
   );
+
+  // These columns *are* approval authority, so naming yourself here is the
+  // same escalation `handleUpdateGroupUsers` blocks on `approverAccess`. A
+  // group's own admin may still do it — a manager approving their team is the
+  // normal case — but authority borrowed from the organization may not.
+  if (viaOrgAdmin && candidates.includes(auth.userId)) {
+    throw new AppError({
+      message: "An organization admin cannot make themselves an approver of this group",
+      logging: true,
+      code: 403,
+      context: { url: req.url, user: auth.userId, groupId },
+    });
+  }
   for (const candidate of candidates) {
     const membership = await services.groupUser.getGroupUser(candidate, groupId);
     if (!membership) {

--- a/src/controllers/group/handlePutGroupApprovers.ts
+++ b/src/controllers/group/handlePutGroupApprovers.ts
@@ -36,18 +36,30 @@ export const handlePutGroupApprovers = async (req: Request, res: Response) => {
     (id): id is string => id !== null
   );
 
-  // These columns *are* approval authority, so naming yourself here is the
-  // same escalation `handleUpdateGroupUsers` blocks on `approverAccess`. A
-  // group's own admin may still do it — a manager approving their team is the
-  // normal case — but authority borrowed from the organization may not.
-  if (viaOrgAdmin && candidates.includes(auth.userId)) {
-    throw new AppError({
-      message: "An organization admin cannot make themselves an approver of this group",
-      logging: true,
-      code: 403,
-      context: { url: req.url, user: auth.userId, groupId },
-    });
+  // These columns *are* approval authority, so writing them is the same
+  // escalation `handleUpdateGroupUsers` blocks on `approverAccess`. A group's
+  // own admin may still do it — a manager naming their team's approver is the
+  // normal case — but authority borrowed from the organization may not add an
+  // approver at all: blocking only `auth.userId` would leave a delegate free
+  // to name a second account of their own instead. Keeping the existing
+  // approvers, or removing one, stays allowed.
+  if (viaOrgAdmin) {
+    const group = await services.group.getGroup(groupId);
+    const existing = new Set(
+      [group?.mainApprovalUser, group?.tempApprovalUser].filter((id): id is string => id != null)
+    );
+    const added = candidates.filter((candidate) => !existing.has(candidate));
+
+    if (added.length > 0) {
+      throw new AppError({
+        message: "An organization admin cannot add an approver to this group",
+        logging: true,
+        code: 403,
+        context: { url: req.url, user: auth.userId, groupId, added },
+      });
+    }
   }
+
   for (const candidate of candidates) {
     const membership = await services.groupUser.getGroupUser(candidate, groupId);
     if (!membership) {

--- a/src/controllers/group/handlePutGroupMirrors.ts
+++ b/src/controllers/group/handlePutGroupMirrors.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
+import { assertGroupAdmin, getAdministrableGroupIds } from "../groupUser/utils.js";
 import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";
 import type { ValidatedPutGroupMirrorsType } from "../../services/groupMirror/types.js";
@@ -31,17 +32,19 @@ export const handlePutGroupMirrors = async (req: Request, res: Response) => {
     });
   }
 
-  const access = await services.groupUser.getGroupUser(auth.userId, targetGroupId);
-  if (!access?.adminAccess) {
+  await assertGroupAdmin(auth.userId, targetGroupId);
+
+  await assertGroupWritable(targetGroupId);
+
+  const targetGroup = await services.group.getGroup(targetGroupId);
+  if (!targetGroup) {
     throw new AppError({
-      message: "No permission for related group",
+      message: "Group not found",
       logging: true,
-      code: 403,
+      code: 404,
       context: { url: req.url, userId: auth.userId, targetGroupId },
     });
   }
-
-  await assertGroupWritable(targetGroupId);
 
   const targetMembership = await services.groupUser.getGroupUser(data.userId, targetGroupId);
   if (!targetMembership) {
@@ -53,9 +56,11 @@ export const handlePutGroupMirrors = async (req: Request, res: Response) => {
     });
   }
 
-  const adminGroupIds = (await services.groupUser.getAdminGroupIdsForUser(auth.userId)).filter(
-    (id) => id !== targetGroupId
-  );
+  // Scoped to the target's organization: mirroring must never carry one
+  // organization's leave into another's group.
+  const adminGroupIds = (
+    await getAdministrableGroupIds(auth.userId, { organizationId: targetGroup.organizationId })
+  ).filter((id) => id !== targetGroupId);
   const adminOf = new Set(adminGroupIds);
 
   const notAdminOf = data.sourceGroupIds.filter((id) => !adminOf.has(id));

--- a/src/controllers/group/handlePutGroupQuotas.ts
+++ b/src/controllers/group/handlePutGroupQuotas.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
 import { getAuth } from "../../middleware/authSession.js";
+import { assertGroupAdmin } from "../groupUser/utils.js";
 import type { ValidatedPutGroupQuotasType } from "../../services/group/types.js";
 import AppError from "../../utils/appError.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
@@ -23,16 +24,7 @@ export const handlePutGroupQuotas = async (req: Request, res: Response) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const data: ValidatedPutGroupQuotasType = req.body;
 
-  const access = await services.groupUser.getGroupUser(auth.userId, groupId);
-
-  if (!access || !access.adminAccess) {
-    throw new AppError({
-      message: "No permission for related group",
-      logging: true,
-      code: 403,
-      context: { url: req.url, user: auth.userId, groupId },
-    });
-  }
+  await assertGroupAdmin(auth.userId, groupId);
 
   await assertGroupWritable(groupId);
 

--- a/src/controllers/group/handlePutGroupWorkingDays.ts
+++ b/src/controllers/group/handlePutGroupWorkingDays.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
 import { getAuth } from "../../middleware/authSession.js";
+import { assertGroupAdmin } from "../groupUser/utils.js";
 import type { ValidatedPutGroupWorkingDaysType } from "../../services/group/types.js";
 import AppError from "../../utils/appError.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
@@ -21,16 +22,7 @@ export const handlePutGroupWorkingDays = async (req: Request, res: Response) => 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const data: ValidatedPutGroupWorkingDaysType = req.body;
 
-  const access = await services.groupUser.getGroupUser(auth.userId, groupId);
-
-  if (!access || !access.adminAccess) {
-    throw new AppError({
-      message: "No permission for related group",
-      logging: true,
-      code: 403,
-      context: { url: req.url, user: auth.userId, groupId },
-    });
-  }
+  await assertGroupAdmin(auth.userId, groupId);
 
   await assertGroupWritable(groupId);
 

--- a/src/controllers/group/tests/handleGetGroup.test.ts
+++ b/src/controllers/group/tests/handleGetGroup.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockGetGroup, mockGetGroupUser, mockIsOrganizationAdmin, mockResolveOrganizationBadges } =
+  vi.hoisted(() => ({
+    mockGetGroup: vi.fn(),
+    mockGetGroupUser: vi.fn(),
+    mockIsOrganizationAdmin: vi.fn(),
+    mockResolveOrganizationBadges: vi.fn(),
+  }));
+
+vi.mock("../../../middleware/authSession.js", () => ({ getAuth: vi.fn() }));
+
+// The access helpers reach for the service modules directly rather than through
+// createDBServices, so both routes must resolve to the same mocks.
+vi.mock("../../../services/groupUser/groupUserServices.js", () => ({
+  getGroupUser: mockGetGroupUser,
+  getAdminGroupIdsForUser: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../services/group/groupServices.js", () => ({
+  getGroup: mockGetGroup,
+  getLiveGroupIdsForOrganizations: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../services/organization/organizationServices.js", () => ({
+  isOrganizationAdmin: mockIsOrganizationAdmin,
+  getAdminOrganizationsForUser: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../services/organization/organizationBadge.js", () => ({
+  resolveOrganizationBadges: mockResolveOrganizationBadges,
+}));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    group: { getGroup: mockGetGroup },
+    groupUser: { getGroupUser: mockGetGroupUser },
+  }),
+}));
+
+import { handleGetGroup } from "../handleGetGroup.js";
+import { getAuth } from "../../../middleware/authSession.js";
+import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
+
+const groupId = "550e8400-e29b-41d4-a716-446655440000";
+
+const group = {
+  id: groupId,
+  organizationId: "org-1",
+  groupName: "Engineering",
+  managerUserId: "manager_1",
+};
+
+const badge = { id: "org-1", name: "Acme", plan: "PRO", status: "active", active: true };
+
+describe("handleGetGroup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getAuth).mockReturnValue(mockAuthData);
+    mockGetGroup.mockResolvedValue(group);
+    mockIsOrganizationAdmin.mockResolvedValue(false);
+    mockResolveOrganizationBadges.mockResolvedValue(new Map([["org-1", badge]]));
+  });
+
+  const call = async () => {
+    const { req, res } = makeReqRes({ params: { groupId } });
+    await handleGetGroup(req, res);
+    return vi.mocked(res.json).mock.calls[0]?.[0] as {
+      organization: unknown;
+      access: { canView: boolean; canAdmin: boolean; viaOrgAdmin: boolean; isMember: boolean };
+    };
+  };
+
+  it("404s for a group that does not exist", async () => {
+    mockGetGroup.mockResolvedValue(undefined);
+    const { req, res } = makeReqRes({ params: { groupId } });
+
+    await expect(handleGetGroup(req, res)).rejects.toThrow("Group not found");
+  });
+
+  it("403s for someone with neither membership nor organization rights", async () => {
+    mockGetGroupUser.mockResolvedValue(undefined);
+    const { req, res } = makeReqRes({ params: { groupId } });
+
+    await expect(handleGetGroup(req, res)).rejects.toThrow("No access for related group");
+  });
+
+  it("reports a plain member as a viewer, not an admin", async () => {
+    mockGetGroupUser.mockResolvedValue({ viewAccess: true, adminAccess: false });
+
+    expect((await call()).access).toEqual({
+      canView: true,
+      canAdmin: false,
+      viaOrgAdmin: false,
+      isMember: true,
+    });
+  });
+
+  it("reports a group admin's rights as their own, not the organization's", async () => {
+    mockGetGroupUser.mockResolvedValue({ viewAccess: true, adminAccess: true });
+
+    expect((await call()).access).toEqual({
+      canView: true,
+      canAdmin: true,
+      viaOrgAdmin: false,
+      isMember: true,
+    });
+  });
+
+  it("lets an org admin in without a membership, flagged as org authority", async () => {
+    mockGetGroupUser.mockResolvedValue(undefined);
+    mockIsOrganizationAdmin.mockResolvedValue(true);
+
+    expect((await call()).access).toEqual({
+      canView: true,
+      canAdmin: true,
+      viaOrgAdmin: true,
+      isMember: false,
+    });
+  });
+
+  it("carries the organization badge", async () => {
+    mockGetGroupUser.mockResolvedValue({ viewAccess: true, adminAccess: false });
+
+    expect((await call()).organization).toEqual(badge);
+  });
+});

--- a/src/controllers/group/tests/handleGroupMirrors.test.ts
+++ b/src/controllers/group/tests/handleGroupMirrors.test.ts
@@ -9,6 +9,7 @@ vi.mock("../../../services/billing/guards.js", () => ({
 }));
 
 const {
+  mockGetGroup,
   mockGetGroupUser,
   mockGetGroupUsers,
   mockGetAdminGroupIdsForUser,
@@ -18,6 +19,7 @@ const {
   mockGetMirrorsIntoGroupForUsers,
   mockSetMirrorsIntoGroupForUser,
 } = vi.hoisted(() => ({
+  mockGetGroup: vi.fn(),
   mockGetGroupUser: vi.fn(),
   mockGetGroupUsers: vi.fn(),
   mockGetAdminGroupIdsForUser: vi.fn(),
@@ -34,6 +36,27 @@ vi.mock("../../../db/db.js", () => ({
   db: { transaction: vi.fn((callback) => callback({})) },
 }));
 
+// The group-access helpers reach for the service modules directly rather than
+// through createDBServices, so both routes must resolve to the same mocks.
+// Org-admin access is off here; it has its own suite.
+vi.mock("../../../services/groupUser/groupUserServices.js", () => ({
+  getGroupUser: mockGetGroupUser,
+  getAdminGroupIdsForUser: mockGetAdminGroupIdsForUser,
+}));
+
+vi.mock("../../../services/group/groupServices.js", () => ({
+  getGroup: mockGetGroup,
+  getLiveGroupIdsForOrganizations: vi.fn().mockResolvedValue([]),
+  // With no org-admin groups in play, the organization scope is a pass-through
+  // over the caller's membership-derived admin groups.
+  filterGroupIdsByOrganization: vi.fn((groupIds: string[]) => Promise.resolve(groupIds)),
+}));
+
+vi.mock("../../../services/organization/organizationServices.js", () => ({
+  isOrganizationAdmin: vi.fn().mockResolvedValue(false),
+  getAdminOrganizationsForUser: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("../../../services/DBServices.js", () => ({
   createDBServices: () => ({
     groupUser: {
@@ -42,7 +65,7 @@ vi.mock("../../../services/DBServices.js", () => ({
       getAdminGroupIdsForUser: mockGetAdminGroupIdsForUser,
       getMembershipPairs: mockGetMembershipPairs,
     },
-    group: { getAllGroups: mockGetAllGroups },
+    group: { getAllGroups: mockGetAllGroups, getGroup: mockGetGroup },
     groupMirror: {
       getMirrorsIntoGroupForUser: mockGetMirrorsIntoGroupForUser,
       getMirrorsIntoGroupForUsers: mockGetMirrorsIntoGroupForUsers,
@@ -74,6 +97,7 @@ describe("handleGetGroupMirrors", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
+    mockGetGroup.mockResolvedValue({ id: TARGET, organizationId: "org-1" });
     mockGetGroupUser.mockResolvedValue({ viewAccess: true, adminAccess: true });
     mockGetGroupUsers.mockResolvedValue([memberRow(MEMBER, "Ada Byron")]);
     mockGetAdminGroupIdsForUser.mockResolvedValue([TARGET, SOURCE_A, SOURCE_B]);

--- a/src/controllers/groupUser/handleDeleteGroupUser.ts
+++ b/src/controllers/groupUser/handleDeleteGroupUser.ts
@@ -52,6 +52,12 @@ export const handleDeleteGroupUser = async (req: Request, res: Response) => {
   }
 
   const removed = await db.transaction(async (tx) => {
+    // Organization first, then group — the order every other path takes (see
+    // `handlePostGroupInvite`). Reversing it deadlocks against any FK-checked
+    // write to `group_users`, which holds the organization lock and then needs
+    // a key-share lock on the group.
+    await services.organization.lockOrganization(group.organizationId, tx);
+
     // Re-read the group under a row lock: the approver columns below are
     // rewritten from the values read here, and the copy fetched before the
     // transaction can already be stale if another admin reassigned approvers.
@@ -84,6 +90,24 @@ export const handleDeleteGroupUser = async (req: Request, res: Response) => {
         locked.tempApprovalUser === userId ? null : locked.tempApprovalUser,
         tx
       );
+    }
+
+    // Same reasoning one level up: an org-admin grant is only ever issued to
+    // one of the organization's own people, so leaving the last of its groups
+    // must end it too. Otherwise someone removed from the company keeps
+    // administering every group in it until the owner notices.
+    //
+    // The count spans the whole organization, which is why the lock taken at
+    // the top of this transaction has to be the organization's: two removals
+    // from different groups would otherwise each see the other's membership as
+    // live and neither would revoke.
+    const remaining = await services.groupUser.countActiveMembershipsInOrganization(
+      userId,
+      locked.organizationId,
+      tx
+    );
+    if (remaining === 0) {
+      await services.organization.removeOrganizationAdmin(locked.organizationId, userId, tx);
     }
 
     return row;

--- a/src/controllers/groupUser/handleUpdateGroupUsers.ts
+++ b/src/controllers/groupUser/handleUpdateGroupUsers.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from "express";
 import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
 import type { ValidatedPutGroupUserUpdateType } from "../../services/groupUser/types.js";
+import { resolveGroupAdmin } from "./utils.js";
 import AppError from "../../utils/appError.js";
 import { logger } from "../../middleware/logger.js";
 import { db } from "../../db/db.js";
@@ -14,15 +15,60 @@ export const handleUpdateGroupUsers = async (req: Request, res: Response) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const data: ValidatedPutGroupUserUpdateType = req.body;
 
-  const access = await services.groupUser.getGroupUser(auth.userId, data.groupId);
-
-  if (!access || !access.adminAccess) {
+  const { canAdmin, viaOrgAdmin } = await resolveGroupAdmin(auth.userId, data.groupId);
+  if (!canAdmin) {
     throw new AppError({
       message: "No permission for related group",
       logging: true,
       code: 403,
-      context: { url: req.url, user: auth.userId, data: data },
+      context: { url: req.url, user: auth.userId, groupId: data.groupId },
     });
+  }
+
+  // Authority borrowed from the organization administers a group; it never
+  // creates approval authority in one — not for the caller, and not for anyone
+  // else either, or a delegate would route around the self-check below by
+  // inviting a second account of their own and promoting that. Clearing
+  // `approverAccess` stays allowed: taking rights away is always safe.
+  if (viaOrgAdmin) {
+    const current = await services.groupUser.getGroupUsers(data.groupId);
+    const approverBefore = new Map(current.map((row) => [row.userId, row.approverAccess]));
+    const grantsApprover = data.data.some(
+      (record) => record.approverAccess && !approverBefore.get(record.userId)
+    );
+
+    if (grantsApprover) {
+      throw new AppError({
+        message: "An organization admin cannot grant approver rights in this group",
+        logging: true,
+        code: 403,
+        context: { url: req.url, user: auth.userId, groupId: data.groupId },
+      });
+    }
+  }
+
+  // Nobody may raise their own permissions, only keep or lower them. Every
+  // record for the caller, not just the first: the loop below applies them all
+  // in order, so a duplicated entry would otherwise let a harmless first
+  // record pass the check while a later one does the raising.
+  const selfRecords = data.data.filter((record) => record.userId === auth.userId);
+  if (selfRecords.length > 0) {
+    const current = await services.groupUser.getGroupUser(auth.userId, data.groupId);
+    const raises = selfRecords.some(
+      (self) =>
+        (self.viewAccess && !current?.viewAccess) ||
+        (self.adminAccess && !current?.adminAccess) ||
+        (self.approverAccess && !current?.approverAccess)
+    );
+
+    if (raises) {
+      throw new AppError({
+        message: "You cannot raise your own permissions in a group",
+        logging: true,
+        code: 403,
+        context: { url: req.url, user: auth.userId, groupId: data.groupId },
+      });
+    }
   }
 
   await db.transaction(async (tx) => {

--- a/src/controllers/groupUser/tests/handlePostGroupInvite.test.ts
+++ b/src/controllers/groupUser/tests/handlePostGroupInvite.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Billing plan-limit guards are no-ops here; their behavior has its own suite.
+// `isOrganizationAdmin` returns false so these cases exercise membership alone
+// — org-admin access has its own suite.
 vi.mock("../../../services/organization/organizationServices.js", () => ({
   lockOrganization: vi.fn(),
+  isOrganizationAdmin: vi.fn().mockResolvedValue(false),
+  getAdminOrganizationsForUser: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("../../../services/billing/guards.js", () => ({
@@ -34,10 +38,16 @@ vi.mock("../../../db/db.js", () => ({
   db: { transaction: vi.fn((callback) => callback({})) },
 }));
 
-// `assertGroupAdmin` reaches for the service module directly rather than
+// `assertGroupAdmin` reaches for the service modules directly rather than
 // through createDBServices, so both routes must resolve to the same mock.
 vi.mock("../../../services/groupUser/groupUserServices.js", () => ({
   getGroupUser: mockGetGroupUser,
+  getAdminGroupIdsForUser: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../services/group/groupServices.js", () => ({
+  getGroup: mockGetGroup,
+  getLiveGroupIdsForOrganizations: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("../../../services/DBServices.js", () => ({
@@ -53,8 +63,9 @@ vi.mock("../../../services/DBServices.js", () => ({
 }));
 
 vi.mock("../../../services/groupUser/inviteNotifier.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../../services/groupUser/inviteNotifier.js")>();
+  const actual = await importOriginal<
+    typeof import("../../../services/groupUser/inviteNotifier.js")
+  >();
   return { ...actual, notifyGroupInvited: mockNotifyGroupInvited };
 });
 

--- a/src/controllers/groupUser/utils.ts
+++ b/src/controllers/groupUser/utils.ts
@@ -1,18 +1,129 @@
-import { getGroupUser } from "../../services/groupUser/groupUserServices.js";
+import {
+  getAdminGroupIdsForUser,
+  getGroupUser,
+} from "../../services/groupUser/groupUserServices.js";
+import {
+  filterGroupIdsByOrganization,
+  getGroup,
+  getLiveGroupIdsForOrganizations,
+} from "../../services/group/groupServices.js";
+import {
+  getAdminOrganizationsForUser,
+  isOrganizationAdmin,
+} from "../../services/organization/organizationServices.js";
+import type { DbTransaction } from "../../db/db.js";
 import AppError from "../../utils/appError.js";
+
+/**
+ * True when the caller administers the organization that owns the group.
+ *
+ * Org admins are administrators *over* an org's groups without being members
+ * of them, so this deliberately grants only administration — never approver
+ * rights (deciding someone's leave is a workflow role held through group
+ * membership) and never membership itself.
+ */
+const isOrganizationAdminForGroup = async (
+  userId: string,
+  groupId: string,
+  tx?: DbTransaction
+): Promise<boolean> => {
+  const group = await getGroup(groupId, tx);
+  if (!group) return false;
+  return isOrganizationAdmin(userId, group.organizationId, tx);
+};
 
 export const validateUserGroupAccess = async (
   userId: string,
-  groupId: string
+  groupId: string,
+  tx?: DbTransaction
 ): Promise<boolean> => {
-  const groupUser = await getGroupUser(userId, groupId);
-  return groupUser?.viewAccess ?? false;
+  const groupUser = await getGroupUser(userId, groupId, tx);
+  if (groupUser?.viewAccess) return true;
+  return isOrganizationAdminForGroup(userId, groupId, tx);
 };
 
-/** Throws 403 unless the caller's membership carries `adminAccess`. */
-export const assertGroupAdmin = async (userId: string, groupId: string): Promise<void> => {
-  const groupUser = await getGroupUser(userId, groupId);
-  if (!groupUser?.adminAccess) {
+/**
+ * Whether the caller may administer the group, and whether that authority came
+ * from the organization rather than a membership — the UI surfaces the
+ * difference so nobody edits another team believing they belong to it.
+ */
+export const resolveGroupAdmin = async (
+  userId: string,
+  groupId: string,
+  tx?: DbTransaction
+): Promise<{ canAdmin: boolean; viaOrgAdmin: boolean }> => {
+  const groupUser = await getGroupUser(userId, groupId, tx);
+  if (groupUser?.adminAccess) return { canAdmin: true, viaOrgAdmin: false };
+
+  const viaOrg = await isOrganizationAdminForGroup(userId, groupId, tx);
+  return { canAdmin: viaOrg, viaOrgAdmin: viaOrg };
+};
+
+/**
+ * The caller's whole standing in one group, resolved once. The individual
+ * helpers each re-read the membership and the group, which is fine at a single
+ * call site but wasteful for a screen that needs the full picture.
+ */
+export const resolveGroupAccess = async (
+  userId: string,
+  group: { id: string; organizationId: string },
+  tx?: DbTransaction
+): Promise<{ canView: boolean; canAdmin: boolean; viaOrgAdmin: boolean; isMember: boolean }> => {
+  const membership = await getGroupUser(userId, group.id, tx);
+  if (membership?.adminAccess) {
+    return { canView: true, canAdmin: true, viaOrgAdmin: false, isMember: true };
+  }
+
+  const viaOrgAdmin = await isOrganizationAdmin(userId, group.organizationId, tx);
+
+  return {
+    canView: viaOrgAdmin || (membership?.viewAccess ?? false),
+    canAdmin: viaOrgAdmin,
+    viaOrgAdmin,
+    isMember: membership !== undefined,
+  };
+};
+
+/**
+ * Every group the caller may administer: those their membership grants, plus
+ * every live group of an organization they administer.
+ *
+ * `organizationId` confines the result to one organization. Mirroring passes
+ * it: a user who owns one organization and holds a delegated grant in another
+ * administers groups in both, and without the scope they could project a
+ * second organization's leave into their own group.
+ */
+export const getAdministrableGroupIds = async (
+  userId: string,
+  options?: { organizationId?: string },
+  tx?: DbTransaction
+): Promise<string[]> => {
+  const organizations = await getAdminOrganizationsForUser(userId, tx);
+  const scoped = options?.organizationId
+    ? organizations.filter((organization) => organization.id === options.organizationId)
+    : organizations;
+
+  const fromOrganizations = await getLiveGroupIdsForOrganizations(
+    scoped.map((organization) => organization.id),
+    tx
+  );
+
+  const fromMembership = await getAdminGroupIdsForUser(userId, tx);
+  const membershipScoped = options?.organizationId
+    ? await filterGroupIdsByOrganization(fromMembership, options.organizationId, tx)
+    : fromMembership;
+
+  return [...new Set([...membershipScoped, ...fromOrganizations])];
+};
+
+/** Throws 403 unless the caller's membership carries `adminAccess`, or they administer the group's organization. */
+export const assertGroupAdmin = async (
+  userId: string,
+  groupId: string,
+  tx?: DbTransaction
+): Promise<void> => {
+  const { canAdmin } = await resolveGroupAdmin(userId, groupId, tx);
+  if (!canAdmin) {
     throw new AppError({
       message: "No permission for related group",
       logging: true,

--- a/src/controllers/organization/handleDeleteOrganizationAdmin.ts
+++ b/src/controllers/organization/handleDeleteOrganizationAdmin.ts
@@ -1,0 +1,33 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { createDBServices } from "../../services/DBServices.js";
+import { getAuth } from "../../middleware/authSession.js";
+import AppError from "../../utils/appError.js";
+import { assertOrganizationOwner, resolveAdministeredOrganization } from "./utils.js";
+
+const services = createDBServices();
+
+/** Revokes an org admin grant. Owner-only, and the owner's own rights cannot be revoked. */
+export const handleDeleteOrganizationAdmin = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const userId = z.string().min(1).parse(req.params.userId);
+
+  const { organization } = await resolveAdministeredOrganization(req);
+  assertOrganizationOwner(organization, auth.userId);
+
+  const removed = await services.organization.removeOrganizationAdmin(organization.id, userId);
+
+  if (!removed) {
+    throw new AppError({
+      message: "This user is not an administrator of this organization",
+      logging: true,
+      code: 404,
+      context: { userId: auth.userId, organizationId: organization.id, target: userId },
+    });
+  }
+
+  const admins = await services.organization.listOrganizationAdmins(organization.id);
+
+  return res.status(200).json(admins);
+};

--- a/src/controllers/organization/handleGetOrganization.ts
+++ b/src/controllers/organization/handleGetOrganization.ts
@@ -1,0 +1,52 @@
+import type { Request, Response } from "express";
+import { createDBServices } from "../../services/DBServices.js";
+import { getAuth } from "../../middleware/authSession.js";
+import { resolveEntitlements } from "../../services/billing/entitlements.js";
+import { resolveAdministeredOrganization } from "./utils.js";
+
+const services = createDBServices();
+
+/**
+ * The organization management screen: identity, the plan it runs on, its
+ * groups and its administrators.
+ *
+ * Delegated admins see the plan but not the money — `billingEmail` and the
+ * Paddle linkage stay owner-only, and subscription detail beyond plan/status
+ * lives on `/api/billing/subscription`, which resolves by ownership.
+ */
+export const handleGetOrganization = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const { organization, isOwner } = await resolveAdministeredOrganization(req);
+
+  const subscription = await services.billing.getSubscriptionForOrganization(organization.id);
+  const entitlements = resolveEntitlements(subscription ?? null, new Date());
+  const groups = await services.group.getGroupUsageForOrganization(organization.id);
+  const admins = await services.organization.listOrganizationAdmins(organization.id);
+
+  return res.status(200).json({
+    organization: {
+      id: organization.id,
+      name: organization.name,
+      isOwner,
+      billingEmail: isOwner ? organization.billingEmail : null,
+      createdAt: organization.createdAt,
+    },
+    plan: {
+      plan: entitlements.plan,
+      status: subscription?.status ?? null,
+      writable: entitlements.writable,
+      graceEndsAt: entitlements.graceEndsAt,
+      maxGroups: entitlements.maxGroups,
+      maxMembersPerGroup: entitlements.maxMembersPerGroup,
+    },
+    groups: groups.map((group) => ({
+      id: group.id,
+      groupName: group.groupName,
+      members: group.members,
+      createdAt: group.createdAt,
+    })),
+    admins,
+    viewer: { userId: auth.userId },
+  });
+};

--- a/src/controllers/organization/handleGetOrganizationCandidates.ts
+++ b/src/controllers/organization/handleGetOrganizationCandidates.ts
@@ -1,0 +1,22 @@
+import type { Request, Response } from "express";
+import { createDBServices } from "../../services/DBServices.js";
+import { getAuth } from "../../middleware/authSession.js";
+import { assertOrganizationOwner, resolveAdministeredOrganization } from "./utils.js";
+
+const services = createDBServices();
+
+/**
+ * Who may be promoted to organization admin: the members of the org's own
+ * groups, minus its existing admins. Deliberately not a lookup by email —
+ * that would let an owner probe whether any address has an account.
+ */
+export const handleGetOrganizationCandidates = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const { organization } = await resolveAdministeredOrganization(req);
+  assertOrganizationOwner(organization, auth.userId);
+
+  const candidates = await services.organization.listOrganizationAdminCandidates(organization.id);
+
+  return res.status(200).json(candidates);
+};

--- a/src/controllers/organization/handleGetOrganizations.ts
+++ b/src/controllers/organization/handleGetOrganizations.ts
@@ -1,0 +1,23 @@
+import type { Request, Response } from "express";
+import { createDBServices } from "../../services/DBServices.js";
+import { getAuth } from "../../middleware/authSession.js";
+
+const services = createDBServices();
+
+/**
+ * The organizations the caller owns or administers — owned first. Drives the
+ * organization page's switcher for anyone who administers more than one.
+ */
+export const handleGetOrganizations = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const organizations = await services.organization.getAdminOrganizationsForUser(auth.userId);
+
+  return res.status(200).json(
+    organizations.map((organization) => ({
+      id: organization.id,
+      name: organization.name,
+      isOwner: organization.ownerUserId === auth.userId,
+    }))
+  );
+};

--- a/src/controllers/organization/handlePatchOrganization.ts
+++ b/src/controllers/organization/handlePatchOrganization.ts
@@ -1,0 +1,49 @@
+import type { Request, Response } from "express";
+import { createDBServices } from "../../services/DBServices.js";
+import { getAuth } from "../../middleware/authSession.js";
+import AppError from "../../utils/appError.js";
+import type { ValidatedPatchOrganizationType } from "../../services/organization/types.js";
+import { assertOrganizationOwner, resolveAdministeredOrganization } from "./utils.js";
+
+const services = createDBServices();
+
+/**
+ * Renames the organization, or repoints the billing address. The name is
+ * editable by any org admin; `billingEmail` is owner-only — it is where the
+ * subscription grace warnings go.
+ */
+export const handlePatchOrganization = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data: ValidatedPatchOrganizationType = req.body;
+
+  const { organization } = await resolveAdministeredOrganization(req);
+
+  if (data.billingEmail !== undefined) {
+    assertOrganizationOwner(organization, auth.userId);
+  }
+
+  const updated = await services.organization.updateOrganization(organization.id, {
+    ...(data.name !== undefined ? { name: data.name } : {}),
+    ...(data.billingEmail !== undefined ? { billingEmail: data.billingEmail } : {}),
+  });
+
+  if (!updated) {
+    throw new AppError({
+      message: "Organization not found",
+      logging: true,
+      code: 404,
+      context: { userId: auth.userId, organizationId: organization.id },
+    });
+  }
+
+  const isOwner = updated.ownerUserId === auth.userId;
+
+  return res.status(200).json({
+    id: updated.id,
+    name: updated.name,
+    isOwner,
+    billingEmail: isOwner ? updated.billingEmail : null,
+  });
+};

--- a/src/controllers/organization/handlePostOrganizationAdmin.ts
+++ b/src/controllers/organization/handlePostOrganizationAdmin.ts
@@ -1,0 +1,52 @@
+import type { Request, Response } from "express";
+import { createDBServices } from "../../services/DBServices.js";
+import { getAuth } from "../../middleware/authSession.js";
+import AppError from "../../utils/appError.js";
+import type { ValidatedPostOrganizationAdminType } from "../../services/organization/types.js";
+import { assertOrganizationOwner, resolveAdministeredOrganization } from "./utils.js";
+
+const services = createDBServices();
+
+/**
+ * Promotes one of the organization's own people to org admin. Owner-only:
+ * an admin who could appoint further admins would make the grant
+ * self-propagating, and revoking the first one would no longer undo it.
+ */
+export const handlePostOrganizationAdmin = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data: ValidatedPostOrganizationAdminType = req.body;
+
+  const { organization } = await resolveAdministeredOrganization(req);
+  assertOrganizationOwner(organization, auth.userId);
+
+  // The candidate list is the authorization boundary, not just the UI's menu:
+  // it is what confines a grant to people already inside the organization.
+  const candidates = await services.organization.listOrganizationAdminCandidates(organization.id);
+  if (!candidates.some((candidate) => candidate.userId === data.userId)) {
+    throw new AppError({
+      message: "This user is not a member of any group in this organization",
+      logging: true,
+      code: 422,
+      context: { userId: auth.userId, organizationId: organization.id, target: data.userId },
+    });
+  }
+
+  await services.organization.grantOrganizationAdmin({
+    organizationId: organization.id,
+    userId: data.userId,
+    grantedByUserId: auth.userId,
+    // The check above is only the fast path; this is the one that counts,
+    // because it runs under the organization lock that the revocation in
+    // `handleDeleteGroupUser` also takes.
+    assertStillEligible: (tx) =>
+      services.groupUser
+        .countActiveMembershipsInOrganization(data.userId, organization.id, tx)
+        .then((count) => count > 0),
+  });
+
+  const admins = await services.organization.listOrganizationAdmins(organization.id);
+
+  return res.status(201).json(admins);
+};

--- a/src/controllers/organization/handlePostOrganizationAdmin.ts
+++ b/src/controllers/organization/handlePostOrganizationAdmin.ts
@@ -25,6 +25,19 @@ export const handlePostOrganizationAdmin = async (req: Request, res: Response) =
   // it is what confines a grant to people already inside the organization.
   const candidates = await services.organization.listOrganizationAdminCandidates(organization.id);
   if (!candidates.some((candidate) => candidate.userId === data.userId)) {
+    // The candidate list also excludes people who already administer the org,
+    // so "not a member" would be a flatly wrong answer for them — which a
+    // client hits whenever its list is stale after a concurrent grant.
+    const admins = await services.organization.listOrganizationAdmins(organization.id);
+    if (admins.some((admin) => admin.userId === data.userId)) {
+      throw new AppError({
+        message: "This user already administers this organization",
+        logging: true,
+        code: 409,
+        context: { userId: auth.userId, organizationId: organization.id, target: data.userId },
+      });
+    }
+
     throw new AppError({
       message: "This user is not a member of any group in this organization",
       logging: true,

--- a/src/controllers/organization/tests/organizationControllers.test.ts
+++ b/src/controllers/organization/tests/organizationControllers.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockGetOrganizationById,
+  mockGetAdminOrganizationsForUser,
+  mockIsOrganizationAdmin,
+  mockUpdateOrganization,
+  mockListOrganizationAdmins,
+  mockListOrganizationAdminCandidates,
+  mockGrantOrganizationAdmin,
+  mockRemoveOrganizationAdmin,
+  mockGetSubscriptionForOrganization,
+  mockGetGroupUsageForOrganization,
+} = vi.hoisted(() => ({
+  mockGetOrganizationById: vi.fn(),
+  mockGetAdminOrganizationsForUser: vi.fn(),
+  mockIsOrganizationAdmin: vi.fn(),
+  mockUpdateOrganization: vi.fn(),
+  mockListOrganizationAdmins: vi.fn(),
+  mockListOrganizationAdminCandidates: vi.fn(),
+  mockGrantOrganizationAdmin: vi.fn(),
+  mockRemoveOrganizationAdmin: vi.fn(),
+  mockGetSubscriptionForOrganization: vi.fn(),
+  mockGetGroupUsageForOrganization: vi.fn(),
+}));
+
+vi.mock("../../../middleware/authSession.js", () => ({ getAuth: vi.fn() }));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    organization: {
+      getOrganizationById: mockGetOrganizationById,
+      getAdminOrganizationsForUser: mockGetAdminOrganizationsForUser,
+      isOrganizationAdmin: mockIsOrganizationAdmin,
+      updateOrganization: mockUpdateOrganization,
+      listOrganizationAdmins: mockListOrganizationAdmins,
+      listOrganizationAdminCandidates: mockListOrganizationAdminCandidates,
+      grantOrganizationAdmin: mockGrantOrganizationAdmin,
+      removeOrganizationAdmin: mockRemoveOrganizationAdmin,
+    },
+    groupUser: { countActiveMembershipsInOrganization: vi.fn().mockResolvedValue(1) },
+    billing: { getSubscriptionForOrganization: mockGetSubscriptionForOrganization },
+    group: { getGroupUsageForOrganization: mockGetGroupUsageForOrganization },
+  }),
+}));
+
+import { handleGetOrganization } from "../handleGetOrganization.js";
+import { handlePatchOrganization } from "../handlePatchOrganization.js";
+import { handleGetOrganizationCandidates } from "../handleGetOrganizationCandidates.js";
+import { handlePostOrganizationAdmin } from "../handlePostOrganizationAdmin.js";
+import { handleDeleteOrganizationAdmin } from "../handleDeleteOrganizationAdmin.js";
+import { getAuth } from "../../../middleware/authSession.js";
+import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
+
+const OWNER = mockAuthData.userId;
+const DELEGATE = "delegate_789";
+
+const organization = {
+  id: "org-1",
+  name: "Acme",
+  ownerUserId: OWNER,
+  billingEmail: "billing@acme.test",
+  paddleCustomerId: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+};
+
+/** The same organization seen by a delegated admin rather than its owner. */
+const foreignOrganization = { ...organization, ownerUserId: "someone_else" };
+
+describe("organization controllers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getAuth).mockReturnValue(mockAuthData);
+    mockIsOrganizationAdmin.mockResolvedValue(true);
+    mockGetAdminOrganizationsForUser.mockResolvedValue([organization]);
+    mockGetSubscriptionForOrganization.mockResolvedValue(undefined);
+    mockGetGroupUsageForOrganization.mockResolvedValue([]);
+    mockListOrganizationAdmins.mockResolvedValue([]);
+  });
+
+  describe("handleGetOrganization", () => {
+    it("returns the caller's own organization when none is named", async () => {
+      const { req, res } = makeReqRes();
+
+      await handleGetOrganization(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(vi.mocked(res.json).mock.calls[0]?.[0]).toMatchObject({
+        organization: { id: "org-1", isOwner: true, billingEmail: "billing@acme.test" },
+        plan: { plan: "FREE", status: null },
+      });
+    });
+
+    it("hides the billing address from a delegated admin", async () => {
+      mockGetAdminOrganizationsForUser.mockResolvedValue([foreignOrganization]);
+      const { req, res } = makeReqRes();
+
+      await handleGetOrganization(req, res);
+
+      expect(vi.mocked(res.json).mock.calls[0]?.[0]).toMatchObject({
+        organization: { isOwner: false, billingEmail: null },
+      });
+    });
+
+    it("403s for an organization the caller does not administer", async () => {
+      mockGetOrganizationById.mockResolvedValue(foreignOrganization);
+      mockIsOrganizationAdmin.mockResolvedValue(false);
+      const { req, res } = makeReqRes({ query: { organizationId: "org-1" } });
+
+      await expect(handleGetOrganization(req, res)).rejects.toThrow(
+        "No permission for related organization"
+      );
+    });
+
+    it("404s for a caller with no organization yet", async () => {
+      mockGetAdminOrganizationsForUser.mockResolvedValue([]);
+      const { req, res } = makeReqRes();
+
+      await expect(handleGetOrganization(req, res)).rejects.toThrow("Organization not found");
+    });
+  });
+
+  describe("handlePatchOrganization", () => {
+    it("lets any organization admin rename it", async () => {
+      mockGetAdminOrganizationsForUser.mockResolvedValue([foreignOrganization]);
+      mockUpdateOrganization.mockResolvedValue({ ...foreignOrganization, name: "Renamed" });
+      const { req, res } = makeReqRes({ body: { name: "Renamed" } });
+
+      await handlePatchOrganization(req, res);
+
+      expect(mockUpdateOrganization).toHaveBeenCalledWith("org-1", { name: "Renamed" });
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("refuses a billing address change from a delegated admin", async () => {
+      mockGetAdminOrganizationsForUser.mockResolvedValue([foreignOrganization]);
+      const { req, res } = makeReqRes({ body: { billingEmail: "new@acme.test" } });
+
+      await expect(handlePatchOrganization(req, res)).rejects.toThrow(
+        "Only the organization owner can perform this action"
+      );
+      expect(mockUpdateOrganization).not.toHaveBeenCalled();
+    });
+
+    it("lets the owner change the billing address", async () => {
+      mockUpdateOrganization.mockResolvedValue({ ...organization, billingEmail: "new@acme.test" });
+      const { req, res } = makeReqRes({ body: { billingEmail: "new@acme.test" } });
+
+      await handlePatchOrganization(req, res);
+
+      expect(mockUpdateOrganization).toHaveBeenCalledWith("org-1", {
+        billingEmail: "new@acme.test",
+      });
+    });
+  });
+
+  describe("handleGetOrganizationCandidates", () => {
+    it("is owner-only", async () => {
+      mockGetAdminOrganizationsForUser.mockResolvedValue([foreignOrganization]);
+      const { req, res } = makeReqRes();
+
+      await expect(handleGetOrganizationCandidates(req, res)).rejects.toThrow(
+        "Only the organization owner can perform this action"
+      );
+    });
+
+    it("returns the candidate list for the owner", async () => {
+      mockListOrganizationAdminCandidates.mockResolvedValue([{ userId: DELEGATE }]);
+      const { req, res } = makeReqRes();
+
+      await handleGetOrganizationCandidates(req, res);
+
+      expect(res.json).toHaveBeenCalledWith([{ userId: DELEGATE }]);
+    });
+  });
+
+  describe("handlePostOrganizationAdmin", () => {
+    it("refuses a grant from a delegated admin", async () => {
+      mockGetAdminOrganizationsForUser.mockResolvedValue([foreignOrganization]);
+      const { req, res } = makeReqRes({ body: { userId: DELEGATE } });
+
+      await expect(handlePostOrganizationAdmin(req, res)).rejects.toThrow(
+        "Only the organization owner can perform this action"
+      );
+      expect(mockGrantOrganizationAdmin).not.toHaveBeenCalled();
+    });
+
+    it("refuses someone who belongs to no group in the organization", async () => {
+      mockListOrganizationAdminCandidates.mockResolvedValue([]);
+      const { req, res } = makeReqRes({ body: { userId: DELEGATE } });
+
+      await expect(handlePostOrganizationAdmin(req, res)).rejects.toThrow(
+        "This user is not a member of any group in this organization"
+      );
+      expect(mockGrantOrganizationAdmin).not.toHaveBeenCalled();
+    });
+
+    it("grants to a candidate and returns the new admin list", async () => {
+      mockListOrganizationAdminCandidates.mockResolvedValue([{ userId: DELEGATE }]);
+      mockListOrganizationAdmins.mockResolvedValue([{ userId: OWNER }, { userId: DELEGATE }]);
+      const { req, res } = makeReqRes({ body: { userId: DELEGATE } });
+
+      await handlePostOrganizationAdmin(req, res);
+
+      // The service re-checks eligibility under the organization lock; the
+      // controller must hand it a way to do that.
+      const grant = mockGrantOrganizationAdmin.mock.calls[0]?.[0] as {
+        assertStillEligible?: unknown;
+      };
+      expect(typeof grant.assertStillEligible).toBe("function");
+
+      expect(mockGrantOrganizationAdmin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: "org-1",
+          userId: DELEGATE,
+          grantedByUserId: OWNER,
+        })
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+  });
+
+  describe("handleDeleteOrganizationAdmin", () => {
+    it("refuses a revoke from a delegated admin", async () => {
+      mockGetAdminOrganizationsForUser.mockResolvedValue([foreignOrganization]);
+      const { req, res } = makeReqRes({ params: { userId: DELEGATE } });
+
+      await expect(handleDeleteOrganizationAdmin(req, res)).rejects.toThrow(
+        "Only the organization owner can perform this action"
+      );
+      expect(mockRemoveOrganizationAdmin).not.toHaveBeenCalled();
+    });
+
+    it("404s when the target was not an admin", async () => {
+      mockRemoveOrganizationAdmin.mockResolvedValue(false);
+      const { req, res } = makeReqRes({ params: { userId: DELEGATE } });
+
+      await expect(handleDeleteOrganizationAdmin(req, res)).rejects.toThrow(
+        "This user is not an administrator of this organization"
+      );
+    });
+
+    it("revokes and returns the remaining admins", async () => {
+      mockRemoveOrganizationAdmin.mockResolvedValue(true);
+      mockListOrganizationAdmins.mockResolvedValue([{ userId: OWNER }]);
+      const { req, res } = makeReqRes({ params: { userId: DELEGATE } });
+
+      await handleDeleteOrganizationAdmin(req, res);
+
+      expect(mockRemoveOrganizationAdmin).toHaveBeenCalledWith("org-1", DELEGATE);
+      expect(res.json).toHaveBeenCalledWith([{ userId: OWNER }]);
+    });
+  });
+});

--- a/src/controllers/organization/utils.ts
+++ b/src/controllers/organization/utils.ts
@@ -1,0 +1,81 @@
+import type { Request } from "express";
+import { z } from "zod";
+import { createDBServices } from "../../services/DBServices.js";
+import { getAuth } from "../../middleware/authSession.js";
+import AppError from "../../utils/appError.js";
+import type { OrganizationType } from "../../services/organization/types.js";
+
+const services = createDBServices();
+
+/**
+ * The organization to act on when the request names none: the caller's own.
+ * A delegated admin who owns nothing gets a default only when they administer
+ * exactly one — with several there is no sensible pick, and silently taking
+ * the oldest would let an unqualified `PATCH` rename the wrong organization.
+ */
+const resolveDefaultOrganization = async (userId: string) => {
+  const administered = await services.organization.getAdminOrganizationsForUser(userId);
+  const owned = administered.find((organization) => organization.ownerUserId === userId);
+  if (owned) return owned;
+
+  if (administered.length > 1) {
+    throw new AppError({
+      message: "Name the organization to act on",
+      logging: true,
+      code: 400,
+      context: { userId, administered: administered.length },
+    });
+  }
+
+  return administered[0];
+};
+
+/**
+ * Resolves the organization the request is about and checks the caller
+ * administers it. `organizationId` may be omitted, in which case the caller's
+ * own organization is used — most people have exactly one.
+ */
+export const resolveAdministeredOrganization = async (
+  req: Request
+): Promise<{ organization: OrganizationType; isOwner: boolean }> => {
+  const auth = getAuth(req);
+
+  const organizationId = z.string().min(1).optional().parse(req.query.organizationId);
+
+  const organization = organizationId
+    ? await services.organization.getOrganizationById(organizationId)
+    : await resolveDefaultOrganization(auth.userId);
+
+  if (!organization) {
+    throw new AppError({
+      message: "Organization not found",
+      logging: true,
+      code: 404,
+      context: { userId: auth.userId, organizationId },
+    });
+  }
+
+  const isAdmin = await services.organization.isOrganizationAdmin(auth.userId, organization.id);
+  if (!isAdmin) {
+    throw new AppError({
+      message: "No permission for related organization",
+      logging: true,
+      code: 403,
+      context: { userId: auth.userId, organizationId: organization.id },
+    });
+  }
+
+  return { organization, isOwner: organization.ownerUserId === auth.userId };
+};
+
+/** Throws 403 unless the caller owns the organization — billing-adjacent writes are owner-only. */
+export const assertOrganizationOwner = (organization: OrganizationType, userId: string): void => {
+  if (organization.ownerUserId !== userId) {
+    throw new AppError({
+      message: "Only the organization owner can perform this action",
+      logging: true,
+      code: 403,
+      context: { userId, organizationId: organization.id },
+    });
+  }
+};

--- a/src/controllers/quotas/handleGetCarryOverSuggestion.ts
+++ b/src/controllers/quotas/handleGetCarryOverSuggestion.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
-import AppError from "../../utils/appError.js";
+import { assertGroupAdmin } from "../groupUser/utils.js";
 
 const services = createDBServices();
 
@@ -22,16 +22,7 @@ export const handleGetCarryOverSuggestion = async (req: Request, res: Response) 
   const groupId = z.uuid().parse(req.params.groupId);
   const { userId, year } = queryParams.parse(req.query);
 
-  const access = await services.groupUser.getGroupUser(auth.userId, groupId);
-
-  if (!access || !access.adminAccess) {
-    throw new AppError({
-      message: "No permission for related group",
-      logging: true,
-      code: 403,
-      context: { url: req.url, user: auth.userId, groupId },
-    });
-  }
+  await assertGroupAdmin(auth.userId, groupId);
 
   const suggestion = await services.report.getCarryOverSuggestion(userId, groupId, year);
 

--- a/src/controllers/quotas/handleGetUserQuota.ts
+++ b/src/controllers/quotas/handleGetUserQuota.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
 import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
+import { validateUserGroupAccess } from "../groupUser/utils.js";
 import { z } from "zod";
 import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";
@@ -28,9 +29,9 @@ export const handleGetUserQuota = async (req: Request, res: Response) => {
   }
 
   const result = await db.transaction(async (tx) => {
-    const access = await services.groupUser.getGroupUser(auth.userId, groupId, tx);
+    const canView = await validateUserGroupAccess(auth.userId, groupId, tx);
 
-    if (!access || !access.viewAccess) {
+    if (!canView) {
       throw new AppError({
         message: "No permission for related group",
         logging: true,

--- a/src/controllers/quotas/handlePutUserQuota.ts
+++ b/src/controllers/quotas/handlePutUserQuota.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
+import { assertGroupAdmin } from "../groupUser/utils.js";
 import type { ValidatedPutUserQuotaType } from "../../services/userYearQuotas/types.js";
 import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";
@@ -26,16 +27,7 @@ export const handlePutUserQuota = async (req: Request, res: Response) => {
   const data: ValidatedPutUserQuotaType = req.body;
 
   const result = await db.transaction(async (tx) => {
-    const access = await services.groupUser.getGroupUser(auth.userId, groupId, tx);
-
-    if (!access || !access.adminAccess) {
-      throw new AppError({
-        message: "No permission for related group",
-        logging: true,
-        code: 403,
-        context: { url: req.url, user: auth.userId, groupId },
-      });
-    }
+    await assertGroupAdmin(auth.userId, groupId, tx);
 
     const member = await services.groupUser.getGroupUser(data.userId, groupId, tx);
 

--- a/src/controllers/quotas/tests/handlePutUserQuota.test.ts
+++ b/src/controllers/quotas/tests/handlePutUserQuota.test.ts
@@ -16,6 +16,24 @@ const { mockGetGroupUser, mockGetUserYearGroupQuotas, mockUpsertUserYearQuota, m
     mockPostChanges: vi.fn(),
   }));
 
+// `assertGroupAdmin` reaches for the service modules directly rather than
+// through createDBServices, so both routes must resolve to the same mock.
+// Org-admin access is off here; it has its own suite.
+vi.mock("../../../services/groupUser/groupUserServices.js", () => ({
+  getGroupUser: mockGetGroupUser,
+  getAdminGroupIdsForUser: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../services/group/groupServices.js", () => ({
+  getGroup: vi.fn().mockResolvedValue({ id: "group", organizationId: "org" }),
+  getLiveGroupIdsForOrganizations: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../services/organization/organizationServices.js", () => ({
+  isOrganizationAdmin: vi.fn().mockResolvedValue(false),
+  getAdminOrganizationsForUser: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("../../../middleware/authSession.js", () => ({
   getAuth: vi.fn(),
 }));

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -12,6 +12,7 @@ import { vacationEvents } from "./vacation-event-schema.js";
 import { userSettings } from "./user-settings-schema.js";
 import { reportExports } from "./report-export-schema.js";
 import { organizations } from "./organization-schema.js";
+import { organizationUsers } from "./organization-users-schema.js";
 import { subscriptions } from "./subscription-schema.js";
 import { paddleEvents } from "./paddle-event-schema.js";
 
@@ -35,6 +36,7 @@ export const schema = {
   calendarSyncTypes,
   reportExports,
   organizations,
+  organizationUsers,
   subscriptions,
   paddleEvents,
 };

--- a/src/db/schema/organization-schema.ts
+++ b/src/db/schema/organization-schema.ts
@@ -3,11 +3,13 @@ import { user } from "./auth-schema.js";
 
 /**
  * Billing owner sitting above `groups`, so "who pays" is decoupled from "who
- * manages a group". Phase 1: exactly one org per user (unique index on
- * ownerUserId) and membership stays implicit (owner only) — an
- * `organization_users` table can be added later without touching `groups`.
+ * manages a group". Exactly one org per user (unique index on ownerUserId).
  * Rows are created lazily by `ensureOrganizationForUser`; users with no
  * groups get no row.
+ *
+ * The owner is **not** stored in `organization_users` — that table holds
+ * delegated admins only, so "is this user an org admin" is owner-or-row and
+ * `isOrganizationAdmin` is the only correct way to ask.
  */
 export const organizations = pgTable(
   "organizations",

--- a/src/db/schema/organization-users-schema.ts
+++ b/src/db/schema/organization-users-schema.ts
@@ -1,0 +1,52 @@
+import { index, pgEnum, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { organizations } from "./organization-schema.js";
+import { user } from "./auth-schema.js";
+import { enumToPgEnum } from "../../utils/enumToPgEnum.js";
+
+export enum organizationRole {
+  Admin = "ADMIN",
+}
+
+export const organizationRoleEnum = pgEnum("organization_role", enumToPgEnum(organizationRole));
+
+/**
+ * Delegated administrators of an organization. The **owner is not stored
+ * here** — it is `organizations.ownerUserId`, the same way a group's manager
+ * sits on `groups.managerUserId` rather than carrying a `group_users` row.
+ * Readers must therefore treat owner-or-row as "org admin"; a bare lookup in
+ * this table answers only half the question.
+ *
+ * An org admin is an administrator *over* the org's groups, not a member of
+ * them: no quota row, no place in a group's member list, no ability to book
+ * leave there.
+ */
+export const organizationUsers = pgTable(
+  "organization_users",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    role: organizationRoleEnum("role").notNull().default(organizationRole.Admin),
+    grantedByUserId: text("granted_by_user_id").references(() => user.id, { onDelete: "set null" }),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("organization_users_org_id_user_id_uniq")
+      .on(table.organizationId, table.userId)
+      .where(sql`${table.deletedAt} IS NULL`),
+    // Every group-scoped authorization check falls back to "is the caller an
+    // admin of this group's org", keyed by user.
+    index("idx_organization_users_user_id").on(table.userId),
+    index("idx_organization_users_organization_id").on(table.organizationId),
+  ]
+);

--- a/src/db/schema/out/0013_abandoned_bromley.sql
+++ b/src/db/schema/out/0013_abandoned_bromley.sql
@@ -1,0 +1,18 @@
+CREATE TYPE "public"."organization_role" AS ENUM('ADMIN');--> statement-breakpoint
+CREATE TABLE "organization_users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"role" "organization_role" DEFAULT 'ADMIN' NOT NULL,
+	"granted_by_user_id" text,
+	"deleted_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "organization_users" ADD CONSTRAINT "organization_users_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_users" ADD CONSTRAINT "organization_users_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_users" ADD CONSTRAINT "organization_users_granted_by_user_id_user_id_fk" FOREIGN KEY ("granted_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "organization_users_org_id_user_id_uniq" ON "organization_users" USING btree ("organization_id","user_id") WHERE "organization_users"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "idx_organization_users_user_id" ON "organization_users" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_organization_users_organization_id" ON "organization_users" USING btree ("organization_id");

--- a/src/db/schema/out/meta/0013_snapshot.json
+++ b/src/db/schema/out/meta/0013_snapshot.json
@@ -1,0 +1,2828 @@
+{
+  "id": "6cb54e6f-353a-4e76-a33a-83ca1fdb6377",
+  "prevId": "a684d2c5-3a52-4fea-b6d4-90669edd388a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_mirrors": {
+      "name": "group_mirrors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_group_id": {
+          "name": "target_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_mirrors_user_source_target_uniq": {
+          "name": "group_mirrors_user_source_target_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_mirrors\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_target_group_id": {
+          "name": "idx_group_mirrors_target_group_id",
+          "columns": [
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_user_id": {
+          "name": "idx_group_mirrors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_mirrors_user_id_user_id_fk": {
+          "name": "group_mirrors_user_id_user_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_source_group_id_groups_id_fk": {
+          "name": "group_mirrors_source_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_target_group_id_groups_id_fk": {
+          "name": "group_mirrors_target_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "target_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_organization_id": {
+          "name": "idx_groups_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_organization_id_organizations_id_fk": {
+          "name": "groups_organization_id_organizations_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approver_access": {
+          "name": "approver_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invite_link_group_id": {
+          "name": "idx_invite_link_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_group_email_open_uniq": {
+          "name": "invite_link_group_email_open_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_link\".\"used_at\" IS NULL AND \"invite_link\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_link_invited_by_user_id_user_id_fk": {
+          "name": "invite_link_invited_by_user_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_organizations_owner_user_id": {
+          "name": "uq_organizations_owner_user_id",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_users": {
+      "name": "organization_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "organization_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_users_org_id_user_id_uniq": {
+          "name": "organization_users_org_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organization_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_users_user_id": {
+          "name": "idx_organization_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_users_organization_id": {
+          "name": "idx_organization_users_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_users_organization_id_organizations_id_fk": {
+          "name": "organization_users_organization_id_organizations_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_users_user_id_user_id_fk": {
+          "name": "organization_users_user_id_user_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_users_granted_by_user_id_user_id_fk": {
+          "name": "organization_users_granted_by_user_id_user_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paddle_events": {
+      "name": "paddle_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_exports_user_id_idx": {
+          "name": "report_exports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_exports_created_at_idx": {
+          "name": "report_exports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_user_id_user_id_fk": {
+          "name": "report_exports_user_id_user_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_subscription_id": {
+          "name": "paddle_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "subscription_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "billing_cycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_group_slots": {
+          "name": "extra_group_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_override": {
+          "name": "manual_plan_override",
+          "type": "manual_plan_override",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_groups": {
+          "name": "manual_max_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_members_per_group": {
+          "name": "manual_max_members_per_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_until": {
+          "name": "manual_plan_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_subscriptions_organization_id": {
+          "name": "uq_subscriptions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_paddle_subscription_id": {
+          "name": "idx_subscriptions_paddle_subscription_id",
+          "columns": [
+            {
+              "expression": "paddle_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_organization_id_organizations_id_fk": {
+          "name": "subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboard_scope": {
+          "name": "dashboard_scope",
+          "type": "dashboard_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MINE'"
+        },
+        "dashboard_group_id": {
+          "name": "dashboard_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_settings_dashboard_group_id_groups_id_fk": {
+          "name": "user_settings_dashboard_group_id_groups_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "dashboard_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "carried_over_days": {
+          "name": "carried_over_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        },
+        "user_year_quotas_related_year_range_chk": {
+          "name": "user_year_quotas_related_year_range_chk",
+          "value": "\"user_year_quotas\".\"related_year\"::int BETWEEN 2025 AND 2100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "half_day": {
+          "name": "half_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vacation\".\"deleted_at\" IS NULL AND \"vacation\".\"rejected_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.organization_role": {
+      "name": "organization_role",
+      "schema": "public",
+      "values": [
+        "ADMIN"
+      ]
+    },
+    "public.billing_cycle": {
+      "name": "billing_cycle",
+      "schema": "public",
+      "values": [
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.manual_plan_override": {
+      "name": "manual_plan_override",
+      "schema": "public",
+      "values": [
+        "FREE",
+        "PRO",
+        "ENTERPRISE",
+        "CUSTOM"
+      ]
+    },
+    "public.subscription_plan": {
+      "name": "subscription_plan",
+      "schema": "public",
+      "values": [
+        "PRO",
+        "ENTERPRISE"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "trialing",
+        "past_due",
+        "paused",
+        "canceled"
+      ]
+    },
+    "public.dashboard_scope": {
+      "name": "dashboard_scope",
+      "schema": "public",
+      "values": [
+        "MINE",
+        "GROUP"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/_journal.json
+++ b/src/db/schema/out/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1786801394616,
       "tag": "0012_confused_elektra",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1786877163807,
+      "tag": "0013_abandoned_bromley",
+      "breakpoints": true
     }
   ]
 }

--- a/src/routes/groupRouter.ts
+++ b/src/routes/groupRouter.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { handlePostGroup } from "../controllers/group/handlePostGroup.js";
 import { tryCatch } from "../middleware/tryCatch.js";
 import { handleGetGroups } from "../controllers/group/handleGetGroups.js";
+import { handleGetGroup } from "../controllers/group/handleGetGroup.js";
 import { handlePutGroupQuotas } from "../controllers/group/handlePutGroupQuotas.js";
 import { handlePutGroupWorkingDays } from "../controllers/group/handlePutGroupWorkingDays.js";
 import { bodyValidationMiddleware } from "../middleware/validationMiddleware.js";
@@ -73,6 +74,39 @@ export const groupRouter = (): Router => {
 
   /**
    * @openapi
+   * /api/group/{groupId}:
+   *   get:
+   *     tags:
+   *       - Groups
+   *     summary: One group with the caller's effective rights over it
+   *     description: |
+   *       Unlike `GET /api/group` — which is membership-only, because it also
+   *       drives the dashboard and the request dialog — this reaches groups the
+   *       caller administers through the organization. `access` reports exactly
+   *       what the mutation endpoints will allow, and `access.viaOrgAdmin`
+   *       marks authority that came from the organization rather than a
+   *       membership.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: groupId
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *     responses:
+   *       '200':
+   *         description: The group, its organization badge and the caller's access
+   *       '403':
+   *         description: No access for related group
+   *       '404':
+   *         description: Group not found
+   */
+  app.get("/:groupId", tryCatch(handleGetGroup));
+
+  /**
+   * @openapi
    * /api/group/{groupId}/quotas:
    *   put:
    *     tags:
@@ -80,7 +114,7 @@ export const groupRouter = (): Router => {
    *     summary: Update the group's default allowances
    *     description: |
    *       Sets the vacation / home-office days new members start from. Existing
-   *       per-year quotas are not touched. Requires admin access on the group.
+   *       per-year quotas are not touched. Requires group admin access, or admin of the group's organization.
    *     security:
    *       - bearerAuth: []
    *     parameters:
@@ -134,7 +168,7 @@ export const groupRouter = (): Router => {
    *       Sets which weekdays the group treats as working days. Vacation
    *       requests are only booked — and only counted against quotas — on these
    *       days. Days are `Date.getUTCDay()` numbers (0=Sunday … 6=Saturday); at
-   *       least one is required. Requires admin access on the group.
+   *       least one is required. Requires group admin access, or admin of the group's organization.
    *     security:
    *       - bearerAuth: []
    *     parameters:
@@ -271,7 +305,7 @@ export const groupRouter = (): Router => {
    *     description: |
    *       Names the main and optional stand-in approver. Both must already be
    *       members of the group. A group always has a main approver — clearing it
-   *       would leave its requests undecidable. Requires admin access on the group.
+   *       would leave its requests undecidable. Requires group admin access, or admin of the group's organization.
    *     security:
    *       - bearerAuth: []
    *     parameters:
@@ -304,7 +338,9 @@ export const groupRouter = (): Router => {
    *           lapsed. `errors[].context` carries
    *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
-   *         description: No permission for related group
+   *         description: |
+   *           No permission for related group; or a caller acting on
+   *           organization authority named themselves as an approver.
    *       '404':
    *         description: Group not found
    *       '422':

--- a/src/routes/groupUsersRouter.ts
+++ b/src/routes/groupUsersRouter.ts
@@ -166,7 +166,7 @@ export const groupUsersRouter = (): Router => {
    *       - Group members
    *     summary: Remove a member from a group
    *     description: |
-   *       Soft-deletes the membership. Requires admin access on the group. The
+   *       Soft-deletes the membership. Requires group admin access, or admin of the group's organization. The
    *       group's manager cannot be removed; there is no manager-transfer route
    *       yet, so a manager can only leave by deleting the group. If the
    *       removed member was the main approver, approvals fall back to the
@@ -215,7 +215,7 @@ export const groupUsersRouter = (): Router => {
    *     summary: Update members' permissions in a group
    *     description: |
    *       Sets the four membership flags for one or more members at once.
-   *       Requires admin access on the group. The flags are independent:
+   *       Requires group admin access, or admin of the group's organization. The flags are independent:
    *       `adminAccess` manages the group (members, quotas, invites, working
    *       days, mirroring) but does not decide on leave, and `approverAccess`
    *       decides on leave but manages nothing. `controlledUser` marks a member
@@ -263,7 +263,11 @@ export const groupUsersRouter = (): Router => {
    *       '400':
    *         description: A named member does not belong to the group
    *       '403':
-   *         description: No permission for related group
+   *         description: |
+   *           No permission for related group; or the caller tried to raise
+   *           their own permissions; or a caller acting on organization
+   *           authority tried to grant `approverAccess` — that role is only
+   *           ever granted from inside the group.
    */
   app.put(
     "/",

--- a/src/routes/organizationRouter.ts
+++ b/src/routes/organizationRouter.ts
@@ -104,12 +104,14 @@ export const organizationRouter = (): Router => {
    *         description: The updated organization
    *       '400':
    *         description: |
-   *           No field to update, or `organizationId` omitted by a delegated
-   *           admin who administers several organizations.
+   *           `organizationId` omitted by a delegated admin who owns no
+   *           organization and administers several.
    *       '403':
    *         description: Not an admin, or not the owner for `billingEmail`
    *       '404':
    *         description: Organization not found
+   *       '422':
+   *         description: Body carried neither `name` nor `billingEmail`
    */
   app.patch(
     "/",

--- a/src/routes/organizationRouter.ts
+++ b/src/routes/organizationRouter.ts
@@ -1,0 +1,225 @@
+import { Router } from "express";
+import { tryCatch } from "../middleware/tryCatch.js";
+import { bodyValidationMiddleware } from "../middleware/validationMiddleware.js";
+import {
+  validatePatchOrganization,
+  validatePostOrganizationAdmin,
+} from "../services/organization/types.js";
+import { handleGetOrganization } from "../controllers/organization/handleGetOrganization.js";
+import { handleGetOrganizations } from "../controllers/organization/handleGetOrganizations.js";
+import { handlePatchOrganization } from "../controllers/organization/handlePatchOrganization.js";
+import { handleGetOrganizationCandidates } from "../controllers/organization/handleGetOrganizationCandidates.js";
+import { handlePostOrganizationAdmin } from "../controllers/organization/handlePostOrganizationAdmin.js";
+import { handleDeleteOrganizationAdmin } from "../controllers/organization/handleDeleteOrganizationAdmin.js";
+
+export const organizationRouter = (): Router => {
+  const app = Router();
+
+  /**
+   * @openapi
+   * /api/organization/list:
+   *   get:
+   *     tags:
+   *       - Organization
+   *     summary: Organizations the caller owns or administers
+   *     description: |
+   *       Owned organizations come first. Drives the organization page's
+   *       switcher for anyone who administers more than one. Returns an empty
+   *       array for a user with no organization yet.
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       '200':
+   *         description: Array of `{ id, name, isOwner }`
+   */
+  app.get("/list", tryCatch(handleGetOrganizations));
+
+  /**
+   * @openapi
+   * /api/organization:
+   *   get:
+   *     tags:
+   *       - Organization
+   *     summary: Organization detail — plan, groups and administrators
+   *     description: |
+   *       Defaults to the caller's own organization; pass `organizationId` to
+   *       address one they administer but do not own. Delegated admins see the
+   *       plan and its limits but not the billing address — `billingEmail` is
+   *       null for them, and subscription detail stays on
+   *       `/api/billing/subscription`, which resolves by ownership.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: organizationId
+   *         schema:
+   *           type: string
+   *     responses:
+   *       '200':
+   *         description: Organization, plan, groups, administrators
+   *       '400':
+   *         description: |
+   *           `organizationId` omitted by a delegated admin who owns none and
+   *           administers several — there is no unambiguous default.
+   *       '403':
+   *         description: Caller does not administer this organization
+   *       '404':
+   *         description: No such organization, or the caller has none yet
+   */
+  app.get("/", tryCatch(handleGetOrganization));
+
+  /**
+   * @openapi
+   * /api/organization:
+   *   patch:
+   *     tags:
+   *       - Organization
+   *     summary: Rename the organization or repoint its billing address
+   *     description: |
+   *       The name is editable by any organization admin. `billingEmail` is
+   *       owner-only — it is where subscription grace warnings are sent.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: organizationId
+   *         schema:
+   *           type: string
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               name:
+   *                 type: string
+   *                 minLength: 1
+   *                 maxLength: 120
+   *               billingEmail:
+   *                 type: string
+   *                 format: email
+   *     responses:
+   *       '200':
+   *         description: The updated organization
+   *       '400':
+   *         description: |
+   *           No field to update, or `organizationId` omitted by a delegated
+   *           admin who administers several organizations.
+   *       '403':
+   *         description: Not an admin, or not the owner for `billingEmail`
+   *       '404':
+   *         description: Organization not found
+   */
+  app.patch(
+    "/",
+    bodyValidationMiddleware(validatePatchOrganization),
+    tryCatch(handlePatchOrganization)
+  );
+
+  /**
+   * @openapi
+   * /api/organization/candidates:
+   *   get:
+   *     tags:
+   *       - Organization
+   *     summary: People who may be promoted to organization admin
+   *     description: |
+   *       Active members of the organization's live groups, minus its existing
+   *       administrators. Owner-only. Deliberately not a lookup by email —
+   *       that would let an owner probe whether an address has an account.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: organizationId
+   *         schema:
+   *           type: string
+   *     responses:
+   *       '200':
+   *         description: Array of candidates with the groups they belong to
+   *       '403':
+   *         description: Caller is not the organization owner
+   */
+  app.get("/candidates", tryCatch(handleGetOrganizationCandidates));
+
+  /**
+   * @openapi
+   * /api/organization/admins:
+   *   post:
+   *     tags:
+   *       - Organization
+   *     summary: Grant organization admin
+   *     description: |
+   *       Owner-only: an admin able to appoint further admins would make the
+   *       grant self-propagating. The target must already belong to a group in
+   *       the organization. An org admin may administer every group in the
+   *       organization — its members, quotas, settings and invites — without
+   *       being a member of any of them. The role confers no approver rights
+   *       and no membership, and two routes actively hold that line: nobody
+   *       may raise their own group permissions, and a caller acting on
+   *       organization authority may not name themselves a group's approver.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: organizationId
+   *         schema:
+   *           type: string
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - userId
+   *             properties:
+   *               userId:
+   *                 type: string
+   *     responses:
+   *       '201':
+   *         description: The organization's administrators after the grant
+   *       '403':
+   *         description: Caller is not the organization owner
+   *       '422':
+   *         description: The target belongs to no group in this organization
+   */
+  app.post(
+    "/admins",
+    bodyValidationMiddleware(validatePostOrganizationAdmin),
+    tryCatch(handlePostOrganizationAdmin)
+  );
+
+  /**
+   * @openapi
+   * /api/organization/admins/{userId}:
+   *   delete:
+   *     tags:
+   *       - Organization
+   *     summary: Revoke organization admin
+   *     description: Owner-only. The owner's own rights are not stored and cannot be revoked.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: userId
+   *         required: true
+   *         schema:
+   *           type: string
+   *       - in: query
+   *         name: organizationId
+   *         schema:
+   *           type: string
+   *     responses:
+   *       '200':
+   *         description: The organization's administrators after the revoke
+   *       '403':
+   *         description: Caller is not the organization owner
+   *       '404':
+   *         description: The target is not an administrator of this organization
+   */
+  app.delete("/admins/:userId", tryCatch(handleDeleteOrganizationAdmin));
+
+  return app;
+};

--- a/src/routes/quotasRouter.ts
+++ b/src/routes/quotasRouter.ts
@@ -72,7 +72,7 @@ export const quotasRouter = (): Router => {
    *     summary: Set a member's allowance for a year
    *     description: |
    *       Creates or replaces the member's `user_year_quotas` row for the given
-   *       year. Requires admin access on the group; the change is recorded in
+   *       year. Requires group admin access, or admin of the group's organization; the change is recorded in
    *       the `changes` audit log.
    *     security:
    *       - bearerAuth: []

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import { handleGetCalendarFeed } from "./controllers/calendarSync/handleGetCalen
 import { devRouter } from "./routes/devRouter.js";
 import { requestContext } from "./middleware/requestContext.js";
 import { billingRouter } from "./routes/billingRouter.js";
+import { organizationRouter } from "./routes/organizationRouter.js";
 import { handlePaddleWebhook } from "./controllers/billing/handlePaddleWebhook.js";
 
 export const createServer = () => {
@@ -100,6 +101,7 @@ export const createServer = () => {
   app.use("/api/calendar-sync", calendarSyncRouter());
   app.use("/api/reports", reportRouter());
   app.use("/api/billing", billingRouter());
+  app.use("/api/organization", organizationRouter());
 
   // Public, token-authenticated iCalendar feed. Deliberately NOT behind
   // `authSession`: calendar clients subscribe with just the secret token in

--- a/src/services/DBServices.ts
+++ b/src/services/DBServices.ts
@@ -49,6 +49,7 @@ export type DBServices = Readonly<{
     deleteGroupUser: typeof groupUserServices.deleteGroupUser;
     getAllGroupsForUser: typeof groupUserServices.getAllGroupsForUser;
     getAdminGroupIdsForUser: typeof groupUserServices.getAdminGroupIdsForUser;
+    countActiveMembershipsInOrganization: typeof groupUserServices.countActiveMembershipsInOrganization;
     getMembershipPairs: typeof groupUserServices.getMembershipPairs;
     countDistinctUsersInGroups: typeof groupUserServices.countDistinctUsersInGroups;
   };
@@ -76,6 +77,7 @@ export type DBServices = Readonly<{
     getGroupsWhereUserCanApprove: typeof groupServices.getGroupsWhereUserCanApprove;
     countLiveGroupsForOrganization: typeof groupServices.countLiveGroupsForOrganization;
     getLiveGroupIdsForOrganizationOrdered: typeof groupServices.getLiveGroupIdsForOrganizationOrdered;
+    getLiveGroupIdsForOrganizations: typeof groupServices.getLiveGroupIdsForOrganizations;
     getGroupUsageForOrganization: typeof groupServices.getGroupUsageForOrganization;
   };
   groupMirror: {
@@ -152,8 +154,17 @@ export type DBServices = Readonly<{
   organization: {
     getOrganizationById: typeof organizationServices.getOrganizationById;
     getOrganizationForOwner: typeof organizationServices.getOrganizationForOwner;
+    getOrganizationsByIds: typeof organizationServices.getOrganizationsByIds;
+    getAdminOrganizationsForUser: typeof organizationServices.getAdminOrganizationsForUser;
     ensureOrganizationForUser: typeof organizationServices.ensureOrganizationForUser;
     setOrganizationPaddleCustomerId: typeof organizationServices.setOrganizationPaddleCustomerId;
+    updateOrganization: typeof organizationServices.updateOrganization;
+    isOrganizationAdmin: typeof organizationServices.isOrganizationAdmin;
+    listOrganizationAdmins: typeof organizationServices.listOrganizationAdmins;
+    listOrganizationAdminCandidates: typeof organizationServices.listOrganizationAdminCandidates;
+    grantOrganizationAdmin: typeof organizationServices.grantOrganizationAdmin;
+    removeOrganizationAdmin: typeof organizationServices.removeOrganizationAdmin;
+    lockOrganization: typeof organizationServices.lockOrganization;
   };
   billing: {
     getSubscriptionForOrganization: typeof subscriptionServices.getSubscriptionForOrganization;
@@ -198,6 +209,7 @@ export const createDBServices = (): DBServices => {
       deleteGroupUser: groupUserServices.deleteGroupUser,
       getAllGroupsForUser: groupUserServices.getAllGroupsForUser,
       getAdminGroupIdsForUser: groupUserServices.getAdminGroupIdsForUser,
+      countActiveMembershipsInOrganization: groupUserServices.countActiveMembershipsInOrganization,
       getMembershipPairs: groupUserServices.getMembershipPairs,
       countDistinctUsersInGroups: groupUserServices.countDistinctUsersInGroups,
     },
@@ -225,6 +237,7 @@ export const createDBServices = (): DBServices => {
       getGroupsWhereUserCanApprove: groupServices.getGroupsWhereUserCanApprove,
       countLiveGroupsForOrganization: groupServices.countLiveGroupsForOrganization,
       getLiveGroupIdsForOrganizationOrdered: groupServices.getLiveGroupIdsForOrganizationOrdered,
+      getLiveGroupIdsForOrganizations: groupServices.getLiveGroupIdsForOrganizations,
       getGroupUsageForOrganization: groupServices.getGroupUsageForOrganization,
     },
     groupMirror: {
@@ -301,8 +314,17 @@ export const createDBServices = (): DBServices => {
     organization: {
       getOrganizationById: organizationServices.getOrganizationById,
       getOrganizationForOwner: organizationServices.getOrganizationForOwner,
+      getOrganizationsByIds: organizationServices.getOrganizationsByIds,
+      getAdminOrganizationsForUser: organizationServices.getAdminOrganizationsForUser,
       ensureOrganizationForUser: organizationServices.ensureOrganizationForUser,
       setOrganizationPaddleCustomerId: organizationServices.setOrganizationPaddleCustomerId,
+      updateOrganization: organizationServices.updateOrganization,
+      isOrganizationAdmin: organizationServices.isOrganizationAdmin,
+      listOrganizationAdmins: organizationServices.listOrganizationAdmins,
+      listOrganizationAdminCandidates: organizationServices.listOrganizationAdminCandidates,
+      grantOrganizationAdmin: organizationServices.grantOrganizationAdmin,
+      removeOrganizationAdmin: organizationServices.removeOrganizationAdmin,
+      lockOrganization: organizationServices.lockOrganization,
     },
     billing: {
       getSubscriptionForOrganization: subscriptionServices.getSubscriptionForOrganization,

--- a/src/services/billing/subscriptionServices.ts
+++ b/src/services/billing/subscriptionServices.ts
@@ -1,7 +1,7 @@
 import { db, type DbTransaction } from "../../db/db.js";
 import { subscriptions } from "../../db/schema/subscription-schema.js";
 import { paddleEvents } from "../../db/schema/paddle-event-schema.js";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import type { Subscription, SubscriptionPatch } from "./types.js";
 
@@ -16,6 +16,18 @@ export const getSubscriptionForOrganization = async (
     .limit(1);
 
   return row;
+};
+
+/** Bulk variant for the per-group organization badge — one query, not one per group. */
+export const getSubscriptionsForOrganizations = async (
+  organizationIds: string[],
+  tx?: DbTransaction
+): Promise<Subscription[]> => {
+  if (organizationIds.length === 0) return [];
+  return (tx ?? db)
+    .select()
+    .from(subscriptions)
+    .where(inArray(subscriptions.organizationId, organizationIds));
 };
 
 export const getSubscriptionByPaddleId = async (

--- a/src/services/group/groupServices.ts
+++ b/src/services/group/groupServices.ts
@@ -236,7 +236,12 @@ export const getLiveGroupIdsForOrganizationOrdered = async (
   return rows.map((row) => row.id);
 };
 
-/** Narrows a set of group ids to those belonging to one organization. */
+/**
+ * Narrows a set of group ids to the **live** groups of one organization.
+ * Membership rows outlive a soft-deleted group, so without the `deletedAt`
+ * filter a deleted group would still reach the administrable-group list that
+ * mirroring uses as its source allowlist.
+ */
 export const filterGroupIdsByOrganization = async (
   groupIds: string[],
   organizationId: string,
@@ -246,7 +251,13 @@ export const filterGroupIdsByOrganization = async (
   const rows = await (tx ?? db)
     .select({ id: groups.id })
     .from(groups)
-    .where(and(inArray(groups.id, groupIds), eq(groups.organizationId, organizationId)));
+    .where(
+      and(
+        inArray(groups.id, groupIds),
+        eq(groups.organizationId, organizationId),
+        isNull(groups.deletedAt)
+      )
+    );
   return rows.map((row) => row.id);
 };
 

--- a/src/services/group/groupServices.ts
+++ b/src/services/group/groupServices.ts
@@ -236,6 +236,33 @@ export const getLiveGroupIdsForOrganizationOrdered = async (
   return rows.map((row) => row.id);
 };
 
+/** Narrows a set of group ids to those belonging to one organization. */
+export const filterGroupIdsByOrganization = async (
+  groupIds: string[],
+  organizationId: string,
+  tx?: DbTransaction
+): Promise<string[]> => {
+  if (groupIds.length === 0) return [];
+  const rows = await (tx ?? db)
+    .select({ id: groups.id })
+    .from(groups)
+    .where(and(inArray(groups.id, groupIds), eq(groups.organizationId, organizationId)));
+  return rows.map((row) => row.id);
+};
+
+/** Live group ids across several organizations, for org-admin authorization. */
+export const getLiveGroupIdsForOrganizations = async (
+  organizationIds: string[],
+  tx?: DbTransaction
+): Promise<string[]> => {
+  if (organizationIds.length === 0) return [];
+  const rows = await (tx ?? db)
+    .select({ id: groups.id })
+    .from(groups)
+    .where(and(inArray(groups.organizationId, organizationIds), isNull(groups.deletedAt)));
+  return rows.map((row) => row.id);
+};
+
 /**
  * Live groups of an organization with their active member counts, oldest
  * first — the billing screen's usage meters.

--- a/src/services/groupUser/groupUserServices.ts
+++ b/src/services/groupUser/groupUserServices.ts
@@ -1,5 +1,6 @@
 import { db, type DbTransaction } from "../../db/db.js";
 import { groupUsers } from "../../db/schema/group-users-schema.js";
+import { groups } from "../../db/schema/group-schema.js";
 import { and, asc, count, countDistinct, desc, eq, gt, inArray, isNull } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import type {
@@ -106,6 +107,32 @@ export const getAdminGroupIdsForUser = async (
     );
 
   return rows.map((row) => row.groupId);
+};
+
+/**
+ * How many of an organization's live groups the user still actively belongs to.
+ * Zero means they are no longer one of the organization's people, which is what
+ * an org-admin grant is scoped to.
+ */
+export const countActiveMembershipsInOrganization = async (
+  userId: string,
+  organizationId: string,
+  tx?: DbTransaction
+): Promise<number> => {
+  const [row] = await (tx ?? db)
+    .select({ value: count() })
+    .from(groupUsers)
+    .innerJoin(groups, eq(groupUsers.groupId, groups.id))
+    .where(
+      and(
+        eq(groupUsers.userId, userId),
+        eq(groups.organizationId, organizationId),
+        isNull(groupUsers.deletedAt),
+        isNull(groups.deletedAt)
+      )
+    );
+
+  return Number(row?.value ?? 0);
 };
 
 /** Active (user, group) membership pairs, for cross-referencing many at once. */

--- a/src/services/organization/organizationBadge.ts
+++ b/src/services/organization/organizationBadge.ts
@@ -1,0 +1,55 @@
+import { resolveEntitlements, type PlanName } from "../billing/entitlements.js";
+import { getSubscriptionsForOrganizations } from "../billing/subscriptionServices.js";
+import { getOrganizationsByIds } from "./organizationServices.js";
+import type { subscriptionStatus } from "../../db/schema/subscription-schema.js";
+
+export type OrganizationBadge = {
+  id: string;
+  name: string;
+  plan: PlanName | "CUSTOM";
+  status: subscriptionStatus | null;
+  /** False once a lapsed plan's grace has run out — the badge shows the plan as inactive. */
+  active: boolean;
+};
+
+/**
+ * The organization summary that rides along with a group, so a member can see
+ * which organization covers their group and on what plan.
+ *
+ * It carries no billing internals: no billing email, no renewal date, no
+ * amounts. Those stay on `/api/billing/subscription`, which resolves the
+ * organization by ownership.
+ */
+export const resolveOrganizationBadges = async (
+  organizationIds: string[]
+): Promise<Map<string, OrganizationBadge>> => {
+  const distinct = [...new Set(organizationIds)];
+  if (distinct.length === 0) return new Map();
+
+  const [organizations, subscriptions] = await Promise.all([
+    getOrganizationsByIds(distinct),
+    getSubscriptionsForOrganizations(distinct),
+  ]);
+
+  const subscriptionByOrg = new Map(
+    subscriptions.map((subscription) => [subscription.organizationId, subscription])
+  );
+  const now = new Date();
+
+  return new Map(
+    organizations.map((organization) => {
+      const subscription = subscriptionByOrg.get(organization.id) ?? null;
+      const entitlements = resolveEntitlements(subscription, now);
+      return [
+        organization.id,
+        {
+          id: organization.id,
+          name: organization.name,
+          plan: entitlements.plan,
+          status: subscription?.status ?? null,
+          active: entitlements.plan !== "FREE" && entitlements.writable,
+        },
+      ];
+    })
+  );
+};

--- a/src/services/organization/organizationServices.ts
+++ b/src/services/organization/organizationServices.ts
@@ -1,10 +1,19 @@
 import { db, type DbTransaction } from "../../db/db.js";
 import { organizations } from "../../db/schema/organization-schema.js";
-import { eq } from "drizzle-orm";
+import { organizationUsers } from "../../db/schema/organization-users-schema.js";
+import { groups } from "../../db/schema/group-schema.js";
+import { groupUsers } from "../../db/schema/group-users-schema.js";
+import { user } from "../../db/schema/auth-schema.js";
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import { getUserById } from "../user/userServices.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import AppError from "../../utils/appError.js";
-import type { OrganizationType } from "./types.js";
+import { buildUserSummary } from "../../utils/userPresentation.js";
+import type {
+  OrganizationAdminListItem,
+  OrganizationCandidate,
+  OrganizationType,
+} from "./types.js";
 
 export const getOrganizationById = async (
   organizationId: string,
@@ -91,6 +100,278 @@ export const setOrganizationPaddleCustomerId = async (
     .returning();
 
   return row;
+};
+
+export const updateOrganization = async (
+  organizationId: string,
+  patch: { name?: string; billingEmail?: string },
+  tx?: DbTransaction
+): Promise<OrganizationType | undefined> => {
+  const [row] = await (tx ?? db)
+    .update(organizations)
+    .set(patch)
+    .where(eq(organizations.id, organizationId))
+    .returning();
+
+  return row;
+};
+
+/**
+ * True for the owner as well as anyone holding an active `organization_users`
+ * row. The owner is deliberately not stored in that table, so a caller that
+ * queries it alone answers only half the question.
+ *
+ * Two lookups rather than one join-with-`OR`: an `OR` spanning the outer table
+ * and a nullable joined table cannot be driven by either index, and this runs
+ * on every group-scoped authorization check.
+ */
+export const isOrganizationAdmin = async (
+  userId: string,
+  organizationId: string,
+  tx?: DbTransaction
+): Promise<boolean> => {
+  const [owned] = await (tx ?? db)
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(and(eq(organizations.id, organizationId), eq(organizations.ownerUserId, userId)))
+    .limit(1);
+
+  if (owned) return true;
+
+  const [granted] = await (tx ?? db)
+    .select({ id: organizationUsers.id })
+    .from(organizationUsers)
+    .where(
+      and(
+        eq(organizationUsers.organizationId, organizationId),
+        eq(organizationUsers.userId, userId),
+        isNull(organizationUsers.deletedAt)
+      )
+    )
+    .limit(1);
+
+  return granted !== undefined;
+};
+
+const organizationColumns = {
+  id: organizations.id,
+  name: organizations.name,
+  ownerUserId: organizations.ownerUserId,
+  billingEmail: organizations.billingEmail,
+  paddleCustomerId: organizations.paddleCustomerId,
+  createdAt: organizations.createdAt,
+  updatedAt: organizations.updatedAt,
+};
+
+/**
+ * Organizations the user owns or administers — owned first, then oldest first.
+ * Split into two index-backed queries for the same reason as
+ * {@link isOrganizationAdmin}.
+ */
+export const getAdminOrganizationsForUser = async (
+  userId: string,
+  tx?: DbTransaction
+): Promise<OrganizationType[]> => {
+  const owned = await (tx ?? db)
+    .select(organizationColumns)
+    .from(organizations)
+    .where(eq(organizations.ownerUserId, userId))
+    .orderBy(asc(organizations.createdAt));
+
+  const granted = await (tx ?? db)
+    .select(organizationColumns)
+    .from(organizationUsers)
+    .innerJoin(organizations, eq(organizationUsers.organizationId, organizations.id))
+    .where(and(eq(organizationUsers.userId, userId), isNull(organizationUsers.deletedAt)))
+    .orderBy(asc(organizations.createdAt));
+
+  // A grant on an organization you already own is not representable (the owner
+  // holds no row), but de-duplicate anyway rather than trust that invariant.
+  const ownedIds = new Set(owned.map((organization) => organization.id));
+  return [...owned, ...granted.filter((organization) => !ownedIds.has(organization.id))];
+};
+
+/** The owner first, then delegated admins by name. */
+export const listOrganizationAdmins = async (
+  organizationId: string
+): Promise<OrganizationAdminListItem[]> => {
+  const [organization] = await db
+    .select({ ownerUserId: organizations.ownerUserId })
+    .from(organizations)
+    .where(eq(organizations.id, organizationId))
+    .limit(1);
+
+  if (!organization) return [];
+
+  const owner = await getUserById(organization.ownerUserId);
+
+  const rows = await db
+    .select({
+      userId: organizationUsers.userId,
+      grantedAt: organizationUsers.createdAt,
+      userName: user.name,
+      email: user.email,
+    })
+    .from(organizationUsers)
+    .innerJoin(user, eq(organizationUsers.userId, user.id))
+    .where(
+      and(eq(organizationUsers.organizationId, organizationId), isNull(organizationUsers.deletedAt))
+    )
+    .orderBy(asc(user.name));
+
+  return [
+    ...(owner
+      ? [
+          {
+            userId: owner.id,
+            email: owner.email,
+            isOwner: true,
+            grantedAt: null,
+            user: buildUserSummary(owner),
+          },
+        ]
+      : []),
+    // The owner never holds a row, so this cannot duplicate them.
+    ...rows.map(({ userName, ...rest }) => ({
+      ...rest,
+      isOwner: false,
+      user: buildUserSummary({ id: rest.userId, name: userName }),
+    })),
+  ];
+};
+
+/**
+ * People who can be promoted to org admin: active members of the org's live
+ * groups, minus the owner and anyone already an admin. Restricting the pool to
+ * the org's own people is what lets the endpoint avoid an email lookup, which
+ * would otherwise let any owner probe whether an address has an account.
+ */
+export const listOrganizationAdminCandidates = async (
+  organizationId: string
+): Promise<OrganizationCandidate[]> => {
+  const rows = await db
+    .selectDistinct({
+      userId: groupUsers.userId,
+      userName: user.name,
+      email: user.email,
+      groupName: groups.groupName,
+    })
+    .from(groupUsers)
+    .innerJoin(groups, eq(groupUsers.groupId, groups.id))
+    .innerJoin(user, eq(groupUsers.userId, user.id))
+    .where(
+      and(
+        eq(groups.organizationId, organizationId),
+        isNull(groups.deletedAt),
+        isNull(groupUsers.deletedAt)
+      )
+    )
+    .orderBy(asc(user.name));
+
+  const admins = await listOrganizationAdmins(organizationId);
+  const excluded = new Set(admins.map((admin) => admin.userId));
+
+  const byUser = new Map<string, OrganizationCandidate>();
+  for (const row of rows) {
+    if (excluded.has(row.userId)) continue;
+    const existing = byUser.get(row.userId);
+    if (existing) {
+      existing.groupNames.push(row.groupName);
+      continue;
+    }
+    byUser.set(row.userId, {
+      userId: row.userId,
+      email: row.email,
+      groupNames: [row.groupName],
+      user: buildUserSummary({ id: row.userId, name: row.userName }),
+    });
+  }
+
+  return [...byUser.values()];
+};
+
+/**
+ * Grants org admin. Re-granting someone previously removed revives their row
+ * rather than inserting: the unique index only covers live rows, so repeated
+ * grant/revoke cycles would otherwise pile up a row each time.
+ */
+export const grantOrganizationAdmin = async (input: {
+  organizationId: string;
+  userId: string;
+  grantedByUserId: string;
+  /**
+   * Re-checked inside the transaction, under the organization lock. The
+   * caller's own check races the revocation in `handleDeleteGroupUser`: it
+   * takes the same lock, so without this a grant could be written for someone
+   * whose last membership was removed concurrently — and nothing would ever
+   * auto-revoke it, since there is no membership left to remove.
+   */
+  assertStillEligible?: (tx: DbTransaction) => Promise<boolean>;
+}): Promise<void> => {
+  await db.transaction(async (tx) => {
+    await lockOrganization(input.organizationId, tx);
+
+    if (input.assertStillEligible && !(await input.assertStillEligible(tx))) {
+      throw new AppError({
+        message: "This user is not a member of any group in this organization",
+        logging: true,
+        code: 422,
+        context: { organizationId: input.organizationId, target: input.userId },
+      });
+    }
+
+    const revived = await tx
+      .update(organizationUsers)
+      .set({ deletedAt: null, grantedByUserId: input.grantedByUserId })
+      .where(
+        and(
+          eq(organizationUsers.organizationId, input.organizationId),
+          eq(organizationUsers.userId, input.userId)
+        )
+      )
+      .returning({ id: organizationUsers.id });
+
+    if (revived.length > 0) return;
+
+    await tx
+      .insert(organizationUsers)
+      .values({
+        id: generateRandomUUID(),
+        organizationId: input.organizationId,
+        userId: input.userId,
+        grantedByUserId: input.grantedByUserId,
+      })
+      .onConflictDoNothing();
+  });
+};
+
+export const removeOrganizationAdmin = async (
+  organizationId: string,
+  userId: string,
+  tx?: DbTransaction
+): Promise<boolean> => {
+  const removed = await (tx ?? db)
+    .update(organizationUsers)
+    .set({ deletedAt: new Date() })
+    .where(
+      and(
+        eq(organizationUsers.organizationId, organizationId),
+        eq(organizationUsers.userId, userId),
+        isNull(organizationUsers.deletedAt)
+      )
+    )
+    .returning({ id: organizationUsers.id });
+
+  return removed.length > 0;
+};
+
+/** Bulk lookup for the per-group organization badge — one query, not one per group. */
+export const getOrganizationsByIds = async (
+  organizationIds: string[],
+  tx?: DbTransaction
+): Promise<OrganizationType[]> => {
+  if (organizationIds.length === 0) return [];
+  return (tx ?? db).select().from(organizations).where(inArray(organizations.id, organizationIds));
 };
 
 /**

--- a/src/services/organization/types.ts
+++ b/src/services/organization/types.ts
@@ -30,7 +30,9 @@ export type OrganizationCandidate = {
 export const validatePatchOrganization = z
   .object({
     name: z.string().trim().min(1).max(120).optional(),
-    billingEmail: z.email().trim().toLowerCase().max(320).optional(),
+    // Normalise before validating: `z.email()` runs first in a chain, so a
+    // trailing space would be rejected rather than trimmed away.
+    billingEmail: z.string().trim().toLowerCase().pipe(z.email().max(320)).optional(),
   })
   .refine((body) => body.name !== undefined || body.billingEmail !== undefined, {
     message: "At least one field must be provided",

--- a/src/services/organization/types.ts
+++ b/src/services/organization/types.ts
@@ -1,3 +1,6 @@
+import { z } from "zod";
+import type { UserSummary } from "../../utils/userPresentation.js";
+
 export type OrganizationType = {
   id: string;
   name: string;
@@ -7,3 +10,37 @@ export type OrganizationType = {
   createdAt: Date;
   updatedAt: Date;
 };
+
+export type OrganizationAdminListItem = {
+  userId: string;
+  email: string;
+  /** The owner is synthesised from `organizations.ownerUserId`, not stored. */
+  isOwner: boolean;
+  grantedAt: Date | null;
+  user: UserSummary;
+};
+
+export type OrganizationCandidate = {
+  userId: string;
+  email: string;
+  groupNames: string[];
+  user: UserSummary;
+};
+
+export const validatePatchOrganization = z
+  .object({
+    name: z.string().trim().min(1).max(120).optional(),
+    billingEmail: z.email().trim().toLowerCase().max(320).optional(),
+  })
+  .refine((body) => body.name !== undefined || body.billingEmail !== undefined, {
+    message: "At least one field must be provided",
+  });
+
+export type ValidatedPatchOrganizationType = z.infer<typeof validatePatchOrganization>;
+
+// better-auth user ids are opaque non-UUID strings.
+export const validatePostOrganizationAdmin = z.object({
+  userId: z.string().min(1),
+});
+
+export type ValidatedPostOrganizationAdminType = z.infer<typeof validatePostOrganizationAdmin>;

--- a/src/tests/e2e/organizationAdmin.e2e.test.ts
+++ b/src/tests/e2e/organizationAdmin.e2e.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "../../db/db.js";
+import { groups } from "../../db/schema/group-schema.js";
+import { groupUsers } from "../../db/schema/group-users-schema.js";
+import { organizationUsers } from "../../db/schema/organization-users-schema.js";
+import { subscriptionPlan, subscriptionStatus } from "../../db/schema/subscription-schema.js";
+import { createTestUser, cleanupTestData } from "./helpers/testSetup.js";
+import {
+  ensureOrganizationForUser,
+  grantOrganizationAdmin,
+  isOrganizationAdmin,
+  listOrganizationAdminCandidates,
+  listOrganizationAdmins,
+  removeOrganizationAdmin,
+} from "../../services/organization/organizationServices.js";
+import { resolveOrganizationBadges } from "../../services/organization/organizationBadge.js";
+import { upsertSubscription } from "../../services/billing/subscriptionServices.js";
+import { getGroupsWhereUserCanApprove } from "../../services/group/groupServices.js";
+import {
+  getAdministrableGroupIds,
+  resolveGroupAdmin,
+  validateUserGroupAccess,
+} from "../../controllers/groupUser/utils.js";
+
+/**
+ * Org admins administer an organization's groups without belonging to them,
+ * so the interesting cases all live in the gap between membership and
+ * organization authority. Run against a real database.
+ */
+describe("organization admins", () => {
+  let owner: { id: string };
+  /** Promoted to org admin; deliberately never a member of any group. */
+  let delegate: { id: string };
+  /** A plain member of the org's group — an org member, not an org admin. */
+  let member: { id: string };
+  /** Owns a different organization entirely. */
+  let outsider: { id: string };
+
+  let organizationId: string;
+  let outsiderOrganizationId: string;
+  let groupId: string;
+
+  const insertGroup = async (orgId: string, managerUserId: string, name: string) => {
+    const id = uuidv4();
+    await db.insert(groups).values({
+      id,
+      organizationId: orgId,
+      groupName: name,
+      managerUserId,
+    });
+    return id;
+  };
+
+  const addMember = (userId: string, targetGroupId: string, adminAccess = false) =>
+    db.insert(groupUsers).values({
+      id: uuidv4(),
+      userId,
+      groupId: targetGroupId,
+      viewAccess: true,
+      adminAccess,
+      approverAccess: false,
+      controlledUser: true,
+    });
+
+  beforeAll(async () => {
+    await cleanupTestData();
+
+    owner = await createTestUser("org-owner@test.com", "Org Owner", "password123");
+    delegate = await createTestUser("org-delegate@test.com", "Org Delegate", "password123");
+    member = await createTestUser("org-member@test.com", "Org Member", "password123");
+    outsider = await createTestUser("org-outsider@test.com", "Org Outsider", "password123");
+
+    organizationId = (await ensureOrganizationForUser(owner.id)).id;
+    outsiderOrganizationId = (await ensureOrganizationForUser(outsider.id)).id;
+
+    groupId = await insertGroup(organizationId, owner.id, "Engineering");
+    await addMember(owner.id, groupId, true);
+    await addMember(member.id, groupId);
+  });
+
+  afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  describe("who counts as an admin", () => {
+    it("treats the owner as an admin without storing a row", async () => {
+      expect(await isOrganizationAdmin(owner.id, organizationId)).toBe(true);
+
+      const rows = await db.select().from(organizationUsers);
+      expect(rows.some((row) => row.userId === owner.id)).toBe(false);
+    });
+
+    it("does not treat a group member as an org admin", async () => {
+      expect(await isOrganizationAdmin(member.id, organizationId)).toBe(false);
+    });
+
+    it("does not leak across organizations", async () => {
+      expect(await isOrganizationAdmin(owner.id, outsiderOrganizationId)).toBe(false);
+      expect(await isOrganizationAdmin(outsider.id, organizationId)).toBe(false);
+    });
+  });
+
+  describe("granting and revoking", () => {
+    it("grants, revokes and re-grants without piling up rows", async () => {
+      await grantOrganizationAdmin({
+        organizationId,
+        userId: delegate.id,
+        grantedByUserId: owner.id,
+      });
+      expect(await isOrganizationAdmin(delegate.id, organizationId)).toBe(true);
+
+      expect(await removeOrganizationAdmin(organizationId, delegate.id)).toBe(true);
+      expect(await isOrganizationAdmin(delegate.id, organizationId)).toBe(false);
+
+      await grantOrganizationAdmin({
+        organizationId,
+        userId: delegate.id,
+        grantedByUserId: owner.id,
+      });
+      expect(await isOrganizationAdmin(delegate.id, organizationId)).toBe(true);
+
+      const rows = await db.select().from(organizationUsers);
+      expect(rows.filter((row) => row.userId === delegate.id)).toHaveLength(1);
+    });
+
+    it("reports revoking a non-admin rather than silently succeeding", async () => {
+      expect(await removeOrganizationAdmin(organizationId, member.id)).toBe(false);
+    });
+
+    it("lists the owner first, then delegated admins", async () => {
+      const admins = await listOrganizationAdmins(organizationId);
+
+      expect(admins[0]?.userId).toBe(owner.id);
+      expect(admins[0]?.isOwner).toBe(true);
+      expect(admins.filter((admin) => admin.userId === owner.id)).toHaveLength(1);
+      expect(admins.some((admin) => admin.userId === delegate.id && !admin.isOwner)).toBe(true);
+    });
+  });
+
+  describe("candidates", () => {
+    it("offers the org's group members and excludes existing admins", async () => {
+      const candidates = await listOrganizationAdminCandidates(organizationId);
+      const ids = candidates.map((candidate) => candidate.userId);
+
+      expect(ids).toContain(member.id);
+      expect(ids).not.toContain(owner.id);
+      // Already an admin from the grant suite above.
+      expect(ids).not.toContain(delegate.id);
+      // Never in any of this organization's groups.
+      expect(ids).not.toContain(outsider.id);
+    });
+
+    it("names the groups each candidate belongs to", async () => {
+      const candidates = await listOrganizationAdminCandidates(organizationId);
+      const candidate = candidates.find((row) => row.userId === member.id);
+
+      expect(candidate?.groupNames).toEqual(["Engineering"]);
+    });
+  });
+
+  describe("group access", () => {
+    it("lets an org admin view and administer a group they do not belong to", async () => {
+      expect(await validateUserGroupAccess(delegate.id, groupId)).toBe(true);
+      expect(await resolveGroupAdmin(delegate.id, groupId)).toEqual({
+        canAdmin: true,
+        viaOrgAdmin: true,
+      });
+    });
+
+    it("marks a group admin's own membership as not coming from the org", async () => {
+      expect(await resolveGroupAdmin(owner.id, groupId)).toEqual({
+        canAdmin: true,
+        viaOrgAdmin: false,
+      });
+    });
+
+    it("keeps a plain member out of administration", async () => {
+      expect(await validateUserGroupAccess(member.id, groupId)).toBe(true);
+      expect(await resolveGroupAdmin(member.id, groupId)).toEqual({
+        canAdmin: false,
+        viaOrgAdmin: false,
+      });
+    });
+
+    it("gives an org admin no access to another organization's group", async () => {
+      const foreignGroupId = await insertGroup(
+        outsiderOrganizationId,
+        outsider.id,
+        "Other Company"
+      );
+
+      expect(await validateUserGroupAccess(delegate.id, foreignGroupId)).toBe(false);
+      expect(await resolveGroupAdmin(delegate.id, foreignGroupId)).toEqual({
+        canAdmin: false,
+        viaOrgAdmin: false,
+      });
+    });
+
+    it("grants no approver rights", async () => {
+      // The whole point of the boundary: administering a team is not the same
+      // as being allowed to decide its members' leave.
+      expect(await getGroupsWhereUserCanApprove([groupId], delegate.id)).toEqual([]);
+    });
+
+    it("counts the org's groups as administrable, membership aside", async () => {
+      expect(await getAdministrableGroupIds(delegate.id)).toContain(groupId);
+      expect(await getAdministrableGroupIds(member.id)).not.toContain(groupId);
+    });
+
+    it("stops reaching the group once the grant is revoked", async () => {
+      await removeOrganizationAdmin(organizationId, delegate.id);
+
+      expect(await validateUserGroupAccess(delegate.id, groupId)).toBe(false);
+      expect(await resolveGroupAdmin(delegate.id, groupId)).toEqual({
+        canAdmin: false,
+        viaOrgAdmin: false,
+      });
+
+      await grantOrganizationAdmin({
+        organizationId,
+        userId: delegate.id,
+        grantedByUserId: owner.id,
+      });
+    });
+  });
+
+  describe("organization badge", () => {
+    it("reports a free organization as inactive", async () => {
+      const badges = await resolveOrganizationBadges([organizationId]);
+
+      expect(badges.get(organizationId)).toMatchObject({
+        id: organizationId,
+        plan: "FREE",
+        status: null,
+        active: false,
+      });
+    });
+
+    it("reports an active paid subscription", async () => {
+      await upsertSubscription(organizationId, {
+        plan: subscriptionPlan.Pro,
+        status: subscriptionStatus.Active,
+      });
+
+      const badges = await resolveOrganizationBadges([organizationId]);
+
+      expect(badges.get(organizationId)).toMatchObject({
+        plan: "PRO",
+        status: subscriptionStatus.Active,
+        active: true,
+      });
+    });
+
+    it("reports a lapsed subscription past its grace as inactive", async () => {
+      await upsertSubscription(organizationId, {
+        plan: subscriptionPlan.Pro,
+        status: subscriptionStatus.PastDue,
+        graceEndsAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      const badge = (await resolveOrganizationBadges([organizationId])).get(organizationId);
+
+      expect(badge?.active).toBe(false);
+      // The plan drops to Free once grace expires, which is what the badge
+      // must show — claiming Pro would promise limits the guards no longer give.
+      expect(badge?.plan).toBe("FREE");
+    });
+
+    it("resolves several organizations in one pass", async () => {
+      const badges = await resolveOrganizationBadges([organizationId, outsiderOrganizationId]);
+
+      expect(badges.size).toBe(2);
+      expect(badges.get(outsiderOrganizationId)?.plan).toBe("FREE");
+    });
+  });
+});

--- a/src/tests/e2e/organizationAdminApi.e2e.test.ts
+++ b/src/tests/e2e/organizationAdminApi.e2e.test.ts
@@ -1,0 +1,407 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { v4 as uuidv4 } from "uuid";
+import type { Express } from "express";
+import { createServer } from "../../server.js";
+import { db } from "../../db/db.js";
+import { groups } from "../../db/schema/group-schema.js";
+import { groupUsers } from "../../db/schema/group-users-schema.js";
+import { userYearQuotas } from "../../db/schema/user-year-quotas-schema.js";
+import { createTestUser, cleanupTestData } from "./helpers/testSetup.js";
+import { authCookieFor } from "./helpers/authHelper.js";
+import {
+  ensureOrganizationForUser,
+  grantOrganizationAdmin,
+  isOrganizationAdmin,
+} from "../../services/organization/organizationServices.js";
+
+/**
+ * The org-admin authority as the HTTP surface actually exposes it. The service
+ * helpers have their own suite; this one exists because those helpers being
+ * right is worthless if no handler calls them — reverting the widening must
+ * fail here.
+ */
+describe("organization admin over the API", () => {
+  let app: Express;
+
+  let owner: { id: string };
+  /** Org admin, deliberately never a member of the group. */
+  let delegate: { id: string };
+  let member: { id: string };
+  let outsider: { id: string };
+
+  let ownerCookie: string;
+  let delegateCookie: string;
+  let outsiderCookie: string;
+
+  let organizationId: string;
+  let groupId: string;
+
+  beforeAll(async () => {
+    await cleanupTestData();
+    app = createServer();
+
+    owner = await createTestUser("api-owner@test.com", "Olivia Owner", "password123");
+    delegate = await createTestUser("api-delegate@test.com", "Dana Delegate", "password123");
+    member = await createTestUser("api-member@test.com", "Milo Member", "password123");
+    outsider = await createTestUser("api-outsider@test.com", "Otto Outsider", "password123");
+
+    organizationId = (await ensureOrganizationForUser(owner.id)).id;
+
+    groupId = uuidv4();
+    await db.insert(groups).values({
+      id: groupId,
+      organizationId,
+      groupName: "Engineering",
+      managerUserId: owner.id,
+      mainApprovalUser: owner.id,
+    });
+
+    await db.insert(groupUsers).values([
+      {
+        id: uuidv4(),
+        userId: owner.id,
+        groupId,
+        viewAccess: true,
+        adminAccess: true,
+        approverAccess: true,
+        controlledUser: true,
+      },
+      {
+        id: uuidv4(),
+        userId: member.id,
+        groupId,
+        viewAccess: true,
+        adminAccess: false,
+        approverAccess: false,
+        controlledUser: true,
+      },
+    ]);
+
+    await db.insert(userYearQuotas).values({
+      id: uuidv4(),
+      userId: member.id,
+      groupId,
+      relatedYear: "2026",
+      vacationDays: 20,
+      homeOfficeDays: 0,
+    });
+
+    await grantOrganizationAdmin({
+      organizationId,
+      userId: delegate.id,
+      grantedByUserId: owner.id,
+    });
+
+    ownerCookie = await authCookieFor(owner.id);
+    delegateCookie = await authCookieFor(delegate.id);
+    outsiderCookie = await authCookieFor(outsider.id);
+  });
+
+  afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  describe("reaching a group they do not belong to", () => {
+    it("returns the group with organization authority flagged", async () => {
+      const res = await request(app)
+        .get(`/api/group/${groupId}`)
+        .set("Cookie", delegateCookie)
+        .expect(200);
+
+      expect(res.body.access).toEqual({
+        canView: true,
+        canAdmin: true,
+        viaOrgAdmin: true,
+        isMember: false,
+      });
+      expect(res.body.organization).toMatchObject({ id: organizationId, plan: "FREE" });
+    });
+
+    it("keeps the group out of their own group list", async () => {
+      // `GET /api/group` also drives the dashboard and the request dialog, so a
+      // group they merely administer must not appear there.
+      const res = await request(app).get("/api/group").set("Cookie", delegateCookie).expect(200);
+
+      expect(res.body).toEqual([]);
+    });
+
+    it("lists the group's members", async () => {
+      const res = await request(app)
+        .get(`/api/group-user/${groupId}`)
+        .set("Cookie", delegateCookie)
+        .expect(200);
+
+      expect(res.body.map((row: { userId: string }) => row.userId)).toContain(member.id);
+    });
+
+    it("reads the group's quotas", async () => {
+      await request(app)
+        .get(`/api/quotas/${groupId}?year=2026`)
+        .set("Cookie", delegateCookie)
+        .expect(200);
+    });
+
+    it("changes a member's permissions", async () => {
+      await request(app)
+        .put("/api/group-user")
+        .set("Cookie", delegateCookie)
+        .send({
+          groupId,
+          data: [
+            {
+              userId: member.id,
+              viewAccess: true,
+              adminAccess: true,
+              approverAccess: false,
+              controlledUser: true,
+            },
+          ],
+        })
+        .expect(200);
+    });
+
+    it("edits the group's default quotas", async () => {
+      await request(app)
+        .put(`/api/group/${groupId}/quotas`)
+        .set("Cookie", delegateCookie)
+        .send({ defaultVacationDays: 25, defaultHomeOfficeDays: 5 })
+        .expect(200);
+    });
+
+    it("edits the group's working days", async () => {
+      await request(app)
+        .put(`/api/group/${groupId}/working-days`)
+        .set("Cookie", delegateCookie)
+        .send({ workingDays: [1, 2, 3, 4] })
+        .expect(200);
+    });
+
+    it("sets a member's individual quota", async () => {
+      await request(app)
+        .put(`/api/quotas/${groupId}`)
+        .set("Cookie", delegateCookie)
+        .send({
+          userId: member.id,
+          year: 2026,
+          vacationDays: 22,
+          homeOfficeDays: 3,
+          carriedOverDays: 0,
+        })
+        .expect(200);
+    });
+  });
+
+  describe("limits of the authority", () => {
+    it("refuses a stranger everywhere", async () => {
+      await request(app).get(`/api/group/${groupId}`).set("Cookie", outsiderCookie).expect(403);
+      await request(app)
+        .get(`/api/group-user/${groupId}`)
+        .set("Cookie", outsiderCookie)
+        .expect(403);
+      await request(app)
+        .put(`/api/group/${groupId}/quotas`)
+        .set("Cookie", outsiderCookie)
+        .send({ defaultVacationDays: 1, defaultHomeOfficeDays: 1 })
+        .expect(403);
+    });
+
+    it("will not let an org admin raise their own permissions", async () => {
+      // The escalation this closes: invite yourself in, then grant yourself the
+      // approver rights the organization role deliberately withholds.
+      await db.insert(groupUsers).values({
+        id: uuidv4(),
+        userId: delegate.id,
+        groupId,
+        viewAccess: true,
+        adminAccess: false,
+        approverAccess: false,
+        controlledUser: true,
+      });
+
+      await request(app)
+        .put("/api/group-user")
+        .set("Cookie", delegateCookie)
+        .send({
+          groupId,
+          data: [
+            {
+              userId: delegate.id,
+              viewAccess: true,
+              adminAccess: true,
+              approverAccess: true,
+              controlledUser: true,
+            },
+          ],
+        })
+        .expect(403);
+    });
+
+    it("will not let a repeated self-entry sneak the raise past the check", async () => {
+      // The handler applies every record in order, so checking only the first
+      // match would let a harmless one pass while a later one escalates.
+      await request(app)
+        .put("/api/group-user")
+        .set("Cookie", delegateCookie)
+        .send({
+          groupId,
+          data: [
+            {
+              userId: delegate.id,
+              viewAccess: true,
+              adminAccess: false,
+              approverAccess: false,
+              controlledUser: true,
+            },
+            {
+              userId: delegate.id,
+              viewAccess: true,
+              adminAccess: true,
+              approverAccess: true,
+              controlledUser: true,
+            },
+          ],
+        })
+        .expect(403);
+    });
+
+    it("will not let an org admin grant approver rights to anyone", async () => {
+      // Blocking only self-grants leaves the obvious way around it: invite a
+      // second account you control, then promote that one instead.
+      await request(app)
+        .put("/api/group-user")
+        .set("Cookie", delegateCookie)
+        .send({
+          groupId,
+          data: [
+            {
+              userId: member.id,
+              viewAccess: true,
+              adminAccess: false,
+              approverAccess: true,
+              controlledUser: true,
+            },
+          ],
+        })
+        .expect(403);
+    });
+
+    it("still lets an org admin manage the non-approver permissions", async () => {
+      await request(app)
+        .put("/api/group-user")
+        .set("Cookie", delegateCookie)
+        .send({
+          groupId,
+          data: [
+            {
+              userId: member.id,
+              viewAccess: true,
+              adminAccess: true,
+              approverAccess: false,
+              controlledUser: true,
+            },
+          ],
+        })
+        .expect(200);
+    });
+
+    it("will not let an org admin name themselves the group's approver", async () => {
+      // The approver columns are approval authority by another name; blocking
+      // only `approverAccess` would leave this route as the way around it.
+      await request(app)
+        .put(`/api/group/${groupId}/approvers`)
+        .set("Cookie", delegateCookie)
+        .send({ mainApprovalUser: delegate.id, tempApprovalUser: null })
+        .expect(403);
+    });
+
+    it("still lets an org admin name someone else the approver", async () => {
+      await request(app)
+        .put(`/api/group/${groupId}/approvers`)
+        .set("Cookie", delegateCookie)
+        .send({ mainApprovalUser: member.id, tempApprovalUser: null })
+        .expect(200);
+    });
+
+    it("revokes the org grant when they leave the organization's last group", async () => {
+      expect(await isOrganizationAdmin(delegate.id, organizationId)).toBe(true);
+
+      await request(app)
+        .delete(`/api/group-user/${groupId}/${delegate.id}`)
+        .set("Cookie", ownerCookie)
+        .expect(200);
+
+      expect(await isOrganizationAdmin(delegate.id, organizationId)).toBe(false);
+      await request(app).get(`/api/group/${groupId}`).set("Cookie", delegateCookie).expect(403);
+    });
+  });
+
+  describe("organization endpoints", () => {
+    it("lets the owner rename the organization", async () => {
+      await request(app)
+        .patch("/api/organization")
+        .set("Cookie", ownerCookie)
+        .send({ name: "Acme Renamed" })
+        .expect(200);
+    });
+
+    it("refuses a delegated admin the billing address", async () => {
+      await grantOrganizationAdmin({
+        organizationId,
+        userId: delegate.id,
+        grantedByUserId: owner.id,
+      });
+
+      await request(app)
+        .patch(`/api/organization?organizationId=${organizationId}`)
+        .set("Cookie", delegateCookie)
+        .send({ billingEmail: "attacker@evil.test" })
+        .expect(403);
+    });
+
+    it("refuses a delegated admin the candidate list and the grant routes", async () => {
+      await request(app)
+        .get(`/api/organization/candidates?organizationId=${organizationId}`)
+        .set("Cookie", delegateCookie)
+        .expect(403);
+
+      await request(app)
+        .post(`/api/organization/admins?organizationId=${organizationId}`)
+        .set("Cookie", delegateCookie)
+        .send({ userId: outsider.id })
+        .expect(403);
+    });
+
+    it("refuses to grant admin to someone outside the organization's groups", async () => {
+      await request(app)
+        .post("/api/organization/admins")
+        .set("Cookie", ownerCookie)
+        .send({ userId: outsider.id })
+        .expect(422);
+    });
+
+    it("hides the billing address from a delegated admin's own read", async () => {
+      const res = await request(app)
+        .get(`/api/organization?organizationId=${organizationId}`)
+        .set("Cookie", delegateCookie)
+        .expect(200);
+
+      expect(res.body.organization.billingEmail).toBeNull();
+      expect(res.body.organization.isOwner).toBe(false);
+    });
+
+    it("gives the owner the billing address", async () => {
+      const res = await request(app)
+        .get("/api/organization")
+        .set("Cookie", ownerCookie)
+        .expect(200);
+
+      expect(res.body.organization.isOwner).toBe(true);
+      expect(res.body.organization.billingEmail).toBe("api-owner@test.com");
+    });
+
+    it("404s for a user with no organization at all", async () => {
+      await request(app).get("/api/organization").set("Cookie", outsiderCookie).expect(404);
+    });
+  });
+});

--- a/src/tests/e2e/organizationAdminApi.e2e.test.ts
+++ b/src/tests/e2e/organizationAdminApi.e2e.test.ts
@@ -315,11 +315,23 @@ describe("organization admin over the API", () => {
         .expect(403);
     });
 
-    it("still lets an org admin name someone else the approver", async () => {
+    it("will not let an org admin add anyone else as approver either", async () => {
+      // Blocking only self leaves the proxy: name a second account you control
+      // as `mainApprovalUser` instead.
       await request(app)
         .put(`/api/group/${groupId}/approvers`)
         .set("Cookie", delegateCookie)
         .send({ mainApprovalUser: member.id, tempApprovalUser: null })
+        .expect(403);
+    });
+
+    it("lets an org admin re-submit the approvers a group already has", async () => {
+      // Keeping the current assignment is not an escalation, and the settings
+      // form submits the whole object.
+      await request(app)
+        .put(`/api/group/${groupId}/approvers`)
+        .set("Cookie", delegateCookie)
+        .send({ mainApprovalUser: owner.id, tempApprovalUser: null })
         .expect(200);
     });
 
@@ -378,6 +390,37 @@ describe("organization admin over the API", () => {
         .set("Cookie", ownerCookie)
         .send({ userId: outsider.id })
         .expect(422);
+    });
+
+    it("reports an existing administrator as a conflict, not as a non-member", async () => {
+      // They are excluded from the candidate list for being an admin already,
+      // so "not a member of any group" would be a flatly wrong answer.
+      await request(app)
+        .post("/api/organization/admins")
+        .set("Cookie", ownerCookie)
+        .send({ userId: delegate.id })
+        .expect(409);
+    });
+
+    it("trims and lower-cases a billing address rather than rejecting it", async () => {
+      const res = await request(app)
+        .patch("/api/organization")
+        .set("Cookie", ownerCookie)
+        .send({ billingEmail: "  Billing@Acme.TEST  " })
+        .expect(200);
+
+      expect(res.body.billingEmail).toBe("billing@acme.test");
+
+      // Restore, so this case does not decide what the later reads observe.
+      await request(app)
+        .patch("/api/organization")
+        .set("Cookie", ownerCookie)
+        .send({ billingEmail: "api-owner@test.com" })
+        .expect(200);
+    });
+
+    it("rejects a patch that names no field", async () => {
+      await request(app).patch("/api/organization").set("Cookie", ownerCookie).send({}).expect(422);
     });
 
     it("hides the billing address from a delegated admin's own read", async () => {


### PR DESCRIPTION
## What

Adds `organization_users`, holding ADMIN grants an organization owner delegates to one of the organization's own people. A delegate administers **every group in that organization** — members, quotas, settings, invites — **without belonging to any of them**.

The owner is deliberately *not* stored in that table; it stays `organizations.ownerUserId`, mirroring how a group's manager sits on `groups.managerUserId` rather than carrying a `group_users` row. Org admin is therefore always owner-or-row, and `isOrganizationAdmin` is the only correct way to ask.

## The invariant that shaped the design

**Administration, never approval.** `assertGroupAdmin` and `validateUserGroupAccess` accept org admins; `getGroupsWhereUserCanApprove` does not. Three separate guards hold that line, because review found three ways around a naive version:

| Attack | Guard |
|---|---|
| Invite yourself into the group, then grant yourself `approverAccess` | Nobody may raise their **own** permissions |
| Send a duplicated self-entry so a harmless first record passes while a later one escalates | The check inspects **every** record for the caller, not just the first |
| Name yourself `mainApprovalUser` — approval authority under a different column | A caller acting `viaOrgAdmin` may not name themselves an approver |
| Invite a **second account of your own** and promote that instead | A caller acting `viaOrgAdmin` may not grant `approverAccess` to **anyone** |

## Other endpoints

- `GET /api/group/:groupId` — the group plus the caller's effective access (`canView`, `canAdmin`, `viaOrgAdmin`, `isMember`), so an org admin can open a group's detail screen. `GET /api/group` stays membership-only **on purpose**: it also drives the dashboard, the calendar and the request dialog, and must not surface other people's teams.
- Both group routes carry an organization badge (name, plan, status). No billing internals — the billing address, renewal date and amounts stay on `/api/billing/subscription`, which resolves the organization by ownership.
- `/api/organization/*` for the management screen. Renaming is open to any org admin; `billingEmail`, granting and revoking are owner-only. Candidates for a grant are the organization's own group members — deliberately **not** a lookup by email, which would let an owner probe whether an address has an account.

## Correctness details worth a reviewer's eye

- **The grant is scoped to membership.** `handleDeleteGroupUser` revokes it when the user leaves the organization's last group, under `lockOrganization` taken *before* the group lock — the count spans the organization, and the reverse order deadlocks against FK-checked writes to `group_users`.
- **Grant/revoke race.** The candidate check is re-run inside `grantOrganizationAdmin` under the same organization lock, or a concurrent removal could leave a grant that nothing would ever auto-revoke.
- **Mirroring is confined to one organization** — someone who owns org A and holds a grant in org B could otherwise project B's leave into A.
- **Indexed lookups.** `isOrganizationAdmin` and `getAdminOrganizationsForUser` are two index-backed queries each, not one join with an `OR` spanning a nullable joined table (which no index can drive). They run on every group-scoped authorization check.

## Review findings fixed

Three review rounds. Blocker: `GET /api/quotas/:groupId` was the one quota endpoint left un-widened, so the Quotas tab would 403 while the write endpoint beside it returned 200. Should-fixes: all four escalation paths above, the lock-order inversion, the grant/revoke race, cross-organization mirroring, org grants outliving membership, non-indexable `OR`-joins, and an ambiguous default organization for a delegate who administers several.

## Verification

- 432 unit tests, 144 e2e tests (all green). `src/tests/e2e/organizationAdminApi.e2e.test.ts` drives the real HTTP surface as a delegate — it fails if the widening is reverted, which the first version of the test suite did not.
- Exercised in the browser against a real database: promoted a member to org admin, opened a group they do not belong to, edited its permissions and quotas, and confirmed every guard returns 403 live while the legitimate actions return 200.

## Deploy order

**Merge and deploy this before** Daniel88dev/flexi-day#56 — the frontend needs `/api/organization/*` and `GET /api/group/:groupId`.

⚠️ **Migration `0013` needs applying by hand**, per the usual process. It is a plain `CREATE TABLE` plus indexes, no backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization administration tools for viewing organizations, updating details, managing administrators, and reviewing eligible candidates.
  * Added group details with access permissions and organization subscription badges.
  * Organization administrators can manage eligible group settings and quotas.
* **Bug Fixes**
  * Improved authorization consistency across groups, quotas, mirrors, approvers, and working-day settings.
  * Prevented unauthorized permission escalation and restricted billing changes to owners.
  * Automatically removes organization-admin access when a user leaves their final group.
* **Documentation**
  * Updated API documentation for organization-admin permissions and restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->