### PR TITLE
feat: admins create, edit and cancel bookings on behalf of members

### DIFF
--- a/src/controllers/vacation/handleBulkCancelVacation.ts
+++ b/src/controllers/vacation/handleBulkCancelVacation.ts
@@ -8,6 +8,7 @@ import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationsCancelled } from "../../services/vacation/vacationNotifier.js";
 import { assertGroupsWritable } from "../../services/billing/guards.js";
+import { resolveGroupAdmin } from "../groupUser/utils.js";
 
 const services = createDBServices();
 
@@ -33,10 +34,12 @@ export const handleBulkCancelVacation = async (req: Request, res: Response) => {
     const approvableGroups = new Set(
       await services.group.getGroupsWhereUserCanApprove(distinctGroupIds, auth.userId, tx)
     );
+    // Same admin verdict as the single-cancel path (`resolveVacationPermissions`):
+    // group admins and org admins alike.
     const adminGroups = new Set<string>();
     for (const groupId of distinctGroupIds) {
-      const membership = await services.groupUser.getGroupUser(auth.userId, groupId, tx);
-      if (membership?.adminAccess) adminGroups.add(groupId);
+      const { canAdmin } = await resolveGroupAdmin(auth.userId, groupId, tx);
+      if (canAdmin) adminGroups.add(groupId);
     }
 
     const unauthorized = rows.filter(
@@ -54,7 +57,7 @@ export const handleBulkCancelVacation = async (req: Request, res: Response) => {
 
     await assertGroupsWritable(distinctGroupIds, tx);
 
-    const updated = await services.vacation.cancelVacationsBulk(uniqueIds, tx);
+    const updated = await services.vacation.cancelVacationsBulk(uniqueIds, auth.userId, tx);
 
     await services.vacationEvent.createVacationEvents(
       updated.map((row) => ({

--- a/src/controllers/vacation/handleDeleteVacation.ts
+++ b/src/controllers/vacation/handleDeleteVacation.ts
@@ -53,7 +53,7 @@ export const handleDeleteVacation = async (req: Request, res: Response) => {
 
     await assertGroupWritable(vacationData.groupId, tx);
 
-    const deleted = await services.vacation.deleteVacation(vacationId, tx);
+    const deleted = await services.vacation.deleteVacation(vacationId, auth.userId, tx);
     if (!deleted) {
       throw new AppError({
         code: 500,

--- a/src/controllers/vacation/handleGetVacation.ts
+++ b/src/controllers/vacation/handleGetVacation.ts
@@ -43,6 +43,7 @@ export const handleGetVacation = async (req: Request, res: Response) => {
     ...detail,
     canApprove: permissions.canApprove,
     canCancel: permissions.canCancel,
+    canEdit: permissions.canEdit,
     history,
   });
 };

--- a/src/controllers/vacation/handleGetVacations.ts
+++ b/src/controllers/vacation/handleGetVacations.ts
@@ -25,12 +25,19 @@ const validateMonth = z.coerce
 
 const validateGroupId = z.string().min(1).optional();
 
+// Opt-in: the calendar and dashboard keep their live-rows-only view.
+const validateIncludeCancelled = z
+  .enum(["true", "false"])
+  .optional()
+  .transform((value) => value === "true");
+
 export const handleGetVacations = async (req: Request, res: Response) => {
   const auth = getAuth(req);
 
   const year = validateYear.parse(req.query.year);
   const month = validateMonth.parse(req.query.month);
   const groupId = validateGroupId.parse(req.query.groupId);
+  const includeCancelled = validateIncludeCancelled.parse(req.query.includeCancelled);
 
   const range = formatStartAndEndDate(year, month);
 
@@ -38,7 +45,8 @@ export const handleGetVacations = async (req: Request, res: Response) => {
     const result = await services.vacation.getVacationsForUser(
       auth.userId,
       range.startDate,
-      range.endDate
+      range.endDate,
+      { includeCancelled }
     );
     const canApprove = await resolveCanApproveForList(auth.userId, result);
     // Same shape either way, so the calendar does not branch on scope.
@@ -65,7 +73,9 @@ export const handleGetVacations = async (req: Request, res: Response) => {
   const result = await services.vacation.getVacationsForGroup(
     groupId,
     range.startDate,
-    range.endDate
+    range.endDate,
+    null,
+    { includeCancelled }
   );
   const canApprove = await resolveCanApproveForList(auth.userId, result);
 

--- a/src/controllers/vacation/handlePostVacation.ts
+++ b/src/controllers/vacation/handlePostVacation.ts
@@ -164,6 +164,22 @@ export const handlePostVacation = async (req: Request, res: Response) => {
     // into a group that has just become read-only.
     await assertGroupWritable(data.groupId, tx);
 
+    if (onBehalf) {
+      // Same reasoning for delegated authority: the pre-transaction checks
+      // fail fast for the client, but a revocation committing in between must
+      // still abort the write, so both are re-asserted on the tx snapshot.
+      await assertGroupAdmin(auth.userId, data.groupId, tx);
+      const liveAccess = await services.groupUser.getGroupUser(targetUserId, data.groupId, tx);
+      if (!liveAccess?.controlledUser) {
+        throw new AppError({
+          message: "That member cannot book leave in this group",
+          logging: true,
+          code: 403,
+          context: { targetUserId, groupId: data.groupId },
+        });
+      }
+    }
+
     await assertRequestWithinQuota(records, tx);
 
     const rows = await services.vacation.postVacationBulk(records, tx);

--- a/src/controllers/vacation/handlePostVacation.ts
+++ b/src/controllers/vacation/handlePostVacation.ts
@@ -11,9 +11,14 @@ import {
 import { createDBServices } from "../../services/DBServices.js";
 import { db } from "../../db/db.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
-import { notifyVacationRequested } from "../../services/vacation/vacationNotifier.js";
+import {
+  notifyVacationBookedOnBehalf,
+  notifyVacationDecision,
+  notifyVacationRequested,
+} from "../../services/vacation/vacationNotifier.js";
 import { assertRequestWithinQuota } from "../../services/vacation/quotaGuard.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
+import { assertGroupAdmin } from "../groupUser/utils.js";
 
 const services = createDBServices();
 
@@ -69,13 +74,34 @@ export const handlePostVacation = async (req: Request, res: Response) => {
     });
   }
 
-  const access = await services.groupUser.getGroupUser(auth.userId, data.groupId);
+  const targetUserId = data.userId ?? auth.userId;
+  const onBehalf = targetUserId !== auth.userId;
+
+  if (onBehalf) {
+    // Group admins and org admins may book for a member; the booking itself is
+    // still gated on the member's own `controlledUser` membership below.
+    await assertGroupAdmin(auth.userId, data.groupId);
+  } else if (data.autoApprove) {
+    // Self-booking keeps the normal flow — whether an admin may wave their own
+    // request through is governed by the approval rules (`mayDecideOwn`), not
+    // by this shortcut.
+    throw new AppError({
+      message: "`autoApprove` is only valid when booking on behalf of a member",
+      logging: true,
+      code: 422,
+    });
+  }
+
+  const access = await services.groupUser.getGroupUser(targetUserId, data.groupId);
 
   if (!access || !access.controlledUser) {
     throw new AppError({
-      message: "No access for related group",
+      message: onBehalf
+        ? "That member cannot book leave in this group"
+        : "No access for related group",
       logging: true,
       code: 403,
+      context: { targetUserId, groupId: data.groupId },
     });
   }
 
@@ -116,9 +142,11 @@ export const handlePostVacation = async (req: Request, res: Response) => {
     });
   }
 
+  const approvalStamp = data.autoApprove ? { approvedAt: new Date(), approvedBy: auth.userId } : {};
+
   const records = workingDays.map((day) => ({
     id: generateRandomUUID(),
-    userId: auth.userId,
+    userId: targetUserId,
     groupId: data.groupId,
     requestedDay: day,
     startTime: data.startTime,
@@ -126,6 +154,8 @@ export const handlePostVacation = async (req: Request, res: Response) => {
     vacationType: data.vacationType,
     halfDay: data.halfDay,
     note: data.note,
+    createdByUserId: auth.userId,
+    ...approvalStamp,
   }));
 
   const created = await db.transaction(async (tx) => {
@@ -146,6 +176,19 @@ export const handlePostVacation = async (req: Request, res: Response) => {
       })),
       tx
     );
+    if (data.autoApprove) {
+      // A separate APPROVED event so the timeline reads like the normal flow:
+      // the admin both created and approved the record.
+      await services.vacationEvent.createVacationEvents(
+        rows.map((row) => ({
+          id: generateRandomUUID(),
+          vacationId: row.id,
+          eventType: vacationEventType.Approved,
+          actorUserId: auth.userId,
+        })),
+        tx
+      );
+    }
     return rows;
   });
 
@@ -158,17 +201,35 @@ export const handlePostVacation = async (req: Request, res: Response) => {
     });
   }
 
-  // Best-effort notification. The rows above are already committed, so any
+  // Best-effort notifications. The rows above are already committed, so any
   // failure here must NOT bubble up: a 5xx would tempt the client to retry a
   // non-idempotent endpoint (the insert uses onConflictDoNothing, so the retry
   // would return an empty set and our "no rows created" guard would mislead
-  // the caller into thinking nothing was booked). notifyVacationRequested
-  // swallows and logs its own errors.
-  await notifyVacationRequested(
-    created,
-    { id: auth.userId, name: auth.userName },
-    data.note ?? null
-  );
+  // the caller into thinking nothing was booked). The notifiers swallow and
+  // log their own errors.
+  const actor = { id: auth.userId, name: auth.userName };
+  if (data.autoApprove) {
+    // Nothing left to decide, so approvers are not asked; the member hears the
+    // record was booked and approved for them.
+    await notifyVacationDecision(created, "approved", actor);
+  } else if (onBehalf) {
+    // Approvers must see the member as the requester — the leave is theirs;
+    // the admin who filed it is attributed on the timeline and in the member's
+    // own notice, and must not displace the member in the approver mail.
+    const member = await services.user.getUserById(targetUserId).catch(() => undefined);
+    if (member) {
+      await notifyVacationRequested(
+        created,
+        { id: member.id, name: member.name },
+        data.note ?? null
+      );
+    }
+    // No fallback to the admin: a mail naming the wrong requester is worse
+    // than no mail — the request still sits in every approver's queue.
+    await notifyVacationBookedOnBehalf(created, actor);
+  } else {
+    await notifyVacationRequested(created, actor, data.note ?? null);
+  }
 
   return res.status(201).json(created);
 };

--- a/src/controllers/vacation/handleUpdateVacation.ts
+++ b/src/controllers/vacation/handleUpdateVacation.ts
@@ -1,0 +1,155 @@
+import type { Request, Response } from "express";
+import { getAuth } from "../../middleware/authSession.js";
+import AppError from "../../utils/appError.js";
+import { db } from "../../db/db.js";
+import { createDBServices } from "../../services/DBServices.js";
+import { generateRandomUUID } from "../../utils/generateUUID.js";
+import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
+import type { ValidatedUpdateVacationType } from "../../services/vacation/types.js";
+import type { VacationUpdatePatch } from "../../services/vacation/vacationServices.js";
+import { describeVacationChanges } from "../../services/vacation/vacationChangeDetail.js";
+import { assertEditWithinQuota } from "../../services/vacation/quotaGuard.js";
+import { assertGroupWritable } from "../../services/billing/guards.js";
+import { resolveGroupAdmin } from "../groupUser/utils.js";
+import { notifyVacationUpdated } from "../../services/vacation/vacationNotifier.js";
+
+const services = createDBServices();
+
+/**
+ * Admin-only in-place edit of one member's day rows. Only per-day fields are
+ * editable; moving a record to another day is a cancel + re-create, so the
+ * partial `uniq_vacation_user_day` index never comes into play here. Every row
+ * gets an UPDATED timeline event whose reason summarizes what changed.
+ */
+export const handleUpdateVacation = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data: ValidatedUpdateVacationType = req.body;
+  const uniqueIds = Array.from(new Set(data.ids));
+
+  const patch: VacationUpdatePatch = {
+    ...(data.vacationType !== undefined && { vacationType: data.vacationType }),
+    ...(data.startTime !== undefined && { startTime: data.startTime }),
+    ...(data.endTime !== undefined && { endTime: data.endTime }),
+    ...(data.halfDay !== undefined && { halfDay: data.halfDay }),
+    ...(data.note !== undefined && { note: data.note }),
+  };
+
+  const { updated, previous } = await db.transaction(async (tx) => {
+    // Excludes soft-deleted rows, so a cancelled id lands in the 404 too — a
+    // cancelled record is history and must be re-created, not edited back.
+    const rows = await services.vacation.getVacationsByIds(uniqueIds, tx);
+
+    if (rows.length !== uniqueIds.length) {
+      throw new AppError({
+        code: 404,
+        message: "One or more vacations not found",
+        context: { auth, requested: uniqueIds.length, found: rows.length },
+      });
+    }
+
+    // Authorize before inspecting the batch further: the rejected/mixed checks
+    // below would otherwise leak record status to callers with no standing.
+    for (const groupId of new Set(rows.map((r) => r.groupId))) {
+      const { canAdmin } = await resolveGroupAdmin(auth.userId, groupId, tx);
+      if (!canAdmin) {
+        throw new AppError({
+          code: 403,
+          message: "You are not allowed to edit records in this group",
+          logging: true,
+          context: { auth, groupId },
+        });
+      }
+    }
+
+    const rejected = rows.filter((r) => r.rejectedAt !== null);
+    if (rejected.length > 0) {
+      throw new AppError({
+        code: 409,
+        message: "Rejected records cannot be edited",
+        logging: true,
+        context: { auth, rejected: rejected.map((r) => r.id) },
+      });
+    }
+
+    // One member, one group per call: the edit is a single admin action on a
+    // single record run, and the quota guard and events assume as much.
+    const userIds = new Set(rows.map((r) => r.userId));
+    const groupIds = new Set(rows.map((r) => r.groupId));
+    const first = rows[0];
+    if (!first || userIds.size > 1 || groupIds.size > 1) {
+      throw new AppError({
+        code: 422,
+        message: "All records must belong to the same member and group",
+        logging: true,
+        context: { auth, userIds: [...userIds], groupIds: [...groupIds] },
+      });
+    }
+
+    // The schema's endTime > startTime refine only sees the patch; a one-sided
+    // time change must also be checked against each row's stored counterpart
+    // or it could persist an inverted range.
+    if (patch.startTime !== undefined || patch.endTime !== undefined) {
+      const inverted = rows.filter((row) => {
+        const start = patch.startTime !== undefined ? patch.startTime : row.startTime;
+        const end = patch.endTime !== undefined ? patch.endTime : row.endTime;
+        return Boolean(start && end && end <= start);
+      });
+      if (inverted.length > 0) {
+        throw new AppError({
+          code: 422,
+          message: "`endTime` must be later than `startTime`",
+          logging: true,
+          context: { auth, inverted: inverted.map((r) => r.id) },
+        });
+      }
+    }
+
+    await assertGroupWritable(first.groupId, tx);
+
+    const weightChanged = rows.some(
+      (row) =>
+        (patch.vacationType !== undefined && patch.vacationType !== row.vacationType) ||
+        (patch.halfDay !== undefined && patch.halfDay !== row.halfDay)
+    );
+    if (weightChanged) {
+      await assertEditWithinQuota(
+        rows.map((row) => ({ ...row, ...patch })),
+        tx
+      );
+    }
+
+    const updatedRows = await services.vacation.updateVacationRows(uniqueIds, patch, tx);
+    if (updatedRows.length !== uniqueIds.length) {
+      // A concurrent cancel or reject won the race for some row.
+      throw new AppError({
+        code: 409,
+        message: "One or more records changed while editing — refresh and retry",
+        logging: true,
+        context: { auth, requested: uniqueIds.length, updated: updatedRows.length },
+      });
+    }
+
+    await services.vacationEvent.createVacationEvents(
+      rows.map((row) => ({
+        id: generateRandomUUID(),
+        vacationId: row.id,
+        eventType: vacationEventType.Updated,
+        actorUserId: auth.userId,
+        reason: describeVacationChanges(row, patch),
+      })),
+      tx
+    );
+
+    return { updated: updatedRows, previous: first };
+  });
+
+  // Post-commit and best-effort; the notifier logs its own failures. Editing
+  // your own record needs no notice.
+  if (previous.userId !== auth.userId) {
+    await notifyVacationUpdated(updated, { id: auth.userId, name: auth.userName });
+  }
+
+  return res.status(200).json(updated);
+};

--- a/src/controllers/vacation/handleUpdateVacation.ts
+++ b/src/controllers/vacation/handleUpdateVacation.ts
@@ -39,7 +39,9 @@ export const handleUpdateVacation = async (req: Request, res: Response) => {
   const { updated, previous } = await db.transaction(async (tx) => {
     // Excludes soft-deleted rows, so a cancelled id lands in the 404 too — a
     // cancelled record is history and must be re-created, not edited back.
-    const rows = await services.vacation.getVacationsByIds(uniqueIds, tx);
+    // Locked: a concurrent PATCH must wait and re-read, or its change summary
+    // would describe values this edit is about to replace.
+    const rows = await services.vacation.getVacationsByIds(uniqueIds, tx, { forUpdate: true });
 
     if (rows.length !== uniqueIds.length) {
       throw new AppError({

--- a/src/controllers/vacation/tests/handleBulkCancelVacation.test.ts
+++ b/src/controllers/vacation/tests/handleBulkCancelVacation.test.ts
@@ -15,6 +15,7 @@ const {
   mockGetGroupsWhereUserCanApprove,
   mockGetGroupUser,
   mockNotifyVacationsCancelled,
+  mockResolveGroupAdmin,
 } = vi.hoisted(() => ({
   mockGetVacationsByIds: vi.fn(),
   mockCancelVacationsBulk: vi.fn(),
@@ -22,6 +23,11 @@ const {
   mockGetGroupsWhereUserCanApprove: vi.fn(),
   mockGetGroupUser: vi.fn(),
   mockNotifyVacationsCancelled: vi.fn(),
+  mockResolveGroupAdmin: vi.fn(),
+}));
+
+vi.mock("../../groupUser/utils.js", () => ({
+  resolveGroupAdmin: mockResolveGroupAdmin,
 }));
 
 vi.mock("../../../utils/generateUUID.js", () => ({
@@ -70,6 +76,7 @@ describe("handleBulkCancelVacation", () => {
     (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
     mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
     mockGetGroupUser.mockResolvedValue(null);
+    mockResolveGroupAdmin.mockResolvedValue({ canAdmin: false, viaOrgAdmin: false });
     mockCancelVacationsBulk.mockImplementation(async (ids: string[]) => ids.map((id) => ({ id })));
   });
 
@@ -79,7 +86,11 @@ describe("handleBulkCancelVacation", () => {
 
     await handleBulkCancelVacation(req, res);
 
-    expect(mockCancelVacationsBulk).toHaveBeenCalledWith(["v-1", "v-2"], expect.anything());
+    expect(mockCancelVacationsBulk).toHaveBeenCalledWith(
+      ["v-1", "v-2"],
+      mockAuthData.userId,
+      expect.anything()
+    );
     expect(mockCreateVacationEvents).toHaveBeenCalledWith(
       expect.arrayContaining([expect.objectContaining({ eventType: "CANCELLED" })]),
       expect.anything()
@@ -100,7 +111,26 @@ describe("handleBulkCancelVacation", () => {
 
     await handleBulkCancelVacation(req, res);
 
-    expect(mockCancelVacationsBulk).toHaveBeenCalledWith(["v-1", "v-2"], expect.anything());
+    expect(mockCancelVacationsBulk).toHaveBeenCalledWith(
+      ["v-1", "v-2"],
+      mockAuthData.userId,
+      expect.anything()
+    );
+  });
+
+  it("lets an org admin cancel someone else's request", async () => {
+    const othersRows = ownedRows.map((r) => ({ ...r, userId: "someone_else" }));
+    const { req, res } = makeReqRes({ body: { ids: ["v-1", "v-2"] } });
+    mockGetVacationsByIds.mockResolvedValue(othersRows);
+    mockResolveGroupAdmin.mockResolvedValue({ canAdmin: true, viaOrgAdmin: true });
+
+    await handleBulkCancelVacation(req, res);
+
+    expect(mockCancelVacationsBulk).toHaveBeenCalledWith(
+      ["v-1", "v-2"],
+      mockAuthData.userId,
+      expect.anything()
+    );
   });
 
   it("rejects a plain member cancelling someone else's request", async () => {

--- a/src/controllers/vacation/tests/handleDeleteVacation.test.ts
+++ b/src/controllers/vacation/tests/handleDeleteVacation.test.ts
@@ -14,12 +14,18 @@ const {
   mockCreateVacationEvent,
   mockGetGroupUser,
   mockGetGroupsWhereUserCanApprove,
+  mockResolveGroupAdmin,
 } = vi.hoisted(() => ({
   mockGetVacationById: vi.fn(),
   mockDeleteVacation: vi.fn(),
   mockCreateVacationEvent: vi.fn(),
   mockGetGroupUser: vi.fn(),
   mockGetGroupsWhereUserCanApprove: vi.fn(),
+  mockResolveGroupAdmin: vi.fn(),
+}));
+
+vi.mock("../../groupUser/utils.js", () => ({
+  resolveGroupAdmin: mockResolveGroupAdmin,
 }));
 
 vi.mock("../../../middleware/authSession.js", () => ({
@@ -65,6 +71,7 @@ describe("handleDeleteVacation", () => {
     (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
     mockDeleteVacation.mockResolvedValue({ id: vacationId });
     mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
+    mockResolveGroupAdmin.mockResolvedValue({ canAdmin: false, viaOrgAdmin: false });
   });
 
   it("lets the owner cancel their own approved vacation and records the reason", async () => {
@@ -78,7 +85,11 @@ describe("handleDeleteVacation", () => {
 
     await handleDeleteVacation(req, res);
 
-    expect(mockDeleteVacation).toHaveBeenCalledWith(vacationId, expect.anything());
+    expect(mockDeleteVacation).toHaveBeenCalledWith(
+      vacationId,
+      mockAuthData.userId,
+      expect.anything()
+    );
     expect(mockCreateVacationEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         vacationId,
@@ -100,7 +111,27 @@ describe("handleDeleteVacation", () => {
 
     await handleDeleteVacation(req, res);
 
-    expect(mockDeleteVacation).toHaveBeenCalledWith(vacationId, expect.anything());
+    expect(mockDeleteVacation).toHaveBeenCalledWith(
+      vacationId,
+      mockAuthData.userId,
+      expect.anything()
+    );
+  });
+
+  it("lets an org admin cancel someone else's vacation", async () => {
+    const { req, res } = makeReqRes({ params: { id: vacationId } });
+
+    mockGetVacationById.mockResolvedValue({ ...ownedVacation, userId: "someone_else" });
+    mockGetGroupUser.mockResolvedValue(undefined);
+    mockResolveGroupAdmin.mockResolvedValue({ canAdmin: true, viaOrgAdmin: true });
+
+    await handleDeleteVacation(req, res);
+
+    expect(mockDeleteVacation).toHaveBeenCalledWith(
+      vacationId,
+      mockAuthData.userId,
+      expect.anything()
+    );
   });
 
   it("rejects a plain member cancelling someone else's vacation", async () => {

--- a/src/controllers/vacation/tests/handleGetVacation.test.ts
+++ b/src/controllers/vacation/tests/handleGetVacation.test.ts
@@ -5,11 +5,17 @@ const {
   mockGetVacationEvents,
   mockGetGroupUser,
   mockGetGroupsWhereUserCanApprove,
+  mockResolveGroupAdmin,
 } = vi.hoisted(() => ({
   mockGetVacationDetailById: vi.fn(),
   mockGetVacationEvents: vi.fn(),
   mockGetGroupUser: vi.fn(),
   mockGetGroupsWhereUserCanApprove: vi.fn(),
+  mockResolveGroupAdmin: vi.fn(),
+}));
+
+vi.mock("../../groupUser/utils.js", () => ({
+  resolveGroupAdmin: mockResolveGroupAdmin,
 }));
 
 vi.mock("../../../middleware/authSession.js", () => ({
@@ -48,6 +54,7 @@ describe("handleGetVacation", () => {
     vi.clearAllMocks();
     (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
     mockGetVacationEvents.mockResolvedValue([]);
+    mockResolveGroupAdmin.mockResolvedValue({ canAdmin: false, viaOrgAdmin: false });
   });
 
   it("returns the detail with history and the owner's permissions", async () => {
@@ -66,8 +73,43 @@ describe("handleGetVacation", () => {
         id: vacationId,
         canApprove: false,
         canCancel: true,
+        canEdit: false,
         history: [{ id: "e-1", eventType: "CREATED" }],
       })
+    );
+  });
+
+  it("marks an org admin as able to view, cancel and edit but not approve", async () => {
+    const { req, res } = makeReqRes({ params: { id: vacationId } });
+
+    mockGetVacationDetailById.mockResolvedValue({ ...detail, userId: "someone_else" });
+    mockGetGroupUser.mockResolvedValue(undefined);
+    mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
+    mockResolveGroupAdmin.mockResolvedValue({ canAdmin: true, viaOrgAdmin: true });
+
+    await handleGetVacation(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ canApprove: false, canCancel: true, canEdit: true })
+    );
+  });
+
+  it("reports a cancelled record as neither cancellable nor editable", async () => {
+    const { req, res } = makeReqRes({ params: { id: vacationId } });
+
+    mockGetVacationDetailById.mockResolvedValue({
+      ...detail,
+      userId: "someone_else",
+      deletedAt: new Date("2026-08-01T00:00:00Z"),
+    });
+    mockGetGroupUser.mockResolvedValue(undefined);
+    mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
+    mockResolveGroupAdmin.mockResolvedValue({ canAdmin: true, viaOrgAdmin: false });
+
+    await handleGetVacation(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ canApprove: false, canCancel: false, canEdit: false })
     );
   });
 

--- a/src/controllers/vacation/tests/handleGetVacations.test.ts
+++ b/src/controllers/vacation/tests/handleGetVacations.test.ts
@@ -88,6 +88,18 @@ describe("handleGetVacations", () => {
     vi.restoreAllMocks();
   });
 
+  it("passes includeCancelled=true through so the requests view can show cancelled rows", async () => {
+    const { req, res } = makeReqRes({ year: "2024", month: "3", includeCancelled: "true" });
+    mockGetVacationsForUser.mockResolvedValue([]);
+
+    await handleGetVacations(req, res);
+
+    expect(mockGetVacationsForUser).toHaveBeenCalledWith("user_123", "2024-01-01", "2024-01-31", {
+      includeCancelled: true,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
   it("should return vacations for the authenticated user with provided year and month", async () => {
     const { req, res } = makeReqRes({ year: "2024", month: "3" });
     const mockVacations = [
@@ -110,7 +122,9 @@ describe("handleGetVacations", () => {
 
     expect(getAuth).toHaveBeenCalledWith(req);
     expect(formatStartAndEndDate).toHaveBeenCalledWith(2024, 3);
-    expect(mockGetVacationsForUser).toHaveBeenCalledWith("user_123", "2024-01-01", "2024-01-31");
+    expect(mockGetVacationsForUser).toHaveBeenCalledWith("user_123", "2024-01-01", "2024-01-31", {
+      includeCancelled: false,
+    });
     expect(res.status).toHaveBeenCalledWith(200);
     // Own records carry the same mirror fields as group ones so the calendar
     // never has to branch on which scope produced the row.
@@ -176,7 +190,9 @@ describe("handleGetVacations", () => {
 
     await handleGetVacations(req, res);
 
-    expect(mockGetVacationsForUser).toHaveBeenCalledWith("user_123", "2024-01-01", "2024-01-31");
+    expect(mockGetVacationsForUser).toHaveBeenCalledWith("user_123", "2024-01-01", "2024-01-31", {
+      includeCancelled: false,
+    });
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith([]);
   });
@@ -242,7 +258,8 @@ describe("handleGetVacations", () => {
     expect(mockGetVacationsForUser).toHaveBeenCalledWith(
       "different_user_456",
       "2024-01-01",
-      "2024-01-31"
+      "2024-01-31",
+      { includeCancelled: false }
     );
   });
 
@@ -280,7 +297,15 @@ describe("handleGetVacations", () => {
 
       await handleGetVacations(req, res);
 
-      expect(mockGetVacationsForGroup).toHaveBeenCalledWith("group_1", "2024-01-01", "2024-01-31");
+      expect(mockGetVacationsForGroup).toHaveBeenCalledWith(
+        "group_1",
+        "2024-01-01",
+        "2024-01-31",
+        null,
+        {
+          includeCancelled: false,
+        }
+      );
       expect(mockGetVacationsForUser).not.toHaveBeenCalled();
       expect(res.json).toHaveBeenCalledWith(
         groupRows.map((row) => ({ ...row, canApprove: false }))
@@ -357,6 +382,8 @@ describe("handleGetVacations", () => {
 
     await handleGetVacations(req, res);
 
-    expect(mockGetVacationsForUser).toHaveBeenCalledWith("user_123", "2024-07-01", "2024-07-31");
+    expect(mockGetVacationsForUser).toHaveBeenCalledWith("user_123", "2024-07-01", "2024-07-31", {
+      includeCancelled: false,
+    });
   });
 });

--- a/src/controllers/vacation/tests/handlePostVacation.test.ts
+++ b/src/controllers/vacation/tests/handlePostVacation.test.ts
@@ -16,7 +16,11 @@ const {
   mockTransaction,
   mockCreateVacationEvents,
   mockNotifyVacationRequested,
+  mockNotifyVacationDecision,
+  mockNotifyVacationBookedOnBehalf,
   mockAssertRequestWithinQuota,
+  mockAssertGroupAdmin,
+  mockGetUserById,
 } = vi.hoisted(() => ({
   mockPostVacationBulk: vi.fn(),
   mockGetGroupUser: vi.fn(),
@@ -25,7 +29,15 @@ const {
   mockTransaction: vi.fn(),
   mockCreateVacationEvents: vi.fn(),
   mockNotifyVacationRequested: vi.fn(),
+  mockNotifyVacationDecision: vi.fn(),
+  mockNotifyVacationBookedOnBehalf: vi.fn(),
   mockAssertRequestWithinQuota: vi.fn(),
+  mockAssertGroupAdmin: vi.fn(),
+  mockGetUserById: vi.fn(),
+}));
+
+vi.mock("../../groupUser/utils.js", () => ({
+  assertGroupAdmin: mockAssertGroupAdmin,
 }));
 
 vi.mock("../../../utils/generateUUID.js", () => ({
@@ -38,6 +50,8 @@ vi.mock("../../../middleware/authSession.js", () => ({
 
 vi.mock("../../../services/vacation/vacationNotifier.js", () => ({
   notifyVacationRequested: mockNotifyVacationRequested,
+  notifyVacationDecision: mockNotifyVacationDecision,
+  notifyVacationBookedOnBehalf: mockNotifyVacationBookedOnBehalf,
 }));
 
 vi.mock("../../../services/vacation/quotaGuard.js", () => ({
@@ -64,6 +78,9 @@ vi.mock("../../../services/DBServices.js", () => ({
     group: {
       getGroup: mockGetGroup,
       getApprovalUsers: mockGetApprovalUsers,
+    },
+    user: {
+      getUserById: mockGetUserById,
     },
   }),
 }));
@@ -331,6 +348,120 @@ describe("handlePostVacation", () => {
       "Selected range contains no working days"
     );
     expect(mockPostVacationBulk).not.toHaveBeenCalled();
+  });
+
+  describe("booking on behalf of a member", () => {
+    const onBehalfBody = (overrides: Record<string, unknown> = {}) =>
+      baseBody({ userId: "member_456", ...overrides });
+
+    beforeEach(() => {
+      mockAssertGroupAdmin.mockResolvedValue(undefined);
+      mockGetGroupUser.mockResolvedValue({
+        userId: "member_456",
+        groupId: "group_123",
+        controlledUser: true,
+      });
+      mockGetUserById.mockResolvedValue({
+        id: "member_456",
+        name: "Member Name",
+        email: "member@example.com",
+      });
+      mockPostVacationBulk.mockImplementation(async (records: unknown[]) => records);
+    });
+
+    it("books for the target member, stamps the admin as creator, and notifies the member", async () => {
+      const { req, res } = makeReqRes({ body: onBehalfBody() });
+
+      await handlePostVacation(req, res);
+
+      expect(mockAssertGroupAdmin).toHaveBeenCalledWith(mockAuthData.userId, "group_123");
+      expect(mockGetGroupUser).toHaveBeenCalledWith("member_456", "group_123");
+      expect(mockPostVacationBulk).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            userId: "member_456",
+            createdByUserId: mockAuthData.userId,
+          }),
+        ],
+        {}
+      );
+      const [records] = mockPostVacationBulk.mock.calls[0] as [{ approvedAt?: Date }[], unknown];
+      expect(records[0]?.approvedAt).toBeUndefined();
+      // Approvers are asked about the member's leave, not the admin's.
+      expect(mockNotifyVacationRequested).toHaveBeenCalledWith(
+        expect.any(Array),
+        { id: "member_456", name: "Member Name" },
+        null
+      );
+      expect(mockNotifyVacationBookedOnBehalf).toHaveBeenCalledWith(expect.any(Array), {
+        id: mockAuthData.userId,
+        name: mockAuthData.userName,
+      });
+      expect(mockNotifyVacationDecision).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it("creates already-approved rows with two timeline events when autoApprove is set", async () => {
+      const { req, res } = makeReqRes({ body: onBehalfBody({ autoApprove: true }) });
+
+      await handlePostVacation(req, res);
+
+      expect(mockPostVacationBulk).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            userId: "member_456",
+            createdByUserId: mockAuthData.userId,
+            approvedBy: mockAuthData.userId,
+            approvedAt: expect.any(Date),
+          }),
+        ],
+        {}
+      );
+      const eventTypes = mockCreateVacationEvents.mock.calls.map(
+        ([events]) => (events as { eventType: string }[])[0]?.eventType
+      );
+      expect(eventTypes).toEqual(["CREATED", "APPROVED"]);
+      expect(mockNotifyVacationDecision).toHaveBeenCalledWith(expect.any(Array), "approved", {
+        id: mockAuthData.userId,
+        name: mockAuthData.userName,
+      });
+      expect(mockNotifyVacationRequested).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it("rejects a non-admin caller passing userId", async () => {
+      const { req, res } = makeReqRes({ body: onBehalfBody() });
+      mockAssertGroupAdmin.mockRejectedValue(new Error("No permission for related group"));
+
+      await expect(handlePostVacation(req, res)).rejects.toThrow("No permission for related group");
+      expect(mockPostVacationBulk).not.toHaveBeenCalled();
+    });
+
+    it("rejects autoApprove on a self-booking", async () => {
+      const { req, res } = makeReqRes({
+        body: baseBody({ userId: mockAuthData.userId, autoApprove: true }),
+      });
+
+      await expect(handlePostVacation(req, res)).rejects.toThrow(
+        "`autoApprove` is only valid when booking on behalf of a member"
+      );
+      expect(mockAssertGroupAdmin).not.toHaveBeenCalled();
+      expect(mockPostVacationBulk).not.toHaveBeenCalled();
+    });
+
+    it("rejects a target member who cannot book in the group", async () => {
+      const { req, res } = makeReqRes({ body: onBehalfBody() });
+      mockGetGroupUser.mockResolvedValue({
+        userId: "member_456",
+        groupId: "group_123",
+        controlledUser: false,
+      });
+
+      await expect(handlePostVacation(req, res)).rejects.toThrow(
+        "That member cannot book leave in this group"
+      );
+      expect(mockPostVacationBulk).not.toHaveBeenCalled();
+    });
   });
 
   it("throws 404 when the group no longer exists", async () => {

--- a/src/controllers/vacation/tests/handlePostVacation.test.ts
+++ b/src/controllers/vacation/tests/handlePostVacation.test.ts
@@ -462,6 +462,24 @@ describe("handlePostVacation", () => {
       );
       expect(mockPostVacationBulk).not.toHaveBeenCalled();
     });
+
+    it("aborts inside the transaction when the member's access was just revoked", async () => {
+      const { req, res } = makeReqRes({ body: onBehalfBody() });
+      // Pre-transaction check passes; the re-check on the tx snapshot does not.
+      mockGetGroupUser
+        .mockResolvedValueOnce({ userId: "member_456", groupId: "group_123", controlledUser: true })
+        .mockResolvedValueOnce({
+          userId: "member_456",
+          groupId: "group_123",
+          controlledUser: false,
+        });
+
+      await expect(handlePostVacation(req, res)).rejects.toThrow(
+        "That member cannot book leave in this group"
+      );
+      expect(mockPostVacationBulk).not.toHaveBeenCalled();
+      expect(mockGetGroupUser).toHaveBeenCalledTimes(2);
+    });
   });
 
   it("throws 404 when the group no longer exists", async () => {

--- a/src/controllers/vacation/tests/handleUpdateVacation.test.ts
+++ b/src/controllers/vacation/tests/handleUpdateVacation.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Billing plan-limit guards are no-ops here; their behavior has its own suite.
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertCanCreateGroup: vi.fn(),
+  assertCanAddMember: vi.fn(),
+  assertGroupWritable: vi.fn(),
+  assertGroupsWritable: vi.fn(),
+}));
+
+const {
+  mockGetVacationsByIds,
+  mockUpdateVacationRows,
+  mockCreateVacationEvents,
+  mockResolveGroupAdmin,
+  mockAssertEditWithinQuota,
+  mockNotifyVacationUpdated,
+} = vi.hoisted(() => ({
+  mockGetVacationsByIds: vi.fn(),
+  mockUpdateVacationRows: vi.fn(),
+  mockCreateVacationEvents: vi.fn(),
+  mockResolveGroupAdmin: vi.fn(),
+  mockAssertEditWithinQuota: vi.fn(),
+  mockNotifyVacationUpdated: vi.fn(),
+}));
+
+vi.mock("../../../utils/generateUUID.js", () => ({
+  generateRandomUUID: vi.fn(() => "uuid"),
+}));
+
+vi.mock("../../../middleware/authSession.js", () => ({
+  getAuth: vi.fn(),
+}));
+
+vi.mock("../../groupUser/utils.js", () => ({
+  resolveGroupAdmin: mockResolveGroupAdmin,
+}));
+
+vi.mock("../../../services/vacation/quotaGuard.js", () => ({
+  assertEditWithinQuota: mockAssertEditWithinQuota,
+}));
+
+vi.mock("../../../services/vacation/vacationNotifier.js", () => ({
+  notifyVacationUpdated: mockNotifyVacationUpdated,
+}));
+
+vi.mock("../../../db/db.js", () => ({
+  db: {
+    transaction: vi.fn((callback: (tx: unknown) => unknown) => callback({})),
+  },
+}));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    vacation: {
+      getVacationsByIds: mockGetVacationsByIds,
+      updateVacationRows: mockUpdateVacationRows,
+    },
+    vacationEvent: { createVacationEvents: mockCreateVacationEvents },
+  }),
+}));
+
+import { handleUpdateVacation } from "../handleUpdateVacation.js";
+import { getAuth } from "../../../middleware/authSession.js";
+import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
+import { vacationType } from "../../../db/schema/vacation-schema.js";
+
+const groupId = "550e8400-e29b-41d4-a716-446655440009";
+
+const baseRow = (overrides: Record<string, unknown> = {}) => ({
+  id: "v-1",
+  userId: "member_456",
+  groupId,
+  requestedDay: "2026-08-20",
+  startTime: "09:00:00",
+  endTime: "17:00:00",
+  vacationType: vacationType.Vacation,
+  halfDay: false,
+  approvedAt: null,
+  rejectedAt: null,
+  deletedAt: null,
+  note: null,
+  ...overrides,
+});
+
+describe("handleUpdateVacation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getAuth as ReturnType<typeof vi.fn>).mockReturnValue(mockAuthData);
+    mockResolveGroupAdmin.mockResolvedValue({ canAdmin: true, viaOrgAdmin: false });
+    mockGetVacationsByIds.mockResolvedValue([baseRow()]);
+    mockUpdateVacationRows.mockImplementation(async (ids: string[]) =>
+      ids.map((id) => baseRow({ id }))
+    );
+  });
+
+  it("updates the rows, writes an UPDATED event with a change summary, and notifies the member", async () => {
+    const { req, res } = makeReqRes({
+      body: { ids: ["v-1"], vacationType: vacationType.Sick, halfDay: true },
+    });
+
+    await handleUpdateVacation(req, res);
+
+    expect(mockUpdateVacationRows).toHaveBeenCalledWith(
+      ["v-1"],
+      { vacationType: vacationType.Sick, halfDay: true },
+      expect.anything()
+    );
+    expect(mockCreateVacationEvents).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          vacationId: "v-1",
+          eventType: "UPDATED",
+          actorUserId: mockAuthData.userId,
+          reason: "Type: Vacation → Sick; Half day: no → yes",
+        }),
+      ],
+      expect.anything()
+    );
+    expect(mockNotifyVacationUpdated).toHaveBeenCalledWith(expect.any(Array), {
+      id: mockAuthData.userId,
+      name: mockAuthData.userName,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("skips the quota guard when only presentation fields change", async () => {
+    const { req, res } = makeReqRes({
+      body: { ids: ["v-1"], startTime: "10:00:00", note: "Doctor" },
+    });
+
+    await handleUpdateVacation(req, res);
+
+    expect(mockAssertEditWithinQuota).not.toHaveBeenCalled();
+    expect(mockUpdateVacationRows).toHaveBeenCalled();
+  });
+
+  it("runs the quota guard at the post-edit weight when the type changes", async () => {
+    const { req, res } = makeReqRes({
+      body: { ids: ["v-1"], vacationType: vacationType.HomeOffice },
+    });
+
+    await handleUpdateVacation(req, res);
+
+    expect(mockAssertEditWithinQuota).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: "v-1", vacationType: vacationType.HomeOffice })],
+      expect.anything()
+    );
+  });
+
+  it("does not notify when the admin edits their own record", async () => {
+    const { req, res } = makeReqRes({ body: { ids: ["v-1"], note: "mine" } });
+    mockGetVacationsByIds.mockResolvedValue([baseRow({ userId: mockAuthData.userId })]);
+
+    await handleUpdateVacation(req, res);
+
+    expect(mockNotifyVacationUpdated).not.toHaveBeenCalled();
+  });
+
+  it("rejects a caller without admin standing", async () => {
+    const { req, res } = makeReqRes({ body: { ids: ["v-1"], note: "x" } });
+    mockResolveGroupAdmin.mockResolvedValue({ canAdmin: false, viaOrgAdmin: false });
+
+    await expect(handleUpdateVacation(req, res)).rejects.toThrow(
+      "You are not allowed to edit records in this group"
+    );
+    expect(mockUpdateVacationRows).not.toHaveBeenCalled();
+  });
+
+  it("404s for cancelled or missing ids", async () => {
+    const { req, res } = makeReqRes({ body: { ids: ["v-1", "v-2"], note: "x" } });
+    mockGetVacationsByIds.mockResolvedValue([baseRow()]);
+
+    await expect(handleUpdateVacation(req, res)).rejects.toThrow("One or more vacations not found");
+  });
+
+  it("422s when a one-sided time patch would invert the stored range", async () => {
+    const { req, res } = makeReqRes({ body: { ids: ["v-1"], startTime: "18:00:00" } });
+
+    await expect(handleUpdateVacation(req, res)).rejects.toThrow(
+      "`endTime` must be later than `startTime`"
+    );
+    expect(mockUpdateVacationRows).not.toHaveBeenCalled();
+  });
+
+  it("accepts a one-sided time patch that keeps the range ordered", async () => {
+    const { req, res } = makeReqRes({ body: { ids: ["v-1"], startTime: "10:00:00" } });
+
+    await handleUpdateVacation(req, res);
+
+    expect(mockUpdateVacationRows).toHaveBeenCalledWith(
+      ["v-1"],
+      { startTime: "10:00:00" },
+      expect.anything()
+    );
+  });
+
+  it("409s on rejected rows — their decision is final", async () => {
+    const { req, res } = makeReqRes({ body: { ids: ["v-1"], note: "x" } });
+    mockGetVacationsByIds.mockResolvedValue([baseRow({ rejectedAt: new Date() })]);
+
+    await expect(handleUpdateVacation(req, res)).rejects.toThrow(
+      "Rejected records cannot be edited"
+    );
+  });
+
+  it("422s when the batch spans more than one member or group", async () => {
+    const { req, res } = makeReqRes({ body: { ids: ["v-1", "v-2"], note: "x" } });
+    mockGetVacationsByIds.mockResolvedValue([
+      baseRow(),
+      baseRow({ id: "v-2", userId: "someone_else" }),
+    ]);
+
+    await expect(handleUpdateVacation(req, res)).rejects.toThrow(
+      "All records must belong to the same member and group"
+    );
+  });
+
+  it("409s when a concurrent change dropped a row from the update", async () => {
+    const { req, res } = makeReqRes({ body: { ids: ["v-1"], note: "x" } });
+    mockUpdateVacationRows.mockResolvedValue([]);
+
+    await expect(handleUpdateVacation(req, res)).rejects.toThrow(
+      "One or more records changed while editing — refresh and retry"
+    );
+    expect(mockNotifyVacationUpdated).not.toHaveBeenCalled();
+  });
+});

--- a/src/controllers/vacation/utils.ts
+++ b/src/controllers/vacation/utils.ts
@@ -2,6 +2,7 @@ import { createDBServices } from "../../services/DBServices.js";
 import type { DbTransaction } from "../../db/db.js";
 import type { VacationType } from "../../services/vacation/types.js";
 import { mayDecideOwn } from "./decisionGuards.js";
+import { resolveGroupAdmin } from "../groupUser/utils.js";
 
 const services = createDBServices();
 
@@ -12,6 +13,8 @@ export type VacationPermissions = {
   canApprove: boolean;
   /** May cancel it — the owner, a group admin, or an approver. */
   canCancel: boolean;
+  /** May edit its per-day fields — group or organization admins only. */
+  canEdit: boolean;
 };
 
 /**
@@ -33,7 +36,10 @@ export const resolveVacationPermissions = async (
     tx
   );
   const isApprover = approvableGroups.includes(vacationRow.groupId);
-  const isAdmin = membership?.adminAccess ?? false;
+  // Group admins and org admins alike: they may manage records on behalf of
+  // members (create / edit / cancel), which is administration — deciding a
+  // member-submitted request stays an approver-only power (`canApprove`).
+  const { canAdmin } = await resolveGroupAdmin(userId, vacationRow.groupId, tx);
   const isCancelled = vacationRow.deletedAt !== null;
   // A decision is final; re-deciding would overturn it and wipe its stamps.
   const isDecidable =
@@ -42,9 +48,10 @@ export const resolveVacationPermissions = async (
     isOwner && isApprover ? await mayDecideOwn(userId, vacationRow.groupId, tx) : false;
 
   return {
-    canView: isOwner || isApprover || (membership?.viewAccess ?? false),
+    canView: isOwner || isApprover || canAdmin || (membership?.viewAccess ?? false),
     canApprove: isApprover && isDecidable && (!isOwner || ownAllowed),
-    canCancel: !isCancelled && (isOwner || isAdmin || isApprover),
+    canCancel: !isCancelled && (isOwner || canAdmin || isApprover),
+    canEdit: canAdmin && !isCancelled && vacationRow.rejectedAt === null,
   };
 };
 

--- a/src/db/schema/out/0015_watery_hulk.sql
+++ b/src/db/schema/out/0015_watery_hulk.sql
@@ -1,0 +1,11 @@
+ALTER TYPE "public"."vacation_event_type" ADD VALUE 'UPDATED';--> statement-breakpoint
+ALTER TABLE "vacation" ADD COLUMN "deleted_by_user_id" text;--> statement-breakpoint
+ALTER TABLE "vacation" ADD COLUMN "created_by_user_id" text;--> statement-breakpoint
+ALTER TABLE "vacation" ADD CONSTRAINT "vacation_deleted_by_user_id_user_id_fk" FOREIGN KEY ("deleted_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vacation" ADD CONSTRAINT "vacation_created_by_user_id_user_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+UPDATE "vacation" SET "created_by_user_id" = "user_id" WHERE "created_by_user_id" IS NULL;--> statement-breakpoint
+UPDATE "vacation" v SET "deleted_by_user_id" = (
+  SELECT e."actor_user_id" FROM "vacation_events" e
+  WHERE e."vacation_id" = v."id" AND e."event_type" = 'CANCELLED'
+  ORDER BY e."created_at" DESC LIMIT 1
+) WHERE v."deleted_at" IS NOT NULL AND v."deleted_by_user_id" IS NULL;

--- a/src/db/schema/out/meta/0015_snapshot.json
+++ b/src/db/schema/out/meta/0015_snapshot.json
@@ -1,0 +1,2990 @@
+{
+  "id": "2d4d20f8-5d79-4357-81db-da6a5eb8ccc4",
+  "prevId": "a3a20add-6f9f-4abf-a064-5c4ef5c992e6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_two_factor_user_id": {
+          "name": "idx_two_factor_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_two_factor_secret": {
+          "name": "idx_two_factor_secret",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_mirrors": {
+      "name": "group_mirrors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_group_id": {
+          "name": "target_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_mirrors_user_source_target_uniq": {
+          "name": "group_mirrors_user_source_target_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_mirrors\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_target_group_id": {
+          "name": "idx_group_mirrors_target_group_id",
+          "columns": [
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_user_id": {
+          "name": "idx_group_mirrors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_mirrors_user_id_user_id_fk": {
+          "name": "group_mirrors_user_id_user_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_source_group_id_groups_id_fk": {
+          "name": "group_mirrors_source_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_target_group_id_groups_id_fk": {
+          "name": "group_mirrors_target_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "target_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_organization_id": {
+          "name": "idx_groups_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_organization_id_organizations_id_fk": {
+          "name": "groups_organization_id_organizations_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approver_access": {
+          "name": "approver_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invite_link_group_id": {
+          "name": "idx_invite_link_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_group_email_open_uniq": {
+          "name": "invite_link_group_email_open_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_link\".\"used_at\" IS NULL AND \"invite_link\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_link_invited_by_user_id_user_id_fk": {
+          "name": "invite_link_invited_by_user_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_organizations_owner_user_id": {
+          "name": "uq_organizations_owner_user_id",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_users": {
+      "name": "organization_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "organization_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_users_org_id_user_id_uniq": {
+          "name": "organization_users_org_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organization_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_users_user_id": {
+          "name": "idx_organization_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_users_organization_id": {
+          "name": "idx_organization_users_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_users_organization_id_organizations_id_fk": {
+          "name": "organization_users_organization_id_organizations_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_users_user_id_user_id_fk": {
+          "name": "organization_users_user_id_user_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_users_granted_by_user_id_user_id_fk": {
+          "name": "organization_users_granted_by_user_id_user_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paddle_events": {
+      "name": "paddle_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_exports_user_id_idx": {
+          "name": "report_exports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_exports_created_at_idx": {
+          "name": "report_exports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_user_id_user_id_fk": {
+          "name": "report_exports_user_id_user_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_subscription_id": {
+          "name": "paddle_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "subscription_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "billing_cycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_group_slots": {
+          "name": "extra_group_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_override": {
+          "name": "manual_plan_override",
+          "type": "manual_plan_override",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_groups": {
+          "name": "manual_max_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_members_per_group": {
+          "name": "manual_max_members_per_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_until": {
+          "name": "manual_plan_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_subscriptions_organization_id": {
+          "name": "uq_subscriptions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_paddle_subscription_id": {
+          "name": "idx_subscriptions_paddle_subscription_id",
+          "columns": [
+            {
+              "expression": "paddle_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_organization_id_organizations_id_fk": {
+          "name": "subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboard_scope": {
+          "name": "dashboard_scope",
+          "type": "dashboard_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MINE'"
+        },
+        "dashboard_group_id": {
+          "name": "dashboard_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_settings_dashboard_group_id_groups_id_fk": {
+          "name": "user_settings_dashboard_group_id_groups_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "dashboard_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "carried_over_days": {
+          "name": "carried_over_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        },
+        "user_year_quotas_related_year_range_chk": {
+          "name": "user_year_quotas_related_year_range_chk",
+          "value": "\"user_year_quotas\".\"related_year\"::int BETWEEN 2025 AND 2100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "half_day": {
+          "name": "half_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_user_id": {
+          "name": "deleted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vacation\".\"deleted_at\" IS NULL AND \"vacation\".\"rejected_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_deleted_by_user_id_user_id_fk": {
+          "name": "vacation_deleted_by_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deleted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_created_by_user_id_user_id_fk": {
+          "name": "vacation_created_by_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.organization_role": {
+      "name": "organization_role",
+      "schema": "public",
+      "values": [
+        "ADMIN"
+      ]
+    },
+    "public.billing_cycle": {
+      "name": "billing_cycle",
+      "schema": "public",
+      "values": [
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.manual_plan_override": {
+      "name": "manual_plan_override",
+      "schema": "public",
+      "values": [
+        "FREE",
+        "PRO",
+        "ENTERPRISE",
+        "CUSTOM"
+      ]
+    },
+    "public.subscription_plan": {
+      "name": "subscription_plan",
+      "schema": "public",
+      "values": [
+        "PRO",
+        "ENTERPRISE"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "trialing",
+        "past_due",
+        "paused",
+        "canceled"
+      ]
+    },
+    "public.dashboard_scope": {
+      "name": "dashboard_scope",
+      "schema": "public",
+      "values": [
+        "MINE",
+        "GROUP"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT",
+        "UPDATED"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/_journal.json
+++ b/src/db/schema/out/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1787068632572,
       "tag": "0014_wandering_prism",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1787135740056,
+      "tag": "0015_watery_hulk",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/vacation-event-schema.ts
+++ b/src/db/schema/vacation-event-schema.ts
@@ -15,6 +15,7 @@ export enum vacationEventType {
   Rejected = "REJECTED",
   Cancelled = "CANCELLED",
   Comment = "COMMENT",
+  Updated = "UPDATED",
 }
 
 export const vacationEventTypeEnum = pgEnum("vacation_event_type", enumToPgEnum(vacationEventType));

--- a/src/db/schema/vacation-schema.ts
+++ b/src/db/schema/vacation-schema.ts
@@ -51,12 +51,21 @@ export const vacation = pgTable(
       onDelete: "set null",
     }),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    // Who cancelled the row. Nullable for rows deleted before the column
+    // existed; the CANCELLED timeline event carries the reason.
+    deletedByUserId: text("deleted_by_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
     rejectedAt: timestamp("rejected_at", { withTimezone: true }),
     rejectedBy: text("rejected_by").references(() => user.id, {
       onDelete: "set null",
     }),
     rejectionReason: text("rejection_reason"),
     note: text("note"),
+    // Differs from `userId` when an admin booked on the member's behalf.
+    createdByUserId: text("created_by_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()

--- a/src/routes/vacationRouter.ts
+++ b/src/routes/vacationRouter.ts
@@ -11,6 +11,7 @@ import {
   validateCommentVacation,
   validatePostVacation,
   validateRejectVacation,
+  validateUpdateVacation,
 } from "../services/vacation/types.js";
 import { handleGetVacation } from "../controllers/vacation/handleGetVacation.js";
 import { handlePostVacation } from "../controllers/vacation/handlePostVacation.js";
@@ -21,6 +22,7 @@ import { handleDeleteVacation } from "../controllers/vacation/handleDeleteVacati
 import { handleBulkApproveVacation } from "../controllers/vacation/handleBulkApproveVacation.js";
 import { handleBulkRejectVacation } from "../controllers/vacation/handleBulkRejectVacation.js";
 import { handleBulkCancelVacation } from "../controllers/vacation/handleBulkCancelVacation.js";
+import { handleUpdateVacation } from "../controllers/vacation/handleUpdateVacation.js";
 
 export const vacationRouter = (): Router => {
   const app = Router();
@@ -68,6 +70,17 @@ export const vacationRouter = (): Router => {
    *         schema:
    *           type: string
    *           format: uuid
+   *       - name: includeCancelled
+   *         in: query
+   *         required: false
+   *         description: |
+   *           When `true`, cancelled (soft-deleted) rows are included so the
+   *           requests view can show them with their `deletedAt` /
+   *           `deletedByUserId` stamps. Defaults to `false`, keeping the
+   *           calendar and dashboard on live rows only.
+   *         schema:
+   *           type: string
+   *           enum: ["true", "false"]
    *     responses:
    *       '200':
    *         description: Array of vacations matching the query
@@ -126,11 +139,13 @@ export const vacationRouter = (): Router => {
    *       - Vacations
    *     summary: Retrieve one vacation with its history
    *     description: |
-   *       Returns the request enriched with the requester, the group name and
-   *       the decision makers, the append-only event timeline (created,
-   *       approved, rejected, cancelled), and the actions this caller may take
-   *       (`canApprove`, `canCancel`). Cancelled requests remain retrievable so
-   *       the timeline can explain what happened to them.
+   *       Returns the request enriched with the requester, the group name, the
+   *       decision makers, who created it (`createdByUser` — an admin when it
+   *       was booked on the member's behalf) and who cancelled it
+   *       (`deletedByUser`), the append-only event timeline (created, approved,
+   *       rejected, cancelled, updated), and the actions this caller may take
+   *       (`canApprove`, `canCancel`, `canEdit`). Cancelled requests remain
+   *       retrievable so the timeline can explain what happened to them.
    *     security:
    *       - bearerAuth: []
    *     parameters:
@@ -161,6 +176,15 @@ export const vacationRouter = (): Router => {
    *       Creates a vacation request that spans an inclusive `from`/`to` range. The
    *       server fans the range out into one row per day, skipping any days the
    *       user already has a vacation for (unique on user + day).
+   *
+   *       Admins may book on behalf of a member by passing `userId`: the caller
+   *       must hold group admin access or administer the group's organization,
+   *       and the member must be allowed to book in the group. `createdByUserId`
+   *       records who filed the request. With `autoApprove` (valid only
+   *       together with `userId`) the rows are created already approved by the
+   *       caller and the timeline gets both a CREATED and an APPROVED event;
+   *       without it the request enters the normal approval flow and the member
+   *       is notified it was filed for them.
    *     operationId: handlePostVacation
    *     security:
    *       - bearerAuth: []
@@ -204,6 +228,9 @@ export const vacationRouter = (): Router => {
    *         groupId:
    *           type: string
    *           format: uuid
+   *         userId:
+   *           type: string
+   *           description: Book on behalf of this member (admins only).
    *         from:
    *           type: string
    *           format: date
@@ -221,6 +248,9 @@ export const vacationRouter = (): Router => {
    *         note:
    *           type: string
    *           nullable: true
+   *         autoApprove:
+   *           type: boolean
+   *           description: Create the rows already approved (on-behalf bookings only).
    *     Vacation:
    *       type: object
    *       properties:
@@ -485,8 +515,10 @@ export const vacationRouter = (): Router => {
    *     description: |
    *       Cancels every supplied day id together — used by the detail view to
    *       cancel a whole multi-day request at once. The caller must, for every
-   *       row, be the owner or have admin/approval rights on its group. An
-   *       optional `reason` is stored on each cancellation event.
+   *       row, be the owner, a group admin, an admin of the group's
+   *       organization, or an approver of its group. Each row is stamped with
+   *       `deletedByUserId`, and an optional `reason` is stored on each
+   *       cancellation event.
    *     security:
    *       - bearerAuth: []
    *     requestBody:
@@ -526,16 +558,94 @@ export const vacationRouter = (): Router => {
 
   /**
    * @openapi
+   * /api/vacation:
+   *   patch:
+   *     tags:
+   *       - Vacations
+   *     summary: Edit per-day fields of one member's vacation rows (admins only)
+   *     description: |
+   *       In-place edit of existing day rows: `startTime`/`endTime`, `halfDay`,
+   *       `vacationType` and `note`. Requires group admin access, or admin of
+   *       the group's organization. All ids must belong to the same member and
+   *       group; the detail view passes a whole contiguous run so it is edited
+   *       atomically. Dates are deliberately not editable — moving a record to
+   *       another day is a cancel + re-create, both audited.
+   *
+   *       Rejected rows cannot be edited (their decision is final) and
+   *       cancelled rows are reported as not found. Type and half-day changes
+   *       re-run the quota check at the rows' post-edit weight. Every row gets
+   *       an UPDATED timeline event whose `reason` summarizes what changed, and
+   *       the member gets an in-app notice when someone else edited their
+   *       record.
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - ids
+   *             properties:
+   *               ids:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *                   format: uuid
+   *               vacationType:
+   *                 type: string
+   *               startTime:
+   *                 type: string
+   *                 nullable: true
+   *               endTime:
+   *                 type: string
+   *                 nullable: true
+   *               halfDay:
+   *                 type: boolean
+   *                 description: Only valid when editing a single day row.
+   *               note:
+   *                 type: string
+   *                 nullable: true
+   *     responses:
+   *       '200':
+   *         description: The updated vacation rows
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/components/schemas/Vacation'
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
+   *       '403':
+   *         description: Not a group or organization admin for these records
+   *       '404':
+   *         description: One or more vacations not found (cancelled rows included)
+   *       '409':
+   *         description: Rejected rows in the batch, or a concurrent change won the race
+   *       '422':
+   *         description: Validation error, mixed members/groups, or the edit exceeds the allowance
+   */
+  app.patch("/", bodyValidationMiddleware(validateUpdateVacation), tryCatch(handleUpdateVacation));
+
+  /**
+   * @openapi
    * /api/vacation/{id}:
    *   delete:
    *     tags:
    *       - Vacations
    *     summary: Cancel (soft delete) a vacation request
    *     description: |
-   *       Soft deletes the vacation row by setting `deletedAt`, including
-   *       already-approved requests. The caller must own the row, or have admin
-   *       access or approval rights on the parent group. An optional `reason`
-   *       is stored on the cancellation event.
+   *       Soft deletes the vacation row by setting `deletedAt` and stamping
+   *       `deletedByUserId` with the caller, including already-approved
+   *       requests. The caller must own the row, or be a group admin, an
+   *       organization admin, or an approver of the parent group. An optional
+   *       `reason` is stored on the cancellation event; the row stays
+   *       retrievable on the detail view and in lists via `includeCancelled`.
    *     security:
    *       - bearerAuth: []
    *     parameters:

--- a/src/services/DBServices.ts
+++ b/src/services/DBServices.ts
@@ -30,6 +30,7 @@ export type DBServices = Readonly<{
     cancelVacationsBulk: typeof vacationServices.cancelVacationsBulk;
     getVacationsByIds: typeof vacationServices.getVacationsByIds;
     deleteVacation: typeof vacationServices.deleteVacation;
+    updateVacationRows: typeof vacationServices.updateVacationRows;
     getPendingApprovalsForApprover: typeof vacationServices.getPendingApprovalsForApprover;
     countUsersOutOnDay: typeof vacationServices.countUsersOutOnDay;
     countApprovedVacationsInRange: typeof vacationServices.countApprovedVacationsInRange;
@@ -190,6 +191,7 @@ export const createDBServices = (): DBServices => {
       cancelVacationsBulk: vacationServices.cancelVacationsBulk,
       getVacationsByIds: vacationServices.getVacationsByIds,
       deleteVacation: vacationServices.deleteVacation,
+      updateVacationRows: vacationServices.updateVacationRows,
       getPendingApprovalsForApprover: vacationServices.getPendingApprovalsForApprover,
       countUsersOutOnDay: vacationServices.countUsersOutOnDay,
       countApprovedVacationsInRange: vacationServices.countApprovedVacationsInRange,

--- a/src/services/vacation/quotaGuard.ts
+++ b/src/services/vacation/quotaGuard.ts
@@ -58,8 +58,8 @@ const allocationFor = async (check: QuotaCheck, tx: DbTransaction): Promise<numb
 
   const group = await services.group.getGroup(check.groupId, tx);
   return check.leaveType === vacationType.Vacation
-    ? (group?.defaultVacationDays ?? 0)
-    : (group?.defaultHomeOfficeDays ?? 0);
+    ? group?.defaultVacationDays ?? 0
+    : group?.defaultHomeOfficeDays ?? 0;
 };
 
 /**
@@ -146,6 +146,26 @@ export const assertRequestWithinQuota = async (
   tx: DbTransaction
 ): Promise<void> => {
   await assertGrouped(rows, [], true, tx);
+};
+
+/**
+ * Guards an in-place edit (type or half-day weight change). The edited rows are
+ * excluded from the current totals and added back at their post-edit weight;
+ * pending days still count, exactly as on create.
+ */
+export const assertEditWithinQuota = async (
+  newStateRows: Pick<
+    VacationType,
+    "id" | "userId" | "groupId" | "requestedDay" | "vacationType" | "halfDay"
+  >[],
+  tx: DbTransaction
+): Promise<void> => {
+  await assertGrouped(
+    newStateRows,
+    newStateRows.map((row) => row.id),
+    true,
+    tx
+  );
 };
 
 /** Rows already count as pending, so they are excluded and added back as granted days. */

--- a/src/services/vacation/tests/quotaGuard.test.ts
+++ b/src/services/vacation/tests/quotaGuard.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockSumCountedDaysForQuota, mockGetUserYearGroupQuotas, mockGetGroup } = vi.hoisted(() => ({
+  mockSumCountedDaysForQuota: vi.fn(),
+  mockGetUserYearGroupQuotas: vi.fn(),
+  mockGetGroup: vi.fn(),
+}));
+
+vi.mock("../../DBServices.js", () => ({
+  createDBServices: () => ({
+    vacation: { sumCountedDaysForQuota: mockSumCountedDaysForQuota },
+    userYearQuotas: { getUserYearGroupQuotas: mockGetUserYearGroupQuotas },
+    group: { getGroup: mockGetGroup },
+  }),
+}));
+
+import { assertEditWithinQuota, assertRequestWithinQuota } from "../quotaGuard.js";
+import { vacationType } from "../../../db/schema/vacation-schema.js";
+import type { DbTransaction } from "../../../db/db.js";
+
+const tx = { execute: vi.fn() } as unknown as DbTransaction;
+
+const editedRow = (overrides: Record<string, unknown> = {}) => ({
+  id: "v-1",
+  userId: "u-1",
+  groupId: "g-1",
+  requestedDay: "2026-08-20",
+  vacationType: vacationType.Vacation,
+  halfDay: false,
+  ...overrides,
+});
+
+describe("assertEditWithinQuota", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserYearGroupQuotas.mockResolvedValue([
+      { vacationDays: 1, carriedOverDays: 0, homeOfficeDays: 0 },
+    ]);
+  });
+
+  it("excludes the edited rows so their pre-edit weight is not double-counted", async () => {
+    // Allowance of exactly 1: the member's only booking is the row being
+    // edited. Without the exclusion the old full-day weight would still count
+    // and the same-weight edit would spuriously exceed the allowance.
+    mockSumCountedDaysForQuota.mockResolvedValue({ approved: 0, pending: 0 });
+
+    await expect(
+      assertEditWithinQuota([editedRow({ halfDay: true })], tx)
+    ).resolves.toBeUndefined();
+
+    expect(mockSumCountedDaysForQuota).toHaveBeenCalledWith(
+      "u-1",
+      "g-1",
+      2026,
+      vacationType.Vacation,
+      ["v-1"],
+      tx
+    );
+  });
+
+  it("rejects an edit whose post-edit weight exceeds the allowance", async () => {
+    // Other live bookings already hold the whole allowance.
+    mockSumCountedDaysForQuota.mockResolvedValue({ approved: 0.5, pending: 0.5 });
+
+    await expect(assertEditWithinQuota([editedRow()], tx)).rejects.toThrow(
+      "This would exceed the allowance for that leave type"
+    );
+  });
+
+  it("counts pending days, exactly as the create-time guard does", async () => {
+    mockSumCountedDaysForQuota.mockResolvedValue({ approved: 0, pending: 1 });
+
+    await expect(assertEditWithinQuota([editedRow({ halfDay: true })], tx)).rejects.toThrow(
+      "This would exceed the allowance for that leave type"
+    );
+  });
+
+  it("ignores non-quota-bearing types", async () => {
+    await expect(
+      assertEditWithinQuota([editedRow({ vacationType: vacationType.Sick })], tx)
+    ).resolves.toBeUndefined();
+    expect(mockSumCountedDaysForQuota).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertRequestWithinQuota", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserYearGroupQuotas.mockResolvedValue([
+      { vacationDays: 1, carriedOverDays: 0, homeOfficeDays: 0 },
+    ]);
+  });
+
+  it("excludes nothing — new rows are not stored yet", async () => {
+    mockSumCountedDaysForQuota.mockResolvedValue({ approved: 0, pending: 0 });
+
+    await assertRequestWithinQuota([editedRow()], tx);
+
+    expect(mockSumCountedDaysForQuota).toHaveBeenCalledWith(
+      "u-1",
+      "g-1",
+      2026,
+      vacationType.Vacation,
+      [],
+      tx
+    );
+  });
+});

--- a/src/services/vacation/tests/vacationChangeDetail.test.ts
+++ b/src/services/vacation/tests/vacationChangeDetail.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { describeVacationChanges } from "../vacationChangeDetail.js";
+import { vacationType } from "../../../db/schema/vacation-schema.js";
+
+const baseRow = {
+  startTime: "09:00:00" as string | null,
+  endTime: "17:00:00" as string | null,
+  vacationType: vacationType.Vacation,
+  halfDay: false,
+  note: null as string | null,
+};
+
+describe("describeVacationChanges", () => {
+  it("names only the fields that actually moved", () => {
+    expect(
+      describeVacationChanges(baseRow, { vacationType: vacationType.Sick, halfDay: true })
+    ).toBe("Type: Vacation → Sick; Half day: no → yes");
+  });
+
+  it("summarizes a time change with dashes for cleared values", () => {
+    expect(describeVacationChanges(baseRow, { startTime: null, endTime: null })).toBe(
+      "Time: 09:00:00–17:00:00 → —–—"
+    );
+  });
+
+  it("reports note adds without leaking the note text", () => {
+    expect(describeVacationChanges(baseRow, { note: "medical" })).toBe("Note added");
+    expect(describeVacationChanges({ ...baseRow, note: "old" }, { note: "new" })).toBe(
+      "Note updated"
+    );
+  });
+
+  it("falls back to a no-change label when the patch matches the row", () => {
+    expect(describeVacationChanges(baseRow, { halfDay: false })).toBe("Re-saved with no change");
+  });
+});

--- a/src/services/vacation/tests/vacationChangeDetail.test.ts
+++ b/src/services/vacation/tests/vacationChangeDetail.test.ts
@@ -23,10 +23,13 @@ describe("describeVacationChanges", () => {
     );
   });
 
-  it("reports note adds without leaking the note text", () => {
+  it("reports note adds, updates and removals without leaking the note text", () => {
     expect(describeVacationChanges(baseRow, { note: "medical" })).toBe("Note added");
     expect(describeVacationChanges({ ...baseRow, note: "old" }, { note: "new" })).toBe(
       "Note updated"
+    );
+    expect(describeVacationChanges({ ...baseRow, note: "old" }, { note: null })).toBe(
+      "Note removed"
     );
   });
 

--- a/src/services/vacation/tests/validatePostVacation.test.ts
+++ b/src/services/vacation/tests/validatePostVacation.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { validatePostVacation } from "../types.js";
+
+const base = {
+  groupId: "550e8400-e29b-41d4-a716-446655440009",
+  from: "2026-08-20",
+  to: "2026-08-20",
+};
+
+describe("validatePostVacation", () => {
+  it("accepts a better-auth-style (non-uuid) userId for on-behalf bookings", () => {
+    // Real accounts carry 32-char alphanumeric ids; only seeded/e2e users are
+    // uuids, so a uuid constraint here passes every test and fails production.
+    const parsed = validatePostVacation.parse({
+      ...base,
+      userId: "QKcQTLPBHUwm2aNwZIDhD95xle3e37VD",
+      autoApprove: true,
+    });
+    expect(parsed.userId).toBe("QKcQTLPBHUwm2aNwZIDhD95xle3e37VD");
+    expect(parsed.autoApprove).toBe(true);
+  });
+
+  it("rejects autoApprove without a target userId", () => {
+    expect(() => validatePostVacation.parse({ ...base, autoApprove: true })).toThrow();
+  });
+
+  it("defaults autoApprove to false", () => {
+    expect(validatePostVacation.parse(base).autoApprove).toBe(false);
+  });
+});

--- a/src/services/vacation/tests/validatePostVacation.test.ts
+++ b/src/services/vacation/tests/validatePostVacation.test.ts
@@ -21,7 +21,9 @@ describe("validatePostVacation", () => {
   });
 
   it("rejects autoApprove without a target userId", () => {
-    expect(() => validatePostVacation.parse({ ...base, autoApprove: true })).toThrow();
+    const result = validatePostVacation.safeParse({ ...base, autoApprove: true });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path.join("."))).toContain("autoApprove");
   });
 
   it("defaults autoApprove to false", () => {

--- a/src/services/vacation/types.ts
+++ b/src/services/vacation/types.ts
@@ -15,10 +15,12 @@ export type VacationType = {
   approvedAt: Date | null;
   approvedBy: string | null;
   deletedAt: Date | null;
+  deletedByUserId: string | null;
   rejectedAt: Date | null;
   rejectedBy: string | null;
   rejectionReason: string | null;
   note: string | null;
+  createdByUserId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -33,8 +35,11 @@ export type VacationInsertType = Pick<
   | "endTime"
   | "vacationType"
   | "halfDay"
+  | "createdByUserId"
 > & {
   note?: string | null;
+  approvedAt?: Date;
+  approvedBy?: string;
 };
 
 export type VacationListItem = VacationType & {
@@ -60,6 +65,8 @@ export type VacationDetail = VacationListItem & {
   groupName: string;
   approvedByUser: UserSummary | null;
   rejectedByUser: UserSummary | null;
+  createdByUser: UserSummary | null;
+  deletedByUser: UserSummary | null;
   // The contiguous same-type run this row belongs to: inclusive span + every day-row id in it.
   rangeStart: DateString;
   rangeEnd: DateString;
@@ -90,6 +97,10 @@ const requestableKindEnum = z.enum(REQUESTABLE_VACATION_TYPES);
 export const validatePostVacation = z
   .object({
     groupId: z.uuid(),
+    // Book on behalf of this member instead of the caller. Requires group
+    // admin rights; the handler authorizes it. Plain string, not uuid: real
+    // accounts carry better-auth's 32-char alphanumeric ids.
+    userId: z.string().min(1).optional(),
     from: z.coerce.date(),
     to: z.coerce.date(),
     vacationType: requestableKindEnum.default(vacationType.Vacation),
@@ -99,6 +110,7 @@ export const validatePostVacation = z
     // optional start/end times above are free-form and cannot stand in for it.
     halfDay: z.boolean().default(false),
     note: z.string().max(1000).nullable().default(null),
+    autoApprove: z.boolean().default(false),
   })
   .refine((data) => !(data.startTime && data.endTime) || data.endTime > data.startTime, {
     message: "`endTime` must be later than `startTime`",
@@ -107,6 +119,10 @@ export const validatePostVacation = z
   .refine((data) => !data.halfDay || data.from.getTime() === data.to.getTime(), {
     message: "`halfDay` is only valid for a single-day request",
     path: ["halfDay"],
+  })
+  .refine((data) => !data.autoApprove || data.userId !== undefined, {
+    message: "`autoApprove` is only valid when booking on behalf of a member",
+    path: ["autoApprove"],
   });
 
 export type ValidatedPostVacationType = z.infer<typeof validatePostVacation>;
@@ -162,3 +178,37 @@ export const validateBulkCancelVacation = z.object({
 });
 
 export type ValidatedBulkCancelVacationType = z.infer<typeof validateBulkCancelVacation>;
+
+/**
+ * Admin edit of existing day rows. Only per-day presentation and accounting
+ * fields are editable — moving a record to another day is a cancel + re-create,
+ * which keeps the partial `uniq_vacation_user_day` index authoritative.
+ */
+export const validateUpdateVacation = z
+  .object({
+    ids,
+    vacationType: requestableKindEnum.optional(),
+    startTime: z.iso.time().nullable().optional(),
+    endTime: z.iso.time().nullable().optional(),
+    halfDay: z.boolean().optional(),
+    note: z.string().max(1000).nullable().optional(),
+  })
+  .refine(
+    (data) =>
+      data.vacationType !== undefined ||
+      data.startTime !== undefined ||
+      data.endTime !== undefined ||
+      data.halfDay !== undefined ||
+      data.note !== undefined,
+    { message: "At least one field to update is required" }
+  )
+  .refine((data) => !(data.startTime && data.endTime) || data.endTime > data.startTime, {
+    message: "`endTime` must be later than `startTime`",
+    path: ["endTime"],
+  })
+  .refine((data) => data.halfDay !== true || new Set(data.ids).size === 1, {
+    message: "`halfDay` is only valid for a single-day record",
+    path: ["halfDay"],
+  });
+
+export type ValidatedUpdateVacationType = z.infer<typeof validateUpdateVacation>;

--- a/src/services/vacation/vacationChangeDetail.ts
+++ b/src/services/vacation/vacationChangeDetail.ts
@@ -50,7 +50,9 @@ export const describeVacationChanges = (
   }
 
   if (patch.note !== undefined && (patch.note ?? null) !== previous.note) {
-    diffs.push(previous.note ? "Note updated" : "Note added");
+    diffs.push(
+      patch.note === null ? "Note removed" : previous.note ? "Note updated" : "Note added"
+    );
   }
 
   return diffs.length > 0 ? diffs.join("; ") : "Re-saved with no change";

--- a/src/services/vacation/vacationChangeDetail.ts
+++ b/src/services/vacation/vacationChangeDetail.ts
@@ -1,0 +1,57 @@
+import { vacationType } from "../../db/schema/vacation-schema.js";
+import type { VacationType } from "./types.js";
+import type { VacationUpdatePatch } from "./vacationServices.js";
+
+const TYPE_LABELS: Record<vacationType, string> = {
+  [vacationType.Vacation]: "Vacation",
+  [vacationType.HomeOffice]: "Home office",
+  [vacationType.Sick]: "Sick",
+  [vacationType.BankHoliday]: "Bank holiday",
+  [vacationType.NonPaidLeave]: "Non-paid leave",
+  [vacationType.PaidTimeOff]: "Paid time off",
+  [vacationType.SickLeave]: "Sick leave",
+  [vacationType.StudyLeave]: "Study leave",
+  [vacationType.Other]: "Other",
+};
+
+const orDash = (value: string | null | undefined): string => (value?.length ? value : "—");
+
+type EditableRow = Pick<
+  VacationType,
+  "startTime" | "endTime" | "vacationType" | "halfDay" | "note"
+>;
+
+/**
+ * Human-readable summary of an in-place edit, stored as the UPDATED event's
+ * `reason`. Rendered verbatim on the request timeline, so it names only the
+ * fields that actually changed.
+ */
+export const describeVacationChanges = (
+  previous: EditableRow,
+  patch: VacationUpdatePatch
+): string => {
+  const diffs: string[] = [];
+
+  if (patch.vacationType !== undefined && patch.vacationType !== previous.vacationType) {
+    diffs.push(`Type: ${TYPE_LABELS[previous.vacationType]} → ${TYPE_LABELS[patch.vacationType]}`);
+  }
+  if (patch.halfDay !== undefined && patch.halfDay !== previous.halfDay) {
+    diffs.push(`Half day: ${previous.halfDay ? "yes" : "no"} → ${patch.halfDay ? "yes" : "no"}`);
+  }
+
+  const startChanged = patch.startTime !== undefined && patch.startTime !== previous.startTime;
+  const endChanged = patch.endTime !== undefined && patch.endTime !== previous.endTime;
+  if (startChanged || endChanged) {
+    const fromStart = orDash(previous.startTime);
+    const fromEnd = orDash(previous.endTime);
+    const toStart = orDash(patch.startTime !== undefined ? patch.startTime : previous.startTime);
+    const toEnd = orDash(patch.endTime !== undefined ? patch.endTime : previous.endTime);
+    diffs.push(`Time: ${fromStart}–${fromEnd} → ${toStart}–${toEnd}`);
+  }
+
+  if (patch.note !== undefined && (patch.note ?? null) !== previous.note) {
+    diffs.push(previous.note ? "Note updated" : "Note added");
+  }
+
+  return diffs.length > 0 ? diffs.join("; ") : "Re-saved with no change";
+};

--- a/src/services/vacation/vacationNotifier.ts
+++ b/src/services/vacation/vacationNotifier.ts
@@ -101,7 +101,8 @@ const groupByUser = (rows: VacationRow[]): Map<string, VacationRow[]> => {
  */
 type Delivery = {
   userId: string;
-  email: TemplatedEmail;
+  /** Absent for in-app-only notices (e.g. "booked on your behalf"). */
+  email?: TemplatedEmail;
   notification: {
     type: notificationType;
     title: string;
@@ -129,7 +130,10 @@ const deliver = async (deliveries: Delivery[]): Promise<void> => {
 
   await Promise.all(
     deliveries
-      .filter((delivery) => acceptsEmail.has(delivery.userId))
+      .filter(
+        (delivery): delivery is Delivery & { email: TemplatedEmail } =>
+          delivery.email !== undefined && acceptsEmail.has(delivery.userId)
+      )
       .map((delivery) => emailSender.sendTemplated(delivery.email))
   );
 };
@@ -214,6 +218,67 @@ export const notifyVacationRequested = async (
     );
   } catch (error) {
     logger.error("notifyVacationRequested failed", { error, requesterId: requester.id });
+  }
+};
+
+/**
+ * In-app-only notice to the member that an admin filed a (pending) request on
+ * their behalf. The approvers are notified separately by
+ * {@link notifyVacationRequested}; auto-approved bookings go through
+ * {@link notifyVacationDecision} instead.
+ */
+export const notifyVacationBookedOnBehalf = async (
+  rows: VacationRow[],
+  actor: { id: string; name: string }
+): Promise<void> => {
+  try {
+    const summary = summarize(rows);
+    if (!summary) return;
+
+    const memberId = rows[0]?.userId;
+    if (!memberId || memberId === actor.id) return;
+
+    await deliver([
+      {
+        userId: memberId,
+        notification: {
+          type: notificationType.ApprovalRequested,
+          title: `${actor.name} requested time off for you`,
+          body: `${summary.leaveType} · ${summary.dateRange} (${summary.dayCount})`,
+          href: summary.requestUrl,
+        },
+      },
+    ]);
+  } catch (error) {
+    logger.error("notifyVacationBookedOnBehalf failed", { error, actorId: actor.id });
+  }
+};
+
+/** In-app-only notice to the member that an admin edited their record. */
+export const notifyVacationUpdated = async (
+  rows: VacationRow[],
+  actor: { id: string; name: string }
+): Promise<void> => {
+  try {
+    const summary = summarize(rows);
+    if (!summary) return;
+
+    const memberId = rows[0]?.userId;
+    if (!memberId || memberId === actor.id) return;
+
+    await deliver([
+      {
+        userId: memberId,
+        notification: {
+          type: notificationType.ApprovalDecided,
+          title: `${actor.name} updated your time off`,
+          body: `${summary.leaveType} · ${summary.dateRange} (${summary.dayCount})`,
+          href: summary.requestUrl,
+        },
+      },
+    ]);
+  } catch (error) {
+    logger.error("notifyVacationUpdated failed", { error, actorId: actor.id });
   }
 };
 

--- a/src/services/vacation/vacationServices.ts
+++ b/src/services/vacation/vacationServices.ts
@@ -360,16 +360,21 @@ export const cancelVacationsBulk = async (
 /**
  * Fetches vacation rows by id (active rows only). Used during bulk approve /
  * reject to authorize the caller against every distinct group in the batch.
+ * `forUpdate` locks the rows for the transaction — the edit path needs it so a
+ * concurrent PATCH serializes behind this read instead of overwriting it with
+ * values (and an UPDATED-event summary) computed from a stale snapshot.
  */
 export const getVacationsByIds = async (
   vacationIds: string[],
-  tx?: DbTransaction
+  tx?: DbTransaction,
+  options?: { forUpdate?: boolean }
 ): Promise<VacationType[]> => {
   if (vacationIds.length === 0) return [];
-  return (tx ?? db)
+  const query = (tx ?? db)
     .select()
     .from(vacation)
     .where(and(inArray(vacation.id, vacationIds), isNull(vacation.deletedAt)));
+  return options?.forUpdate ? query.for("update") : query;
 };
 
 export const rejectVacation = async (

--- a/src/services/vacation/vacationServices.ts
+++ b/src/services/vacation/vacationServices.ts
@@ -60,10 +60,12 @@ const baseVacationSelection = {
   approvedAt: vacation.approvedAt,
   approvedBy: vacation.approvedBy,
   deletedAt: vacation.deletedAt,
+  deletedByUserId: vacation.deletedByUserId,
   rejectedAt: vacation.rejectedAt,
   rejectedBy: vacation.rejectedBy,
   rejectionReason: vacation.rejectionReason,
   note: vacation.note,
+  createdByUserId: vacation.createdByUserId,
   createdAt: vacation.createdAt,
   updatedAt: vacation.updatedAt,
   userName: user.name,
@@ -84,7 +86,8 @@ export const getVacationsForGroup = async (
   groupId: string,
   startDate: string,
   endDate: string,
-  userId: string | null = null
+  userId: string | null = null,
+  options?: { includeCancelled?: boolean }
 ): Promise<GroupVacationListItem[]> => {
   // A mirror only projects records of someone who still belongs to the target
   // group; without this a member who left would keep leaking time off into it.
@@ -105,7 +108,7 @@ export const getVacationsForGroup = async (
   const mirroredIntoThisGroup = and(isNotNull(groupMirrors.id), stillAMember);
 
   const base = [
-    isNull(vacation.deletedAt),
+    options?.includeCancelled ? undefined : isNull(vacation.deletedAt),
     gte(vacation.requestedDay, startDate),
     lt(vacation.requestedDay, endDate),
     or(inThisGroup, mirroredIntoThisGroup),
@@ -148,11 +151,12 @@ export const getVacationsForGroup = async (
 export const getVacationsForUser = async (
   userId: string,
   startDate: string,
-  endDate: string
+  endDate: string,
+  options?: { includeCancelled?: boolean }
 ): Promise<VacationListItem[]> => {
   const where = and(
     eq(vacation.userId, userId),
-    isNull(vacation.deletedAt),
+    options?.includeCancelled ? undefined : isNull(vacation.deletedAt),
     gte(vacation.requestedDay, startDate),
     lt(vacation.requestedDay, endDate)
   );
@@ -339,6 +343,7 @@ export const rejectVacationsBulk = async (
 /** Bulk-cancels (soft-deletes) many vacation rows in a single statement. See rejectVacationsBulk. */
 export const cancelVacationsBulk = async (
   vacationIds: string[],
+  cancellingPerson: string,
   tx?: DbTransaction
 ): Promise<VacationType[]> => {
   if (vacationIds.length === 0) return [];
@@ -346,6 +351,7 @@ export const cancelVacationsBulk = async (
     .update(vacation)
     .set({
       deletedAt: new Date(),
+      deletedByUserId: cancellingPerson,
     })
     .where(and(inArray(vacation.id, vacationIds), isNull(vacation.deletedAt)))
     .returning();
@@ -387,17 +393,50 @@ export const rejectVacation = async (
 
 export const deleteVacation = async (
   vacationId: string,
+  cancellingPerson: string,
   tx?: DbTransaction
 ): Promise<VacationType | undefined> => {
   const [row] = await (tx ?? db)
     .update(vacation)
     .set({
       deletedAt: new Date(),
+      deletedByUserId: cancellingPerson,
     })
     .where(and(eq(vacation.id, vacationId), isNull(vacation.deletedAt)))
     .returning();
 
   return row;
+};
+
+/** Per-day fields an admin may edit in place; day moves are cancel + re-create. */
+export type VacationUpdatePatch = Partial<
+  Pick<VacationType, "startTime" | "endTime" | "vacationType" | "halfDay" | "note">
+>;
+
+/**
+ * Applies one patch to many day rows in a single statement. Live rows only —
+ * the WHERE repeats the not-deleted/not-rejected predicate so a concurrent
+ * cancel or reject drops the row from RETURNING and the caller can 409 instead
+ * of silently resurrecting it. `deletedAt`/`rejectedAt` are never touched here,
+ * which keeps the partial `uniq_vacation_user_day` index out of play.
+ */
+export const updateVacationRows = async (
+  vacationIds: string[],
+  patch: VacationUpdatePatch,
+  tx?: DbTransaction
+): Promise<VacationType[]> => {
+  if (vacationIds.length === 0) return [];
+  return (tx ?? db)
+    .update(vacation)
+    .set(patch)
+    .where(
+      and(
+        inArray(vacation.id, vacationIds),
+        isNull(vacation.deletedAt),
+        isNull(vacation.rejectedAt)
+      )
+    )
+    .returning();
 };
 
 // Given all sibling rows, returns the consecutive-day run containing `targetDay` ([] if absent).
@@ -440,6 +479,8 @@ export const getVacationDetailById = async (
 ): Promise<VacationDetail | undefined> => {
   const approver = alias(user, "approvedByUser");
   const rejecter = alias(user, "rejectedByUser");
+  const creator = alias(user, "createdByUser");
+  const canceller = alias(user, "deletedByUser");
 
   const [row] = await (tx ?? db)
     .select({
@@ -447,18 +488,29 @@ export const getVacationDetailById = async (
       groupName: groups.groupName,
       approvedByName: approver.name,
       rejectedByName: rejecter.name,
+      createdByName: creator.name,
+      deletedByName: canceller.name,
     })
     .from(vacation)
     .innerJoin(user, eq(vacation.userId, user.id))
     .innerJoin(groups, eq(vacation.groupId, groups.id))
     .leftJoin(approver, eq(vacation.approvedBy, approver.id))
     .leftJoin(rejecter, eq(vacation.rejectedBy, rejecter.id))
+    .leftJoin(creator, eq(vacation.createdByUserId, creator.id))
+    .leftJoin(canceller, eq(vacation.deletedByUserId, canceller.id))
     .where(eq(vacation.id, vacationId))
     .limit(1);
 
   if (!row) return undefined;
 
-  const { groupName, approvedByName, rejectedByName, ...vacationRow } = row;
+  const {
+    groupName,
+    approvedByName,
+    rejectedByName,
+    createdByName,
+    deletedByName,
+    ...vacationRow
+  } = row;
 
   // Match the row's deletedAt/rejectedAt state so a re-booked day can't merge
   // into the cancelled or rejected run it replaced — both can sit on the same
@@ -495,6 +547,14 @@ export const getVacationDetailById = async (
     rejectedByUser:
       vacationRow.rejectedBy && rejectedByName
         ? buildUserSummary({ id: vacationRow.rejectedBy, name: rejectedByName })
+        : null,
+    createdByUser:
+      vacationRow.createdByUserId && createdByName
+        ? buildUserSummary({ id: vacationRow.createdByUserId, name: createdByName })
+        : null,
+    deletedByUser:
+      vacationRow.deletedByUserId && deletedByName
+        ? buildUserSummary({ id: vacationRow.deletedByUserId, name: deletedByName })
         : null,
   };
 };

--- a/src/tests/e2e/vacationOnBehalf.e2e.test.ts
+++ b/src/tests/e2e/vacationOnBehalf.e2e.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import request from "supertest";
+import {
+  setupTestEnvironment,
+  cleanupTestData,
+  createTestUser,
+  type TestContext,
+  type TestUser,
+} from "./helpers/testSetup.js";
+import { authCookieFor } from "./helpers/authHelper.js";
+import { db } from "../../db/db.js";
+import { vacation } from "../../db/schema/vacation-schema.js";
+import { groupUsers } from "../../db/schema/group-users-schema.js";
+import { organizationUsers } from "../../db/schema/organization-users-schema.js";
+import { organizations } from "../../db/schema/organization-schema.js";
+import { session } from "../../db/schema/auth-schema.js";
+import { v4 as uuidv4 } from "uuid";
+import { eq } from "drizzle-orm";
+
+// Booking is bounded to this year through the end of the next, so fixed dates
+// would fall out of range as time passes.
+const isoDay = (date: Date) => date.toISOString().slice(0, 10);
+const shift = (base: Date, days: number) => {
+  const next = new Date(base);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+};
+const firstMondayOfDecember = () => {
+  const day = new Date(Date.UTC(new Date().getUTCFullYear(), 11, 1));
+  while (day.getUTCDay() !== 1) day.setUTCDate(day.getUTCDate() + 1);
+  return day;
+};
+const MONDAY_OF_WEEK = firstMondayOfDecember();
+const MON = isoDay(MONDAY_OF_WEEK);
+const TUE = isoDay(shift(MONDAY_OF_WEEK, 1));
+const WED = isoDay(shift(MONDAY_OF_WEEK, 2));
+
+describe("Admin on-behalf vacation management E2E", () => {
+  let context: TestContext;
+  let orgAdmin: TestUser;
+
+  const addToGroup = async (
+    userId: string,
+    groupId: string,
+    permissions: { adminAccess?: boolean; approverAccess?: boolean } = {}
+  ) => {
+    await db.insert(groupUsers).values({
+      id: uuidv4(),
+      groupId,
+      userId,
+      controlledUser: true,
+      adminAccess: permissions.adminAccess ?? false,
+      approverAccess: permissions.approverAccess ?? false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  };
+
+  // user1 owns the organization (group manager); a delegated admin holds an
+  // organization_users row and no group membership at all.
+  const grantOrgAdmin = async (userId: string) => {
+    const [organization] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.ownerUserId, context.user1.id));
+    await db
+      .insert(organizationUsers)
+      .values({
+        id: uuidv4(),
+        organizationId: organization!.id,
+        userId,
+        grantedByUserId: context.user1.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .onConflictDoNothing();
+  };
+
+  beforeAll(async () => {
+    context = await setupTestEnvironment();
+    orgAdmin = await createTestUser("orgadmin@test.com", "Org Admin", "password123");
+  });
+
+  afterAll(async () => {
+    await db.delete(organizationUsers);
+    await cleanupTestData();
+  });
+
+  beforeEach(async () => {
+    await db.delete(vacation);
+    await db.delete(groupUsers);
+    await db.delete(session);
+  });
+
+  const createOnBehalf = (cookie: string[], body: Record<string, unknown>) =>
+    request(context.app)
+      .post("/api/vacation/create-vacation")
+      .set("Cookie", cookie)
+      .send({ groupId: context.group.id, from: WED, to: WED, userId: context.user2.id, ...body });
+
+  describe("create on behalf", () => {
+    it("lets a group admin book an auto-approved day for a member, fully attributed", async () => {
+      await addToGroup(context.user1.id, context.group.id, { adminAccess: true });
+      await addToGroup(context.user2.id, context.group.id);
+      const cookie = await authCookieFor(context.user1.id);
+
+      const response = await createOnBehalf(cookie, { autoApprove: true }).expect(201);
+
+      expect(response.body).toHaveLength(1);
+      expect(response.body[0]).toMatchObject({
+        userId: context.user2.id,
+        createdByUserId: context.user1.id,
+        approvedBy: context.user1.id,
+      });
+      expect(response.body[0].approvedAt).not.toBeNull();
+
+      const detail = await request(context.app)
+        .get(`/api/vacation/${response.body[0].id as string}`)
+        .set("Cookie", cookie)
+        .expect(200);
+      expect(detail.body.createdByUser).toMatchObject({ id: context.user1.id });
+      const eventTypes = detail.body.history.map((e: { eventType: string }) => e.eventType);
+      expect(eventTypes).toEqual(expect.arrayContaining(["CREATED", "APPROVED"]));
+    });
+
+    it("leaves the record pending when autoApprove is off", async () => {
+      await addToGroup(context.user1.id, context.group.id, { adminAccess: true });
+      await addToGroup(context.user2.id, context.group.id);
+      const cookie = await authCookieFor(context.user1.id);
+
+      const response = await createOnBehalf(cookie, { autoApprove: false }).expect(201);
+
+      expect(response.body[0].approvedAt).toBeNull();
+      expect(response.body[0].createdByUserId).toBe(context.user1.id);
+    });
+
+    it("refuses a plain member booking for someone else", async () => {
+      await addToGroup(context.user1.id, context.group.id);
+      await addToGroup(context.user2.id, context.group.id);
+      // user2 (no admin flag) tries to book for user1.
+      const cookie = await authCookieFor(context.user2.id);
+
+      await request(context.app)
+        .post("/api/vacation/create-vacation")
+        .set("Cookie", cookie)
+        .send({
+          groupId: context.group.id,
+          from: WED,
+          to: WED,
+          userId: context.user1.id,
+          autoApprove: true,
+        })
+        .expect(403);
+    });
+
+    it("refuses autoApprove on a self-booking", async () => {
+      await addToGroup(context.user1.id, context.group.id, { adminAccess: true });
+      const cookie = await authCookieFor(context.user1.id);
+
+      await request(context.app)
+        .post("/api/vacation/create-vacation")
+        .set("Cookie", cookie)
+        .send({
+          groupId: context.group.id,
+          from: WED,
+          to: WED,
+          userId: context.user1.id,
+          autoApprove: true,
+        })
+        .expect(422);
+    });
+  });
+
+  describe("PATCH /api/vacation", () => {
+    const bookedDay = async () => {
+      await addToGroup(context.user1.id, context.group.id, { adminAccess: true });
+      await addToGroup(context.user2.id, context.group.id);
+      const cookie = await authCookieFor(context.user1.id);
+      const created = await createOnBehalf(cookie, { autoApprove: true }).expect(201);
+      return { cookie, id: created.body[0].id as string };
+    };
+
+    it("edits per-day fields and appends an UPDATED event with a change summary", async () => {
+      const { cookie, id } = await bookedDay();
+
+      const response = await request(context.app)
+        .patch("/api/vacation")
+        .set("Cookie", cookie)
+        .send({ ids: [id], vacationType: "SICK", halfDay: true })
+        .expect(200);
+
+      expect(response.body[0]).toMatchObject({ vacationType: "SICK", halfDay: true });
+
+      const detail = await request(context.app)
+        .get(`/api/vacation/${id}`)
+        .set("Cookie", cookie)
+        .expect(200);
+      const updatedEvent = detail.body.history.find(
+        (e: { eventType: string }) => e.eventType === "UPDATED"
+      );
+      expect(updatedEvent).toBeDefined();
+      expect(updatedEvent.reason).toContain("Type: Vacation → Sick");
+      expect(updatedEvent.actor).toMatchObject({ id: context.user1.id });
+    });
+
+    it("refuses a non-admin caller", async () => {
+      const { id } = await bookedDay();
+      const memberCookie = await authCookieFor(context.user2.id);
+
+      await request(context.app)
+        .patch("/api/vacation")
+        .set("Cookie", memberCookie)
+        .send({ ids: [id], note: "sneaky" })
+        .expect(403);
+    });
+
+    it("404s for a cancelled record", async () => {
+      const { cookie, id } = await bookedDay();
+      await request(context.app).delete(`/api/vacation/${id}`).set("Cookie", cookie).expect(200);
+
+      await request(context.app)
+        .patch("/api/vacation")
+        .set("Cookie", cookie)
+        .send({ ids: [id], note: "too late" })
+        .expect(404);
+    });
+  });
+
+  describe("delete attribution and cancelled visibility", () => {
+    it("stamps deletedBy, keeps the row visible via includeCancelled, and frees the day", async () => {
+      await addToGroup(context.user1.id, context.group.id, { adminAccess: true });
+      await addToGroup(context.user2.id, context.group.id);
+      const cookie = await authCookieFor(context.user1.id);
+      const created = await createOnBehalf(cookie, { autoApprove: true }).expect(201);
+      const id = created.body[0].id as string;
+
+      await request(context.app)
+        .delete(`/api/vacation/${id}`)
+        .set("Cookie", cookie)
+        .send({ reason: "Booked by mistake" })
+        .expect(200);
+
+      const detail = await request(context.app)
+        .get(`/api/vacation/${id}`)
+        .set("Cookie", cookie)
+        .expect(200);
+      expect(detail.body.deletedAt).not.toBeNull();
+      expect(detail.body.deletedByUser).toMatchObject({ id: context.user1.id });
+
+      const [year, month] = WED.split("-");
+      const memberCookie = await authCookieFor(context.user2.id);
+      const withCancelled = await request(context.app)
+        .get("/api/vacation")
+        .set("Cookie", memberCookie)
+        .query({ year, month: Number(month), includeCancelled: "true" })
+        .expect(200);
+      expect(withCancelled.body.map((r: { id: string }) => r.id)).toContain(id);
+
+      const without = await request(context.app)
+        .get("/api/vacation")
+        .set("Cookie", memberCookie)
+        .query({ year, month: Number(month) })
+        .expect(200);
+      expect(without.body.map((r: { id: string }) => r.id)).not.toContain(id);
+
+      // The day is free again: the partial unique index ignores cancelled rows.
+      await createOnBehalf(cookie, { autoApprove: true }).expect(201);
+    });
+  });
+
+  describe("delegated org admin", () => {
+    it("has full on-behalf CRUD without any group membership", async () => {
+      await addToGroup(context.user2.id, context.group.id);
+      await grantOrgAdmin(orgAdmin.id);
+      const cookie = await authCookieFor(orgAdmin.id);
+
+      const created = await request(context.app)
+        .post("/api/vacation/create-vacation")
+        .set("Cookie", cookie)
+        .send({
+          groupId: context.group.id,
+          from: MON,
+          to: TUE,
+          userId: context.user2.id,
+          autoApprove: true,
+        })
+        .expect(201);
+      expect(created.body).toHaveLength(2);
+      expect(created.body[0]).toMatchObject({
+        createdByUserId: orgAdmin.id,
+        approvedBy: orgAdmin.id,
+      });
+
+      const ids = created.body.map((r: { id: string }) => r.id);
+      await request(context.app)
+        .patch("/api/vacation")
+        .set("Cookie", cookie)
+        .send({ ids, note: "team offsite" })
+        .expect(200);
+
+      await request(context.app)
+        .delete(`/api/vacation/${ids[0] as string}`)
+        .set("Cookie", cookie)
+        .expect(200);
+    });
+
+    it("still cannot approve a member-submitted pending request", async () => {
+      await addToGroup(context.user2.id, context.group.id);
+      await grantOrgAdmin(orgAdmin.id);
+
+      const memberCookie = await authCookieFor(context.user2.id);
+      const created = await request(context.app)
+        .post("/api/vacation/create-vacation")
+        .set("Cookie", memberCookie)
+        .send({ groupId: context.group.id, from: WED, to: WED })
+        .expect(201);
+      const id = created.body[0].id as string;
+
+      const cookie = await authCookieFor(orgAdmin.id);
+      await request(context.app)
+        .post(`/api/vacation/approve/${id}`)
+        .set("Cookie", cookie)
+        .expect(403);
+    });
+  });
+});


### PR DESCRIPTION
## What

Group admins **and** organization admins can now manage a member's vacation records, fully audited:

- **Create on behalf** — `POST /create-vacation` accepts `userId` + `autoApprove`. The booking lands on the member with `createdByUserId` recording who filed it. `autoApprove` (on-behalf only; refused for self-bookings) creates the rows already approved by the admin and writes CREATED + APPROVED timeline events; without it the request enters the normal approval flow, approvers see the *member* as requester, and the member gets an in-app "requested time off for you" notice.
- **Edit** — new `PATCH /api/vacation` edits per-day fields (times, half-day, type, note) of one member's contiguous run atomically. Rejected rows 409, cancelled rows 404, concurrent changes 409, weight changes re-run the quota guard at post-edit weight under the same advisory-lock ordering, and every row gets an UPDATED timeline event with a human-readable change summary. Dates are immutable — moving a day is cancel + re-create, both audited.
- **Delete attribution** — cancellation stamps `deletedByUserId` (single and bulk paths, now both org-admin-aware via `resolveGroupAdmin`), and `GET /api/vacation?includeCancelled=true` keeps cancelled rows visible to the requests view. Detail responses resolve `createdByUser`/`deletedByUser` and a new `canEdit` capability.
- **Org-admin boundary** — a scoped, documented carve-out: org admins may administer records on behalf of members, but still never decide member-submitted requests (`getGroupsWhereUserCanApprove` untouched; e2e asserts the 403).

Migration `0015`: two attributed-by columns (backfilled — creator = the member for historical rows, deleter recovered from the latest CANCELLED event) + the `UPDATED` enum value. ⚠️ Apply by hand in prod as usual; the `ALTER TYPE … ADD VALUE` is not referenced within the migration itself.

## Review findings fixed (3 independent review rounds)

- **Blocker**: on-behalf `userId` was validated as `z.uuid()`, which rejects every real better-auth account id (32-char alphanumeric) — only seeded/e2e users are uuids, so all suites passed while production would 422. Now `z.string().min(1)` with a regression test using a realistic id.
- Approver notifications on pending on-behalf bookings named the admin as requester (and mis-excluded them from the approver list); now the member is the requester, and the mail is skipped rather than mis-attributed if the post-commit member lookup fails.
- One-sided time edits could invert a stored range; `PATCH` now merge-checks each row's stored counterpart (422).
- `PATCH` authorizes every distinct group before the rejected/mixed checks, so record status can't leak to callers with no standing.
- Behavioral tests added for `assertEditWithinQuota`'s exclusion math; `halfDay` refine dedupes ids; `@openapi` docs updated (GET detail, bulk cancel, create, PATCH).

## Verified

- 526 unit + 175 e2e tests green (new e2e suite `vacationOnBehalf.e2e.test.ts`: both create paths, PATCH + timeline, delete attribution + `includeCancelled` visibility, re-booking a cancelled day, delegated org admin full CRUD but 403 on approving).
- Exercised end-to-end in the running stack (`npm run dev:scenario`, signed in as owner): on-behalf auto-approved + pending creates, edit with UPDATED timeline entry, cancel with reason, Cancelled tab, member's in-app notices.

## Reproduce

`npm run dev:scenario` → `http://localhost:3000/dev-sign-in/?email=owner@dev.local` → New Request → pick a member under "For" → toggle "Approve immediately" → open the record's detail for Edit/Cancel and the timeline.

Frontend counterpart: Daniel88dev/flexi-day#61 — **merge this backend PR first**; the frontend degrades gracefully against the old backend but the new UI needs these endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can book vacations for group members, optionally auto-approving them.
  * Administrators can batch-edit eligible vacation requests with change history.
  * Vacation details show who created and cancelled each request.
  * Cancelled vacations can be included in listings when requested.
  * Added clearer edit permissions and in-app notifications for delegated bookings and updates.

* **Bug Fixes**
  * Organization administrators can view, edit, and cancel eligible requests.
  * Cancellation actions now record the person who performed them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->