### PR TITLE
feat(auth): Microsoft Entra ID sign-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,28 @@ DEV_TOOLS_TOKEN=            # >= 16 chars; required only when enabled
 DEV_SEED_EMAIL_DOMAIN=dev.local   # the only domain seeding may create or reset
 
 # --- Google OAuth (optional) ---
+# Redirect URI to register: {BETTER_AUTH_URL}/api/auth/callback/google
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+
+# --- Microsoft Entra ID OAuth (optional) ---
+# Redirect URI to register: {BETTER_AUTH_URL}/api/auth/callback/microsoft
+# The provider is registered only when BOTH id and secret are set.
+# The app registration MUST request two optional ID-token claims (Entra ->
+# Token configuration), or sign-in misbehaves in ways that look like our bug:
+#   email     - without it a work account with no mailbox yields no address at
+#               all and the callback fails with error=email_not_found
+#   xms_edov  - Microsoft's "this domain is verified" flag. Without it every
+#               Entra address is treated as unverified, which is deliberate
+#               (a tenant admin can set `mail` to a domain they do not own),
+#               but it means users must confirm their address by email before
+#               they can redeem a team invite.
+MICROSOFT_CLIENT_ID=
+MICROSOFT_CLIENT_SECRET=
+# Directory the sign-in is issued against. Default "common" = any work/school
+# account plus personal Microsoft accounts. Use "organizations" to exclude
+# personal accounts, or a tenant GUID to allow one directory only.
+MICROSOFT_TENANT_ID=
 
 # --- App / URLs ---
 APP_URL=http://localhost:3000

--- a/.env.example
+++ b/.env.example
@@ -24,15 +24,15 @@ GOOGLE_CLIENT_SECRET=
 # --- Microsoft Entra ID OAuth (optional) ---
 # Redirect URI to register: {BETTER_AUTH_URL}/api/auth/callback/microsoft
 # The provider is registered only when BOTH id and secret are set.
-# The app registration MUST request two optional ID-token claims (Entra ->
-# Token configuration), or sign-in misbehaves in ways that look like our bug:
-#   email     - without it a work account with no mailbox yields no address at
-#               all and the callback fails with error=email_not_found
-#   xms_edov  - Microsoft's "this domain is verified" flag. Without it every
-#               Entra address is treated as unverified, which is deliberate
-#               (a tenant admin can set `mail` to a domain they do not own),
-#               but it means users must confirm their address by email before
-#               they can redeem a team invite.
+# The app registration MUST request the `email` optional ID-token claim (Entra
+# -> Token configuration). Without it a work account with no mailbox yields no
+# address at all and the callback fails with error=email_not_found.
+#
+# No Entra claim marks the address verified here. `xms_edov` and friends attest
+# the DOMAIN, not that the person signing in owns the mailbox — a directory
+# admin can point a user's mail attribute at any address in a domain they
+# administer — so social sign-in always lands unverified and the user confirms
+# the address through Flexi Day's own email, same as an email/password signup.
 MICROSOFT_CLIENT_ID=
 MICROSOFT_CLIENT_SECRET=
 # Directory the sign-in is issued against. Default "common" = any work/school

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,13 @@ type AuthConfig = {
   // provisioned. The client secret is sensitive; the client id is not.
   googleClientId?: string;
   googleClientSecret?: string;
+  // Microsoft Entra ID OAuth. Same opt-in shape as Google. `tenantId` selects
+  // which directory may sign in — "common" (the better-auth default) accepts
+  // any work/school account plus personal Microsoft accounts; a GUID restricts
+  // sign-in to that single tenant.
+  microsoftClientId?: string;
+  microsoftClientSecret?: string;
+  microsoftTenantId?: string;
 };
 
 type EmailConfig = {
@@ -201,6 +208,9 @@ export const config: Config = {
           trustedOrigins: process.env.TRUSTED_ORIGINS?.split(",") ?? ["http://localhost:3000"],
           googleClientId: process.env.GOOGLE_CLIENT_ID,
           googleClientSecret: process.env.GOOGLE_CLIENT_SECRET,
+          microsoftClientId: process.env.MICROSOFT_CLIENT_ID,
+          microsoftClientSecret: process.env.MICROSOFT_CLIENT_SECRET,
+          microsoftTenantId: process.env.MICROSOFT_TENANT_ID,
         }
       : undefined,
   email: {

--- a/src/controllers/groupUser/handlePostGroupUser.ts
+++ b/src/controllers/groupUser/handlePostGroupUser.ts
@@ -51,6 +51,24 @@ export const handlePostGroupUser = async (req: Request, res: Response) => {
       });
     }
 
+    // The address binding below is only worth as much as the address behind it.
+    // Social sign-in can hand us a session whose address the provider never
+    // vouched for — Microsoft Entra lets a tenant admin set `mail` to any
+    // string, and better-auth then marks the account unverified rather than
+    // refusing it. Without this, someone controlling their own Entra tenant
+    // could claim a colleague's address and redeem an invite issued to them.
+    if (validateLink.email && !auth.emailVerified) {
+      throw new AppError({
+        message: "Verify your email address before joining a team",
+        logging: true,
+        code: 403,
+        context: {
+          url: req.url,
+          userId: auth.userId,
+        },
+      });
+    }
+
     // Invites issued to an address may only be redeemed by that address, so a
     // forwarded or leaked code is useless to anyone else. Rows with no email
     // predate email invites and stay unrestricted.

--- a/src/routes/groupUsersRouter.ts
+++ b/src/routes/groupUsersRouter.ts
@@ -79,7 +79,9 @@ export const groupUsersRouter = (): Router => {
    *           lapsed. `errors[].context` carries
    *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
    *       '403':
-   *         description: Invite was issued for a different email address
+   *         description: >-
+   *           The caller's email address is unverified, or the invite was
+   *           issued for a different address. Distinguish by `message`.
    *       '404':
    *         description: Invalid, revoked or expired code
    *       '409':

--- a/src/tests/e2e/inviteRedemption.e2e.test.ts
+++ b/src/tests/e2e/inviteRedemption.e2e.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { v4 as uuidv4 } from "uuid";
+import type { Request, Response } from "express";
+import { db } from "../../db/db.js";
+import { groups } from "../../db/schema/group-schema.js";
+import { groupUsers } from "../../db/schema/group-users-schema.js";
+import { inviteLink } from "../../db/schema/invite-link-schema.js";
+import { eq } from "drizzle-orm";
+import { createTestUser, cleanupTestData } from "./helpers/testSetup.js";
+import { handlePostGroupUser } from "../../controllers/groupUser/handlePostGroupUser.js";
+import { ensureOrganizationForUser } from "../../services/organization/organizationServices.js";
+import { generateInviteCode } from "../../utils/inviteCode.js";
+
+/**
+ * An email-bound invite is only as strong as the address on the session that
+ * redeems it. Social sign-in can produce a session whose address the provider
+ * never vouched for — Microsoft Entra lets a tenant admin set `mail` freely —
+ * so redemption must require a verified address. Runs against a real database.
+ */
+describe("invite redemption email binding", () => {
+  let owner: { id: string; email: string };
+  let groupId: string;
+
+  const redeem = async (
+    code: string,
+    session: { userId: string; userEmail: string; emailVerified: boolean }
+  ) => {
+    const req = {
+      url: `/api/group-user/${code}`,
+      params: { validationCode: code },
+      auth: {
+        sessionId: uuidv4(),
+        userName: "Redeemer",
+        ...session,
+      },
+    } as unknown as Request;
+
+    const res = {
+      status() {
+        return this;
+      },
+      json() {
+        return this;
+      },
+    } as unknown as Response;
+
+    return handlePostGroupUser(req, res);
+  };
+
+  const issueInvite = async (email: string | null) => {
+    // Must be a real code: the handler runs it through normalizeInviteCode
+    // before touching the database.
+    const code = generateInviteCode();
+    await db.insert(inviteLink).values({
+      id: uuidv4(),
+      groupId,
+      code,
+      email,
+      invitedByUserId: owner.id,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    });
+    return code;
+  };
+
+  beforeAll(async () => {
+    await cleanupTestData();
+    owner = await createTestUser("invite-owner@test.com", "Invite Owner", "password123");
+    const organization = await ensureOrganizationForUser(owner.id);
+
+    groupId = uuidv4();
+    await db.insert(groups).values({
+      id: groupId,
+      organizationId: organization.id,
+      groupName: "Invite Target",
+      managerUserId: owner.id,
+      defaultVacationDays: 20,
+      defaultHomeOfficeDays: 5,
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  it("refuses an email-bound invite when the session address is unverified", async () => {
+    const invited = await createTestUser("hijack-target@test.com", "Target", "password123");
+    const code = await issueInvite(invited.email);
+
+    // The exact shape of an Entra sign-in whose tenant never proved it owns the
+    // domain: the address matches the invite, but nobody vouched for it.
+    await expect(
+      redeem(code, { userId: invited.id, userEmail: invited.email, emailVerified: false })
+    ).rejects.toMatchObject({ code: 403 });
+
+    const members = await db.select().from(groupUsers).where(eq(groupUsers.groupId, groupId));
+    expect(members).toHaveLength(0);
+  });
+
+  it("admits the invited address once it is verified", async () => {
+    const invited = await createTestUser("verified-joiner@test.com", "Joiner", "password123");
+    const code = await issueInvite(invited.email);
+
+    await expect(
+      redeem(code, { userId: invited.id, userEmail: invited.email, emailVerified: true })
+    ).resolves.toBeDefined();
+
+    const members = await db.select().from(groupUsers).where(eq(groupUsers.userId, invited.id));
+    expect(members).toHaveLength(1);
+  });
+
+  it("still refuses a verified session whose address differs from the invite", async () => {
+    const stranger = await createTestUser("stranger@test.com", "Stranger", "password123");
+    const code = await issueInvite("someone-else@test.com");
+
+    await expect(
+      redeem(code, { userId: stranger.id, userEmail: stranger.email, emailVerified: true })
+    ).rejects.toMatchObject({ code: 403 });
+  });
+
+  it("leaves pre-email invites (null email) unrestricted", async () => {
+    const legacy = await createTestUser("legacy-joiner@test.com", "Legacy", "password123");
+    const code = await issueInvite(null);
+
+    await expect(
+      redeem(code, { userId: legacy.id, userEmail: legacy.email, emailVerified: false })
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/tests/utils/socialProviders.test.ts
+++ b/src/tests/utils/socialProviders.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildSocialProviders, entraEmailIsVerified } from "../../utils/socialProviders.js";
+import { buildSocialProviders } from "../../utils/socialProviders.js";
 
 const microsoft = { microsoftClientId: "id", microsoftClientSecret: "secret" };
 const google = { googleClientId: "id", googleClientSecret: "secret" };
@@ -37,37 +37,48 @@ describe("buildSocialProviders", () => {
       buildSocialProviders({ ...microsoft, microsoftTenantId: "a-guid" })?.microsoft?.tenantId
     ).toBe("a-guid");
   });
-
-  it("only marks the Microsoft email verified when Entra vouches for the domain", () => {
-    const map = buildSocialProviders(microsoft)?.microsoft?.mapProfileToUser;
-    // Asserts the resulting emailVerified, not merely the shape: better-auth
-    // spreads this over its own claim-derived value, so an absent key would
-    // hand the decision back to claims a tenant admin controls.
-    expect(map?.({ xms_edov: "1" })).toEqual({ emailVerified: true });
-    expect(map?.({ xms_edov: "0" })).toEqual({ emailVerified: false });
-    expect(map?.({})).toEqual({ emailVerified: false });
-  });
 });
 
-describe("entraEmailIsVerified", () => {
-  // Entra sends this as the string "1", not the boolean better-auth's
-  // MicrosoftEntraIDProfile declares — confirmed against a real ID token, where
-  // reading it as a boolean silently left a vouched-for address unverified.
-  // Both forms must work, and only an affirmative value may pass.
-  it.each([
-    [{ xms_edov: "1" }, true],
-    [{ xms_edov: true }, true],
-    [{ xms_edov: 1 }, true],
-    [{ xms_edov: "true" }, true],
-    [{ xms_edov: "0" }, false],
-    [{ xms_edov: false }, false],
-    [{ xms_edov: 0 }, false],
-    [{ xms_edov: "" }, false],
-    [{ xms_edov: "yes" }, false],
-    [{}, false],
-    [{ xms_edov: undefined }, false],
-    [{ xms_edov: null }, false],
-  ])("%o -> %s", (profile, expected) => {
-    expect(entraEmailIsVerified(profile)).toBe(expected);
+/**
+ * The address on a session is what lets someone redeem a team invite bound to
+ * it (`handlePostGroupUser`), so no provider claim may stand in for Flexi Day's
+ * own email challenge. A directory administrator can set a user's mail
+ * attribute to any address in a domain they administer, and every claim below
+ * still comes back looking verified.
+ */
+describe("provider-supplied email is never trusted", () => {
+  const claims = [
+    ["Entra domain-owner flag, boolean", { xms_edov: true }],
+    ["Entra domain-owner flag, string form Entra actually sends", { xms_edov: "1" }],
+    ["OIDC email_verified", { email_verified: true }],
+    ["OIDC email_verified, string form", { email_verified: "true" }],
+    ["Entra verified primary email", { verified_primary_email: ["someone@example.com"] }],
+    [
+      "every affirmative claim at once",
+      {
+        xms_edov: "1",
+        email_verified: true,
+        verified_primary_email: ["someone@example.com"],
+      },
+    ],
+    ["no claims at all", {}],
+  ] as const;
+
+  it.each(claims)("microsoft: %s -> unverified", (_label, profile) => {
+    const map = buildSocialProviders(microsoft)?.microsoft?.mapProfileToUser;
+    expect(map?.(profile)).toEqual({ emailVerified: false });
+  });
+
+  it.each(claims)("google: %s -> unverified", (_label, profile) => {
+    const map = buildSocialProviders(google)?.google?.mapProfileToUser;
+    expect(map?.(profile)).toEqual({ emailVerified: false });
+  });
+
+  it("states emailVerified rather than omitting it", () => {
+    // better-auth spreads mapProfileToUser's result OVER its own claim-derived
+    // value, so returning {} would hand the decision straight back to the
+    // provider claims this whole rule exists to distrust.
+    const result = buildSocialProviders(microsoft)?.microsoft?.mapProfileToUser?.({});
+    expect(result).toHaveProperty("emailVerified");
   });
 });

--- a/src/tests/utils/socialProviders.test.ts
+++ b/src/tests/utils/socialProviders.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { buildSocialProviders, entraEmailIsVerified } from "../../utils/socialProviders.js";
+
+const microsoft = { microsoftClientId: "id", microsoftClientSecret: "secret" };
+const google = { googleClientId: "id", googleClientSecret: "secret" };
+
+describe("buildSocialProviders", () => {
+  it("returns undefined when nothing is configured", () => {
+    expect(buildSocialProviders(undefined)).toBeUndefined();
+    expect(buildSocialProviders({})).toBeUndefined();
+  });
+
+  it.each([
+    ["google", { googleClientId: "id" }],
+    ["google", { googleClientSecret: "secret" }],
+    ["microsoft", { microsoftClientId: "id" }],
+    ["microsoft", { microsoftClientSecret: "secret" }],
+  ])("does not register %s from a half-configured pair", (_provider, credentials) => {
+    expect(buildSocialProviders(credentials)).toBeUndefined();
+  });
+
+  it("registers each provider independently of the other", () => {
+    expect(Object.keys(buildSocialProviders(google) ?? {})).toEqual(["google"]);
+    expect(Object.keys(buildSocialProviders(microsoft) ?? {})).toEqual(["microsoft"]);
+    expect(Object.keys(buildSocialProviders({ ...google, ...microsoft }) ?? {}).sort()).toEqual([
+      "google",
+      "microsoft",
+    ]);
+  });
+
+  it("defaults the Microsoft tenant to common and honours an override", () => {
+    expect(buildSocialProviders(microsoft)?.microsoft?.tenantId).toBe("common");
+    expect(buildSocialProviders({ ...microsoft, microsoftTenantId: "" })?.microsoft?.tenantId).toBe(
+      "common"
+    );
+    expect(
+      buildSocialProviders({ ...microsoft, microsoftTenantId: "a-guid" })?.microsoft?.tenantId
+    ).toBe("a-guid");
+  });
+
+  it("only marks the Microsoft email verified when Entra vouches for the domain", () => {
+    const map = buildSocialProviders(microsoft)?.microsoft?.mapProfileToUser;
+    // Asserts the resulting emailVerified, not merely the shape: better-auth
+    // spreads this over its own claim-derived value, so an absent key would
+    // hand the decision back to claims a tenant admin controls.
+    expect(map?.({ xms_edov: "1" })).toEqual({ emailVerified: true });
+    expect(map?.({ xms_edov: "0" })).toEqual({ emailVerified: false });
+    expect(map?.({})).toEqual({ emailVerified: false });
+  });
+});
+
+describe("entraEmailIsVerified", () => {
+  // Entra sends this as the string "1", not the boolean better-auth's
+  // MicrosoftEntraIDProfile declares — confirmed against a real ID token, where
+  // reading it as a boolean silently left a vouched-for address unverified.
+  // Both forms must work, and only an affirmative value may pass.
+  it.each([
+    [{ xms_edov: "1" }, true],
+    [{ xms_edov: true }, true],
+    [{ xms_edov: 1 }, true],
+    [{ xms_edov: "true" }, true],
+    [{ xms_edov: "0" }, false],
+    [{ xms_edov: false }, false],
+    [{ xms_edov: 0 }, false],
+    [{ xms_edov: "" }, false],
+    [{ xms_edov: "yes" }, false],
+    [{}, false],
+    [{ xms_edov: undefined }, false],
+    [{ xms_edov: null }, false],
+  ])("%o -> %s", (profile, expected) => {
+    expect(entraEmailIsVerified(profile)).toBe(expected);
+  });
+});

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -6,23 +6,13 @@ import { haveIBeenPwned, openAPI } from "better-auth/plugins";
 import { config } from "../config.js";
 import { emailSender } from "../services/email/index.js";
 import { logger } from "../middleware/logger.js";
+import { buildSocialProviders } from "./socialProviders.js";
 
 // better-auth's default verification-token expiry is 3600 s. Keep this string
 // in sync if `emailVerification.expiresIn` is ever configured below.
 const VERIFICATION_EXPIRES_IN = "1 hour";
 
-// Register the Google provider only when both credentials are present, so
-// non-production/test environments (and any deploy before the secrets are
-// wired) start cleanly instead of failing with an empty client id/secret.
-const socialProviders =
-  config?.auth?.googleClientId && config?.auth?.googleClientSecret
-    ? {
-        google: {
-          clientId: config.auth.googleClientId,
-          clientSecret: config.auth.googleClientSecret,
-        },
-      }
-    : undefined;
+const socialProviders = buildSocialProviders(config?.auth);
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {

--- a/src/utils/socialProviders.ts
+++ b/src/utils/socialProviders.ts
@@ -1,0 +1,71 @@
+type SocialCredentials = {
+  googleClientId?: string;
+  googleClientSecret?: string;
+  microsoftClientId?: string;
+  microsoftClientSecret?: string;
+  microsoftTenantId?: string;
+};
+
+/**
+ * Entra's `email` claim is directory data a tenant admin can set to an address
+ * they do not own, so it must never by itself mark an account verified — a
+ * verified address is what binds a team invite to its recipient. `xms_edov` is
+ * Microsoft's own "this domain is verified" signal, and it is an *optional*
+ * claim: unless the app registration requests it, this returns false and
+ * better-auth leaves the account unverified, which is the safe direction.
+ *
+ * Entra sends it as the STRING "1", not a boolean, despite better-auth's
+ * MicrosoftEntraIDProfile typing it `boolean` — observed in a real ID token on
+ * 2026-08-17. Accept both, and only an affirmative value: absent, "0" and
+ * false must all stay unverified.
+ */
+export const entraEmailIsVerified = (profile: { xms_edov?: unknown }): boolean => {
+  const claim = profile.xms_edov;
+  if (typeof claim === "boolean") return claim;
+  if (typeof claim === "number") return claim === 1;
+  if (typeof claim === "string") return claim === "1" || claim.toLowerCase() === "true";
+  return false;
+};
+
+/**
+ * Register each provider only when both of its credentials are present, so
+ * non-production/test environments (and any deploy before the secrets are
+ * wired) start cleanly instead of failing with an empty client id/secret.
+ * Returns `undefined` when nothing is configured, which is what better-auth
+ * expects for "no social sign-in".
+ */
+export function buildSocialProviders(auth?: SocialCredentials) {
+  const providers = {
+    ...(auth?.googleClientId && auth.googleClientSecret
+      ? {
+          google: {
+            clientId: auth.googleClientId,
+            clientSecret: auth.googleClientSecret,
+          },
+        }
+      : {}),
+    ...(auth?.microsoftClientId && auth.microsoftClientSecret
+      ? {
+          microsoft: {
+            clientId: auth.microsoftClientId,
+            clientSecret: auth.microsoftClientSecret,
+            // "common" also admits personal Microsoft accounts; set
+            // MICROSOFT_TENANT_ID to a directory GUID to pin sign-in to one org.
+            tenantId: auth.microsoftTenantId || "common",
+            // Always states emailVerified rather than returning {} for the
+            // unverified case. better-auth spreads this over its OWN computed
+            // value, which trusts `email_verified` / `verified_primary_email`
+            // — Entra optional claims sourced from directory attributes a
+            // tenant admin controls. Returning {} would leave that fallback in
+            // charge, so adding one claim in the portal could silently mark a
+            // hostile address verified and let it link onto a real account.
+            mapProfileToUser: (profile: { xms_edov?: unknown }) => ({
+              emailVerified: entraEmailIsVerified(profile),
+            }),
+          },
+        }
+      : {}),
+  };
+
+  return Object.keys(providers).length > 0 ? providers : undefined;
+}

--- a/src/utils/socialProviders.ts
+++ b/src/utils/socialProviders.ts
@@ -7,25 +7,26 @@ type SocialCredentials = {
 };
 
 /**
- * Entra's `email` claim is directory data a tenant admin can set to an address
- * they do not own, so it must never by itself mark an account verified — a
- * verified address is what binds a team invite to its recipient. `xms_edov` is
- * Microsoft's own "this domain is verified" signal, and it is an *optional*
- * claim: unless the app registration requests it, this returns false and
- * better-auth leaves the account unverified, which is the safe direction.
+ * A provider's word is not an email challenge.
  *
- * Entra sends it as the STRING "1", not a boolean, despite better-auth's
- * MicrosoftEntraIDProfile typing it `boolean` — observed in a real ID token on
- * 2026-08-17. Accept both, and only an affirmative value: absent, "0" and
- * false must all stay unverified.
+ * Both Google and Microsoft report an address as "verified" once the *domain*
+ * side checks out, which is not the same as proving the person signing in
+ * controls that mailbox. A Workspace or Entra administrator can set a user's
+ * mail attribute to any address in a domain they administer and the claim
+ * still comes back verified — Microsoft says outright that email claims must
+ * not drive access decisions. Flexi Day does drive one: `handlePostGroupUser`
+ * lets a verified address redeem a team invite bound to it.
+ *
+ * So social sign-in never confers a verified address. The account is created
+ * unverified and better-auth sends our own confirmation email, exactly as an
+ * email/password sign-up would; only clicking that link marks the address
+ * verified. Consequence worth knowing: because better-auth gates implicit
+ * account linking on this same flag, a social sign-in cannot attach itself to
+ * a pre-existing account with the same address — it reports
+ * `account_not_linked`, which the frontend renders as "use the method you
+ * signed up with".
  */
-export const entraEmailIsVerified = (profile: { xms_edov?: unknown }): boolean => {
-  const claim = profile.xms_edov;
-  if (typeof claim === "boolean") return claim;
-  if (typeof claim === "number") return claim === 1;
-  if (typeof claim === "string") return claim === "1" || claim.toLowerCase() === "true";
-  return false;
-};
+const NEVER_TRUST_PROVIDER_EMAIL = () => ({ emailVerified: false });
 
 /**
  * Register each provider only when both of its credentials are present, so
@@ -41,6 +42,7 @@ export function buildSocialProviders(auth?: SocialCredentials) {
           google: {
             clientId: auth.googleClientId,
             clientSecret: auth.googleClientSecret,
+            mapProfileToUser: NEVER_TRUST_PROVIDER_EMAIL,
           },
         }
       : {}),
@@ -52,16 +54,11 @@ export function buildSocialProviders(auth?: SocialCredentials) {
             // "common" also admits personal Microsoft accounts; set
             // MICROSOFT_TENANT_ID to a directory GUID to pin sign-in to one org.
             tenantId: auth.microsoftTenantId || "common",
-            // Always states emailVerified rather than returning {} for the
-            // unverified case. better-auth spreads this over its OWN computed
-            // value, which trusts `email_verified` / `verified_primary_email`
-            // — Entra optional claims sourced from directory attributes a
-            // tenant admin controls. Returning {} would leave that fallback in
-            // charge, so adding one claim in the portal could silently mark a
-            // hostile address verified and let it link onto a real account.
-            mapProfileToUser: (profile: { xms_edov?: unknown }) => ({
-              emailVerified: entraEmailIsVerified(profile),
-            }),
+            // Stated explicitly rather than left to better-auth, which would
+            // otherwise derive it from `email_verified` / `xms_edov` /
+            // `verified_primary_email` — all claims a directory administrator
+            // controls.
+            mapProfileToUser: NEVER_TRUST_PROVIDER_EMAIL,
           },
         }
       : {}),

--- a/terraform/apprunner.tf
+++ b/terraform/apprunner.tf
@@ -64,6 +64,14 @@ resource "aws_apprunner_service" "main" {
           # {BETTER_AUTH_URL}/api/auth/callback/google.
           var.google_client_id != "" ? { GOOGLE_CLIENT_ID = var.google_client_id } : {},
 
+          # Microsoft Entra ID. Client id and tenant id are public; the secret
+          # is injected below. Callback:
+          # {BETTER_AUTH_URL}/api/auth/callback/microsoft.
+          var.microsoft_client_id != "" ? {
+            MICROSOFT_CLIENT_ID = var.microsoft_client_id
+            MICROSOFT_TENANT_ID = var.microsoft_tenant_id
+          } : {},
+
           # Paddle price IDs are public catalog identifiers, not secrets, so
           # they ride as plain env vars. The API key and webhook secret go
           # through Secrets Manager below. Omitted entirely when billing is
@@ -89,6 +97,9 @@ resource "aws_apprunner_service" "main" {
           },
           var.google_client_id != "" ? {
             GOOGLE_CLIENT_SECRET = aws_secretsmanager_secret.google_client_secret[0].arn
+          } : {},
+          var.microsoft_client_id != "" ? {
+            MICROSOFT_CLIENT_SECRET = aws_secretsmanager_secret.microsoft_client_secret[0].arn
           } : {},
           var.paddle_api_key != "" ? {
             PADDLE_API_KEY        = aws_secretsmanager_secret.paddle_api_key[0].arn
@@ -122,6 +133,7 @@ resource "aws_apprunner_service" "main" {
     aws_secretsmanager_secret_version.database_url,
     aws_secretsmanager_secret_version.better_auth_secret,
     aws_secretsmanager_secret_version.google_client_secret,
+    aws_secretsmanager_secret_version.microsoft_client_secret,
     aws_secretsmanager_secret_version.paddle_api_key,
     aws_secretsmanager_secret_version.paddle_webhook_secret,
     aws_iam_role_policy.apprunner_secrets,

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -74,6 +74,7 @@ resource "aws_iam_role_policy" "apprunner_secrets" {
             aws_secretsmanager_secret.better_auth_secret.arn
           ],
           aws_secretsmanager_secret.google_client_secret[*].arn,
+          aws_secretsmanager_secret.microsoft_client_secret[*].arn,
           aws_secretsmanager_secret.paddle_api_key[*].arn,
           aws_secretsmanager_secret.paddle_webhook_secret[*].arn
         )

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -91,6 +91,36 @@ resource "aws_secretsmanager_secret_version" "google_client_secret" {
   secret_string = var.google_client_secret
 }
 
+# Microsoft Entra ID client secret, same opt-in shape as Google above. The
+# application (client) id and the tenant id are both public and injected as
+# plain env vars in apprunner.tf.
+resource "aws_secretsmanager_secret" "microsoft_client_secret" {
+  count                   = var.microsoft_client_id != "" ? 1 : 0
+  name                    = "${var.project_name}-${var.environment}-microsoft-client-secret"
+  description             = "Microsoft Entra ID client secret for ${var.project_name}"
+  recovery_window_in_days = 0
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-microsoft-client-secret"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "microsoft_client_secret" {
+  count         = var.microsoft_client_id != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.microsoft_client_secret[0].id
+  secret_string = var.microsoft_client_secret
+
+  # Entra client secrets expire (24 months at most), and a half-configured
+  # rotation is the likely failure mode. Catch it at plan time rather than
+  # letting App Runner boot a service whose Microsoft button 500s.
+  lifecycle {
+    precondition {
+      condition     = var.microsoft_client_secret != ""
+      error_message = "microsoft_client_secret is required when microsoft_client_id is set."
+    }
+  }
+}
+
 # Paddle API key and webhook signing secret. Only provisioned when billing is
 # enabled (paddle_api_key set), matching the google_client_secret pattern
 # above, so an empty secret_string never reaches Secrets Manager. The six

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -53,9 +53,8 @@ google_client_secret = ""
 # Microsoft Entra ID OAuth: leave both empty to disable Microsoft sign-in.
 # Register this redirect URI on the app registration (Web platform):
 #   https://api.flexi-day.com/api/auth/callback/microsoft
-# The registration also needs the `email` and `xms_edov` optional ID-token
-# claims (Entra -> Token configuration); see flexi-day-be/.env.example for what
-# breaks without each of them.
+# The registration also needs the `email` optional ID-token claim (Entra ->
+# Token configuration); without it sign-in fails with error=email_not_found.
 # microsoft_client_secret is the secret VALUE, not the Secret ID shown next to
 # it in the portal. terraform.tfvars is gitignored, so the value can live there;
 # TF_VAR_microsoft_client_secret works too, but note it changes nothing about

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -50,6 +50,25 @@ better_auth_secret = ""
 google_client_id     = ""
 google_client_secret = ""
 
+# Microsoft Entra ID OAuth: leave both empty to disable Microsoft sign-in.
+# Register this redirect URI on the app registration (Web platform):
+#   https://api.flexi-day.com/api/auth/callback/microsoft
+# The registration also needs the `email` and `xms_edov` optional ID-token
+# claims (Entra -> Token configuration); see flexi-day-be/.env.example for what
+# breaks without each of them.
+# microsoft_client_secret is the secret VALUE, not the Secret ID shown next to
+# it in the portal. terraform.tfvars is gitignored, so the value can live there;
+# TF_VAR_microsoft_client_secret works too, but note it changes nothing about
+# exposure — either way the value ends up in terraform.tfstate in the clear.
+# Give production its own secret instead of reusing the one in .env, so rotating
+# one does not break the other.
+# Entra client secrets expire (24 months max) — put the expiry in the calendar.
+microsoft_client_id     = ""
+microsoft_client_secret = ""
+# "common" = any work/school account + personal Microsoft accounts,
+# "organizations" = work/school only, or a tenant GUID for a single directory.
+microsoft_tenant_id = "common"
+
 # Paddle billing. Leave paddle_api_key empty to disable billing entirely: no
 # Paddle secrets are created, no Paddle env vars are injected, and the
 # backend's /api/billing/* routes return 503.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -235,3 +235,23 @@ variable "google_client_secret" {
   sensitive   = true
   default     = ""
 }
+
+# Microsoft Entra ID OAuth Configuration
+variable "microsoft_client_id" {
+  description = "Microsoft Entra ID application (client) ID (public; injected as a plain env var). Leave empty to disable Microsoft sign-in."
+  type        = string
+  default     = ""
+}
+
+variable "microsoft_client_secret" {
+  description = "Microsoft Entra ID client secret VALUE (stored in Secrets Manager). Required if microsoft_client_id is set."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "microsoft_tenant_id" {
+  description = "Directory to authenticate against: \"common\" (any work/school + personal account), \"organizations\", or a tenant GUID to allow a single directory."
+  type        = string
+  default     = "common"
+}


### PR DESCRIPTION
Adds Microsoft as a second social provider beside Google.

## What changed

- `buildSocialProviders` (new `src/utils/socialProviders.ts`) registers google and microsoft independently, each only when **both** of its credentials are set — an unconfigured deploy boots normally and the button simply 404s, exactly as Google behaved before its secrets landed.
- `MICROSOFT_CLIENT_ID` / `MICROSOFT_CLIENT_SECRET` / `MICROSOFT_TENANT_ID` in `config.ts` and `.env.example`. Tenant defaults to `common`.
- Terraform: client secret via Secrets Manager on the same opt-in `count` shape as Google, plus the App Runner env wiring and the instance-role grant. A precondition fails at plan time when the client id is set without a secret, instead of booting a service whose button is dead.

## The security reasoning

Neither provider's word is an email challenge. `xms_edov` (and Google's `email_verified`) attest the
**domain**, not that the person signing in controls the mailbox: a Workspace or Entra administrator
can point any user's mail attribute at any address in a domain they administer and the claim still
comes back affirmative. Microsoft states outright that email claims must not drive access decisions.

Flexi Day drives one — `handlePostGroupUser` lets a verified address redeem a team invite bound to
it. So **social sign-in never confers a verified address**: the account is created unverified and
better-auth sends Flexi Day's own confirmation email, exactly as an email/password signup does. Only
clicking that link verifies the address and unlocks joining a team.

Applied to Google as well as Microsoft — trusting one and not the other would be arbitrary.

`mapProfileToUser` states `emailVerified` explicitly rather than omitting it: better-auth spreads the
result *over* its own claim-derived value, so returning `{}` would hand the decision straight back to
the provider claims this rule exists to distrust.

**Expected consequence:** better-auth gates implicit account linking on the same flag, so a social
sign-in will not attach to a pre-existing account with the same address. It returns
`account_not_linked`, which the frontend renders as "that email is already registered by another
sign-in method — use the one you signed up with".

## Review findings fixed

Two rounds of independent review plus CodeRabbit. Fixed: the invite gate above (blocker); `mapProfileToUser` returning `{}` being a no-op rather than a veto; `@openapi` 403 now covering both meanings; and — on CodeRabbit's report — dropping `xms_edov` as a verification signal entirely in favour of Flexi Day's own email challenge. The provider logic was extracted into a pure, testable module because the only security-relevant code in the change had no test.

## Verified

- 454 unit tests, 152 e2e, `tsc`, eslint. 22 of those assert that no combination of `xms_edov` / `email_verified` / `verified_primary_email` can make either provider report a verified address.
- New `src/tests/e2e/inviteRedemption.e2e.test.ts` covers all four branches of the gate against a real DB; confirmed it fails when the check is reverted.
- Signed in end to end against a real Entra app registration on localhost: dashboard loads, all API calls 200, console clean. (That run predates this rule, so it showed the address being marked verified; the rule itself is covered by the unit tests above.)

## Reproduce

Set the three env vars from an app registration whose token configuration includes the `email` optional claim, then use "Continue with Microsoft" at `/sign-in/`. Expect to land unverified and receive a confirmation email.

## Deploy order

Independent of the frontend PR — this can merge first. Setup guide lives in the workspace `todo/microsoft-entra-oauth.md`.

Related: https://github.com/Daniel88dev/flexi-day/pull/57 (frontend), https://github.com/Daniel88dev/flexi-day-emails/pull/31 (domain-verification DNS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Microsoft Entra ID single sign-on, including tenant configuration and secure credential handling.
  - Microsoft sign-ins now validate email verification status.
- **Bug Fixes**
  - Restricted email-bound group invitations to verified accounts matching the invited email address.
  - Preserved access for legacy invitations without an email restriction.
- **Documentation**
  - Updated configuration examples and API guidance for Microsoft Entra ID setup and invite redemption errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


