### PR TITLE
feat: per-group public holidays with a lazily cached dataset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "better-auth": "^1.6.29",
         "cors": "^2.8.5",
         "croner": "^10.0.1",
+        "date-holidays": "^3.35.0",
         "dotenv": "^17.2.3",
         "drizzle-orm": "^0.45.2",
         "exceljs": "^4.4.0",
@@ -3488,6 +3489,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -3512,6 +3519,15 @@
       "license": "MIT",
       "bin": {
         "astring": "bin/astring"
+      }
+    },
+    "node_modules/astronomia": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/astronomia/-/astronomia-4.2.0.tgz",
+      "integrity": "sha512-mTvpBGyXB80aSsDhAAiuwza5VqAyqmj5yzhjBrFhRy17DcWDzJrb8Vdl4Sm+g276S+mY7bk/5hi6akZ5RQFeHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/async": {
@@ -3917,6 +3933,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/caldate": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/caldate/-/caldate-2.0.5.tgz",
+      "integrity": "sha512-JndhrUuDuE975KUhFqJaVR1OQkCHZqpOrJur/CFXEIEhWhBMjxO85cRSK8q4FW+B+yyPq6GYua2u4KvNzTcq0w==",
+      "license": "ISC",
+      "dependencies": {
+        "moment-timezone": "^0.5.43"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4286,6 +4314,73 @@
         "node": ">= 8"
       }
     },
+    "node_modules/date-bengali-revised": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/date-bengali-revised/-/date-bengali-revised-2.0.2.tgz",
+      "integrity": "sha512-q9iDru4+TSA9k4zfm0CFHJj6nBsxP7AYgWC/qodK/i7oOIlj5K2z5IcQDtESfs/Qwqt/xJYaP86tkazd/vRptg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-chinese": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/date-chinese/-/date-chinese-2.1.4.tgz",
+      "integrity": "sha512-WY+6+Qw92ZGWFvGtStmNQHEYpNa87b8IAQ5T8VKt4wqrn24lBXyyBnWI5jAIyy7h/KVwJZ06bD8l/b7yss82Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "astronomia": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-easter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/date-easter/-/date-easter-1.0.3.tgz",
+      "integrity": "sha512-aOViyIgpM4W0OWUiLqivznwTtuMlD/rdUWhc5IatYnplhPiWrLv75cnifaKYhmQwUBLAMWLNG4/9mlLIbXoGBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-holidays": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/date-holidays/-/date-holidays-3.35.0.tgz",
+      "integrity": "sha512-+0n2980Gu7wfVUFp2w4oVYl4Bk2HOGKtxv5WUpOoo9e8bKzgZn6r+zdmZ91ze754mfV/G0TPOweiid+HKIBobg==",
+      "license": "(ISC AND CC-BY-3.0)",
+      "dependencies": {
+        "date-holidays-parser": "^3.4.7",
+        "js-yaml": "^5.2.2",
+        "lodash": "^4.18.1",
+        "prepin": "^1.0.3"
+      },
+      "bin": {
+        "holidays2json": "scripts/holidays2json.cjs"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-holidays-parser": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/date-holidays-parser/-/date-holidays-parser-3.4.7.tgz",
+      "integrity": "sha512-h09ZEtM6u5cYM6m1bX+1Ny9f+nLO9KVZUKNPEnH7lhbXYTfqZogaGTnhONswGeIJFF91UImIftS3CdM9HLW5oQ==",
+      "license": "ISC",
+      "dependencies": {
+        "astronomia": "^4.1.1",
+        "caldate": "^2.0.5",
+        "date-bengali-revised": "^2.0.2",
+        "date-chinese": "^2.1.4",
+        "date-easter": "^1.0.3",
+        "deepmerge": "^4.3.1",
+        "jalaali-js": "^1.2.7",
+        "moment-timezone": "^0.5.47"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.21",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
@@ -4315,6 +4410,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/defu": {
       "version": "6.1.7",
@@ -5777,6 +5881,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/jalaali-js": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/jalaali-js/-/jalaali-js-1.2.8.tgz",
+      "integrity": "sha512-Jl/EwY84JwjW2wsWqeU4pNd22VNQ7EkjI36bDuLw31wH98WQW4fPjD0+mG7cdCK+Y8D6s9R3zLiQ3LaKu6bD8A==",
+      "license": "MIT"
+    },
     "node_modules/jose": {
       "version": "6.2.9",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
@@ -5792,6 +5902,28 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -6256,6 +6388,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -6528,6 +6666,27 @@
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "license": "MIT"
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -6994,6 +7153,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prepin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/prepin/-/prepin-1.0.3.tgz",
+      "integrity": "sha512-0XL2hreherEEvUy0fiaGEfN/ioXFV+JpImqIzQjxk6iBg4jQ2ARKqvC4+BmRD8w/pnpD+lbxvh0Ub+z7yBEjvA==",
+      "license": "Unlicense",
+      "bin": {
+        "prepin": "bin/prepin.js"
       }
     },
     "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "better-auth": "^1.6.29",
     "cors": "^2.8.5",
     "croner": "^10.0.1",
+    "date-holidays": "^3.35.0",
     "dotenv": "^17.2.3",
     "drizzle-orm": "^0.45.2",
     "exceljs": "^4.4.0",

--- a/src/controllers/bankHoliday/handleGetBankHolidayCountries.ts
+++ b/src/controllers/bankHoliday/handleGetBankHolidayCountries.ts
@@ -1,0 +1,6 @@
+import type { Request, Response } from "express";
+import { getSupportedCountries } from "../../services/bankHoliday/holidayDataset.js";
+
+export const handleGetBankHolidayCountries = (_req: Request, res: Response) => {
+  return res.status(200).json(getSupportedCountries());
+};

--- a/src/controllers/bankHoliday/handleGetBankHolidays.ts
+++ b/src/controllers/bankHoliday/handleGetBankHolidays.ts
@@ -1,17 +1,29 @@
 import type { Request, Response } from "express";
 import { createDBServices } from "../../services/DBServices.js";
 import { validateBankHolidayQuery } from "../../services/bankHoliday/types.js";
+import {
+  computePublicHolidays,
+  isSupportedCountry,
+} from "../../services/bankHoliday/holidayDataset.js";
 
 const services = createDBServices();
 
 export const handleGetBankHolidays = async (req: Request, res: Response) => {
   const query = validateBankHolidayQuery.parse(req.query);
 
-  const result = await services.bankHoliday.listBankHolidays(
-    query.year,
-    query.country,
-    query.region
-  );
+  let result = await services.bankHoliday.listBankHolidays(query.year, query.country, query.region);
+
+  // Lazy fill: the table starts empty and is populated per (country, year) on
+  // first request. Unsupported countries simply stay empty. Region-filtered
+  // misses must not refill — the dataset rows carry no region, so the refill
+  // would duplicate an already-cached country instead of satisfying the query.
+  if (result.length === 0 && !query.region && isSupportedCountry(query.country)) {
+    const computed = computePublicHolidays(query.country, query.year);
+    if (computed.length > 0) {
+      await services.bankHoliday.insertBankHolidays(computed);
+      result = await services.bankHoliday.listBankHolidays(query.year, query.country, query.region);
+    }
+  }
 
   return res.status(200).json(
     result.map((row) => ({

--- a/src/controllers/bankHoliday/tests/handleGetBankHolidayCountries.test.ts
+++ b/src/controllers/bankHoliday/tests/handleGetBankHolidayCountries.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../../services/bankHoliday/holidayDataset.js", () => ({
+  getSupportedCountries: () => [
+    { code: "CZ", name: "Czech Republic" },
+    { code: "DE", name: "Germany" },
+  ],
+}));
+
+import { handleGetBankHolidayCountries } from "../handleGetBankHolidayCountries.js";
+import { makeReqRes } from "../../../tests/testUtils.js";
+
+describe("handleGetBankHolidayCountries", () => {
+  it("returns the supported countries", async () => {
+    const { req, res } = makeReqRes();
+
+    await handleGetBankHolidayCountries(req, res);
+
+    expect(vi.mocked(res.status).mock.calls[0]?.[0]).toBe(200);
+    expect(vi.mocked(res.json).mock.calls[0]?.[0]).toEqual([
+      { code: "CZ", name: "Czech Republic" },
+      { code: "DE", name: "Germany" },
+    ]);
+  });
+});

--- a/src/controllers/bankHoliday/tests/handleGetBankHolidays.test.ts
+++ b/src/controllers/bankHoliday/tests/handleGetBankHolidays.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockListBankHolidays, mockInsertBankHolidays, mockComputePublicHolidays } = vi.hoisted(
+  () => ({
+    mockListBankHolidays: vi.fn(),
+    mockInsertBankHolidays: vi.fn(),
+    mockComputePublicHolidays: vi.fn(),
+  })
+);
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    bankHoliday: {
+      listBankHolidays: mockListBankHolidays,
+      insertBankHolidays: mockInsertBankHolidays,
+    },
+  }),
+}));
+
+vi.mock("../../../services/bankHoliday/holidayDataset.js", () => ({
+  computePublicHolidays: mockComputePublicHolidays,
+  isSupportedCountry: (code: string) => code === "CZ",
+}));
+
+import { handleGetBankHolidays } from "../handleGetBankHolidays.js";
+import { makeReqRes } from "../../../tests/testUtils.js";
+
+const storedRow = {
+  id: "bh-1",
+  date: "2026-01-01",
+  name: "New Year's Day",
+  country: "CZ",
+  region: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const computedRow = { id: "bh-1", date: "2026-01-01", name: "New Year's Day", country: "CZ" };
+
+describe("handleGetBankHolidays", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("serves cached rows without touching the dataset", async () => {
+    mockListBankHolidays.mockResolvedValue([storedRow]);
+    const { req, res } = makeReqRes({ query: { country: "CZ", year: "2026" } });
+
+    await handleGetBankHolidays(req, res);
+
+    expect(mockComputePublicHolidays).not.toHaveBeenCalled();
+    expect(mockInsertBankHolidays).not.toHaveBeenCalled();
+    expect(vi.mocked(res.json).mock.calls[0]?.[0]).toEqual([
+      { date: "2026-01-01", name: "New Year's Day", country: "CZ", region: undefined },
+    ]);
+  });
+
+  it("computes, inserts and re-lists on a first request for a supported country", async () => {
+    mockListBankHolidays.mockResolvedValueOnce([]).mockResolvedValueOnce([storedRow]);
+    mockComputePublicHolidays.mockReturnValue([computedRow]);
+    const { req, res } = makeReqRes({ query: { country: "CZ", year: "2026" } });
+
+    await handleGetBankHolidays(req, res);
+
+    expect(mockComputePublicHolidays).toHaveBeenCalledWith("CZ", 2026);
+    expect(mockInsertBankHolidays).toHaveBeenCalledWith([computedRow]);
+    expect(mockListBankHolidays).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(res.json).mock.calls[0]?.[0]).toHaveLength(1);
+  });
+
+  it("returns an empty array for an unsupported country without inserting", async () => {
+    mockListBankHolidays.mockResolvedValue([]);
+    const { req, res } = makeReqRes({ query: { country: "ZZ", year: "2026" } });
+
+    await handleGetBankHolidays(req, res);
+
+    expect(mockComputePublicHolidays).not.toHaveBeenCalled();
+    expect(mockInsertBankHolidays).not.toHaveBeenCalled();
+    expect(vi.mocked(res.json).mock.calls[0]?.[0]).toEqual([]);
+  });
+
+  it("never fills from a region-filtered miss", async () => {
+    // The dataset rows carry no region, so a refill would duplicate the
+    // already-cached country rather than satisfy the region query.
+    mockListBankHolidays.mockResolvedValue([]);
+    const { req, res } = makeReqRes({
+      query: { country: "CZ", year: "2026", region: "PR" },
+    });
+
+    await handleGetBankHolidays(req, res);
+
+    expect(mockComputePublicHolidays).not.toHaveBeenCalled();
+    expect(mockInsertBankHolidays).not.toHaveBeenCalled();
+    expect(vi.mocked(res.json).mock.calls[0]?.[0]).toEqual([]);
+  });
+
+  it("does not insert when the dataset yields nothing", async () => {
+    mockListBankHolidays.mockResolvedValue([]);
+    mockComputePublicHolidays.mockReturnValue([]);
+    const { req, res } = makeReqRes({ query: { country: "CZ", year: "2026" } });
+
+    await handleGetBankHolidays(req, res);
+
+    expect(mockInsertBankHolidays).not.toHaveBeenCalled();
+    expect(mockListBankHolidays).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(res.json).mock.calls[0]?.[0]).toEqual([]);
+  });
+});

--- a/src/controllers/group/handlePutGroupHolidayCountry.ts
+++ b/src/controllers/group/handlePutGroupHolidayCountry.ts
@@ -1,0 +1,49 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { createDBServices } from "../../services/DBServices.js";
+import { assertGroupWritable } from "../../services/billing/guards.js";
+import { getAuth } from "../../middleware/authSession.js";
+import { assertGroupAdmin } from "../groupUser/utils.js";
+import type { ValidatedPutGroupHolidayCountryType } from "../../services/group/types.js";
+import AppError from "../../utils/appError.js";
+import { generateRandomUUID } from "../../utils/generateUUID.js";
+import { changesType } from "../../db/schema/changes-schema.js";
+
+const services = createDBServices();
+
+export const handlePutGroupHolidayCountry = async (req: Request, res: Response) => {
+  const auth = getAuth(req);
+
+  const groupId = z.uuid().parse(req.params.groupId);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data: ValidatedPutGroupHolidayCountryType = req.body;
+
+  await assertGroupAdmin(auth.userId, groupId);
+
+  await assertGroupWritable(groupId);
+
+  const updated = await services.group.updateGroupHolidayCountry(groupId, data.holidayCountry);
+
+  if (!updated) {
+    throw new AppError({
+      message: "Group not found",
+      logging: true,
+      code: 404,
+      context: { url: req.url, user: auth.userId, groupId },
+    });
+  }
+
+  await services.changes.postChanges({
+    id: generateRandomUUID(),
+    userId: auth.userId,
+    groupId,
+    changeType: changesType.Group,
+    changingUserId: auth.userId,
+    changeDetail: data.holidayCountry
+      ? `Public holidays set to ${data.holidayCountry}`
+      : "Public holidays disabled",
+  });
+
+  return res.status(200).json(updated);
+};

--- a/src/controllers/group/tests/handlePutGroupHolidayCountry.test.ts
+++ b/src/controllers/group/tests/handlePutGroupHolidayCountry.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockUpdateGroupHolidayCountry,
+  mockPostChanges,
+  mockAssertGroupAdmin,
+  mockAssertGroupWritable,
+} = vi.hoisted(() => ({
+  mockUpdateGroupHolidayCountry: vi.fn(),
+  mockPostChanges: vi.fn(),
+  mockAssertGroupAdmin: vi.fn(),
+  mockAssertGroupWritable: vi.fn(),
+}));
+
+vi.mock("../../../middleware/authSession.js", () => ({ getAuth: vi.fn() }));
+
+vi.mock("../../groupUser/utils.js", () => ({
+  assertGroupAdmin: mockAssertGroupAdmin,
+}));
+
+vi.mock("../../../services/billing/guards.js", () => ({
+  assertGroupWritable: mockAssertGroupWritable,
+}));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    group: { updateGroupHolidayCountry: mockUpdateGroupHolidayCountry },
+    changes: { postChanges: mockPostChanges },
+  }),
+}));
+
+import { handlePutGroupHolidayCountry } from "../handlePutGroupHolidayCountry.js";
+import { getAuth } from "../../../middleware/authSession.js";
+import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
+import AppError from "../../../utils/appError.js";
+
+const groupId = "550e8400-e29b-41d4-a716-446655440000";
+const group = { id: groupId, groupName: "Engineering", holidayCountry: "CZ" };
+
+describe("handlePutGroupHolidayCountry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getAuth).mockReturnValue(mockAuthData);
+    mockAssertGroupAdmin.mockResolvedValue(undefined);
+    mockAssertGroupWritable.mockResolvedValue(undefined);
+    mockUpdateGroupHolidayCountry.mockResolvedValue(group);
+  });
+
+  it("updates the country and writes an audit row", async () => {
+    const { req, res } = makeReqRes({ params: { groupId }, body: { holidayCountry: "CZ" } });
+
+    await handlePutGroupHolidayCountry(req, res);
+
+    expect(mockAssertGroupAdmin).toHaveBeenCalledWith(mockAuthData.userId, groupId);
+    expect(mockAssertGroupWritable).toHaveBeenCalledWith(groupId);
+    expect(mockUpdateGroupHolidayCountry).toHaveBeenCalledWith(groupId, "CZ");
+    expect(mockPostChanges).toHaveBeenCalledWith(
+      expect.objectContaining({ groupId, changeDetail: "Public holidays set to CZ" })
+    );
+    expect(vi.mocked(res.status).mock.calls[0]?.[0]).toBe(200);
+    expect(vi.mocked(res.json).mock.calls[0]?.[0]).toEqual(group);
+  });
+
+  it("clears the country with null and audits the disable", async () => {
+    mockUpdateGroupHolidayCountry.mockResolvedValue({ ...group, holidayCountry: null });
+    const { req, res } = makeReqRes({ params: { groupId }, body: { holidayCountry: null } });
+
+    await handlePutGroupHolidayCountry(req, res);
+
+    expect(mockUpdateGroupHolidayCountry).toHaveBeenCalledWith(groupId, null);
+    expect(mockPostChanges).toHaveBeenCalledWith(
+      expect.objectContaining({ changeDetail: "Public holidays disabled" })
+    );
+  });
+
+  it("404s for a group that does not exist", async () => {
+    mockUpdateGroupHolidayCountry.mockResolvedValue(undefined);
+    const { req, res } = makeReqRes({ params: { groupId }, body: { holidayCountry: "CZ" } });
+
+    await expect(handlePutGroupHolidayCountry(req, res)).rejects.toThrow("Group not found");
+    expect(mockPostChanges).not.toHaveBeenCalled();
+  });
+
+  it("propagates the 403 from the admin check without writing", async () => {
+    mockAssertGroupAdmin.mockRejectedValue(
+      new AppError({ message: "No access for related group", code: 403, logging: false })
+    );
+    const { req, res } = makeReqRes({ params: { groupId }, body: { holidayCountry: "CZ" } });
+
+    await expect(handlePutGroupHolidayCountry(req, res)).rejects.toThrow(
+      "No access for related group"
+    );
+    expect(mockUpdateGroupHolidayCountry).not.toHaveBeenCalled();
+  });
+
+  it("propagates the 402 billing guard without writing", async () => {
+    mockAssertGroupWritable.mockRejectedValue(
+      new AppError({ message: "Plan lapsed", code: 402, logging: false })
+    );
+    const { req, res } = makeReqRes({ params: { groupId }, body: { holidayCountry: "CZ" } });
+
+    await expect(handlePutGroupHolidayCountry(req, res)).rejects.toThrow("Plan lapsed");
+    expect(mockUpdateGroupHolidayCountry).not.toHaveBeenCalled();
+  });
+});

--- a/src/db/schema/bank-holiday-schema.ts
+++ b/src/db/schema/bank-holiday-schema.ts
@@ -1,4 +1,5 @@
 import { date, index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { isNull } from "drizzle-orm";
 
 export const bankHolidays = pgTable(
   "bank_holidays",
@@ -22,5 +23,11 @@ export const bankHolidays = pgTable(
       table.region,
       table.date
     ),
+    // The index above never fires for NULL regions (Postgres treats NULLs as
+    // distinct), yet the dataset fill writes exactly those rows — without this
+    // partial index, concurrent first fills would duplicate every holiday.
+    uniqueIndex("bank_holidays_country_date_no_region_uidx")
+      .on(table.country, table.date)
+      .where(isNull(table.region)),
   ]
 );

--- a/src/db/schema/group-schema.ts
+++ b/src/db/schema/group-schema.ts
@@ -15,6 +15,8 @@ export const groups = pgTable(
     defaultHomeOfficeDays: integer("default_home_office_days").notNull().default(0),
     // JS `Date.getUTCDay()` numbers (0=Sun … 6=Sat); default Mon–Fri.
     workingDays: integer("working_days").array().notNull().default([1, 2, 3, 4, 5]),
+    // ISO 3166-1 alpha-2; null disables public holidays for the group.
+    holidayCountry: text("holiday_country"),
     managerUserId: text("manager_user_id")
       .notNull()
       .references(() => user.id),

--- a/src/db/schema/out/0016_wandering_lilith.sql
+++ b/src/db/schema/out/0016_wandering_lilith.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "groups" ADD COLUMN "holiday_country" text;

--- a/src/db/schema/out/0017_hot_mysterio.sql
+++ b/src/db/schema/out/0017_hot_mysterio.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "bank_holidays_country_date_no_region_uidx" ON "bank_holidays" USING btree ("country","date") WHERE "bank_holidays"."region" is null;

--- a/src/db/schema/out/meta/0016_snapshot.json
+++ b/src/db/schema/out/meta/0016_snapshot.json
@@ -1,0 +1,2996 @@
+{
+  "id": "497bf784-26cc-4343-a597-830d7649f17f",
+  "prevId": "2d4d20f8-5d79-4357-81db-da6a5eb8ccc4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_two_factor_user_id": {
+          "name": "idx_two_factor_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_two_factor_secret": {
+          "name": "idx_two_factor_secret",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_mirrors": {
+      "name": "group_mirrors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_group_id": {
+          "name": "target_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_mirrors_user_source_target_uniq": {
+          "name": "group_mirrors_user_source_target_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_mirrors\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_target_group_id": {
+          "name": "idx_group_mirrors_target_group_id",
+          "columns": [
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_user_id": {
+          "name": "idx_group_mirrors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_mirrors_user_id_user_id_fk": {
+          "name": "group_mirrors_user_id_user_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_source_group_id_groups_id_fk": {
+          "name": "group_mirrors_source_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_target_group_id_groups_id_fk": {
+          "name": "group_mirrors_target_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "target_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "holiday_country": {
+          "name": "holiday_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_organization_id": {
+          "name": "idx_groups_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_organization_id_organizations_id_fk": {
+          "name": "groups_organization_id_organizations_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approver_access": {
+          "name": "approver_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invite_link_group_id": {
+          "name": "idx_invite_link_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_group_email_open_uniq": {
+          "name": "invite_link_group_email_open_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_link\".\"used_at\" IS NULL AND \"invite_link\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_link_invited_by_user_id_user_id_fk": {
+          "name": "invite_link_invited_by_user_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_organizations_owner_user_id": {
+          "name": "uq_organizations_owner_user_id",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_users": {
+      "name": "organization_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "organization_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_users_org_id_user_id_uniq": {
+          "name": "organization_users_org_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organization_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_users_user_id": {
+          "name": "idx_organization_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_users_organization_id": {
+          "name": "idx_organization_users_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_users_organization_id_organizations_id_fk": {
+          "name": "organization_users_organization_id_organizations_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_users_user_id_user_id_fk": {
+          "name": "organization_users_user_id_user_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_users_granted_by_user_id_user_id_fk": {
+          "name": "organization_users_granted_by_user_id_user_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paddle_events": {
+      "name": "paddle_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_exports_user_id_idx": {
+          "name": "report_exports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_exports_created_at_idx": {
+          "name": "report_exports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_user_id_user_id_fk": {
+          "name": "report_exports_user_id_user_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_subscription_id": {
+          "name": "paddle_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "subscription_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "billing_cycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_group_slots": {
+          "name": "extra_group_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_override": {
+          "name": "manual_plan_override",
+          "type": "manual_plan_override",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_groups": {
+          "name": "manual_max_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_members_per_group": {
+          "name": "manual_max_members_per_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_until": {
+          "name": "manual_plan_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_subscriptions_organization_id": {
+          "name": "uq_subscriptions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_paddle_subscription_id": {
+          "name": "idx_subscriptions_paddle_subscription_id",
+          "columns": [
+            {
+              "expression": "paddle_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_organization_id_organizations_id_fk": {
+          "name": "subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboard_scope": {
+          "name": "dashboard_scope",
+          "type": "dashboard_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MINE'"
+        },
+        "dashboard_group_id": {
+          "name": "dashboard_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_settings_dashboard_group_id_groups_id_fk": {
+          "name": "user_settings_dashboard_group_id_groups_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "dashboard_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "carried_over_days": {
+          "name": "carried_over_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        },
+        "user_year_quotas_related_year_range_chk": {
+          "name": "user_year_quotas_related_year_range_chk",
+          "value": "\"user_year_quotas\".\"related_year\"::int BETWEEN 2025 AND 2100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "half_day": {
+          "name": "half_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_user_id": {
+          "name": "deleted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vacation\".\"deleted_at\" IS NULL AND \"vacation\".\"rejected_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_deleted_by_user_id_user_id_fk": {
+          "name": "vacation_deleted_by_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deleted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_created_by_user_id_user_id_fk": {
+          "name": "vacation_created_by_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.organization_role": {
+      "name": "organization_role",
+      "schema": "public",
+      "values": [
+        "ADMIN"
+      ]
+    },
+    "public.billing_cycle": {
+      "name": "billing_cycle",
+      "schema": "public",
+      "values": [
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.manual_plan_override": {
+      "name": "manual_plan_override",
+      "schema": "public",
+      "values": [
+        "FREE",
+        "PRO",
+        "ENTERPRISE",
+        "CUSTOM"
+      ]
+    },
+    "public.subscription_plan": {
+      "name": "subscription_plan",
+      "schema": "public",
+      "values": [
+        "PRO",
+        "ENTERPRISE"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "trialing",
+        "past_due",
+        "paused",
+        "canceled"
+      ]
+    },
+    "public.dashboard_scope": {
+      "name": "dashboard_scope",
+      "schema": "public",
+      "values": [
+        "MINE",
+        "GROUP"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT",
+        "UPDATED"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/0017_snapshot.json
+++ b/src/db/schema/out/meta/0017_snapshot.json
@@ -1,0 +1,3018 @@
+{
+  "id": "bb7ffe5f-3194-4b8a-a0fc-5b09b2a9ae67",
+  "prevId": "497bf784-26cc-4343-a597-830d7649f17f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_two_factor_user_id": {
+          "name": "idx_two_factor_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_two_factor_secret": {
+          "name": "idx_two_factor_secret",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_date_no_region_uidx": {
+          "name": "bank_holidays_country_date_no_region_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"bank_holidays\".\"region\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_mirrors": {
+      "name": "group_mirrors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_group_id": {
+          "name": "target_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_mirrors_user_source_target_uniq": {
+          "name": "group_mirrors_user_source_target_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_mirrors\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_target_group_id": {
+          "name": "idx_group_mirrors_target_group_id",
+          "columns": [
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_user_id": {
+          "name": "idx_group_mirrors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_mirrors_user_id_user_id_fk": {
+          "name": "group_mirrors_user_id_user_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_source_group_id_groups_id_fk": {
+          "name": "group_mirrors_source_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_target_group_id_groups_id_fk": {
+          "name": "group_mirrors_target_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "target_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "holiday_country": {
+          "name": "holiday_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_organization_id": {
+          "name": "idx_groups_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_organization_id_organizations_id_fk": {
+          "name": "groups_organization_id_organizations_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approver_access": {
+          "name": "approver_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invite_link_group_id": {
+          "name": "idx_invite_link_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_group_email_open_uniq": {
+          "name": "invite_link_group_email_open_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_link\".\"used_at\" IS NULL AND \"invite_link\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_link_invited_by_user_id_user_id_fk": {
+          "name": "invite_link_invited_by_user_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_organizations_owner_user_id": {
+          "name": "uq_organizations_owner_user_id",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_users": {
+      "name": "organization_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "organization_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_users_org_id_user_id_uniq": {
+          "name": "organization_users_org_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organization_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_users_user_id": {
+          "name": "idx_organization_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_users_organization_id": {
+          "name": "idx_organization_users_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_users_organization_id_organizations_id_fk": {
+          "name": "organization_users_organization_id_organizations_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_users_user_id_user_id_fk": {
+          "name": "organization_users_user_id_user_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_users_granted_by_user_id_user_id_fk": {
+          "name": "organization_users_granted_by_user_id_user_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paddle_events": {
+      "name": "paddle_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_exports_user_id_idx": {
+          "name": "report_exports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_exports_created_at_idx": {
+          "name": "report_exports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_user_id_user_id_fk": {
+          "name": "report_exports_user_id_user_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_subscription_id": {
+          "name": "paddle_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "subscription_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "billing_cycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_group_slots": {
+          "name": "extra_group_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_override": {
+          "name": "manual_plan_override",
+          "type": "manual_plan_override",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_groups": {
+          "name": "manual_max_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_members_per_group": {
+          "name": "manual_max_members_per_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_until": {
+          "name": "manual_plan_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_subscriptions_organization_id": {
+          "name": "uq_subscriptions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_paddle_subscription_id": {
+          "name": "idx_subscriptions_paddle_subscription_id",
+          "columns": [
+            {
+              "expression": "paddle_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_organization_id_organizations_id_fk": {
+          "name": "subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboard_scope": {
+          "name": "dashboard_scope",
+          "type": "dashboard_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MINE'"
+        },
+        "dashboard_group_id": {
+          "name": "dashboard_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_settings_dashboard_group_id_groups_id_fk": {
+          "name": "user_settings_dashboard_group_id_groups_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "dashboard_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "carried_over_days": {
+          "name": "carried_over_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        },
+        "user_year_quotas_related_year_range_chk": {
+          "name": "user_year_quotas_related_year_range_chk",
+          "value": "\"user_year_quotas\".\"related_year\"::int BETWEEN 2025 AND 2100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "half_day": {
+          "name": "half_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_user_id": {
+          "name": "deleted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vacation\".\"deleted_at\" IS NULL AND \"vacation\".\"rejected_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_deleted_by_user_id_user_id_fk": {
+          "name": "vacation_deleted_by_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deleted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_created_by_user_id_user_id_fk": {
+          "name": "vacation_created_by_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.organization_role": {
+      "name": "organization_role",
+      "schema": "public",
+      "values": [
+        "ADMIN"
+      ]
+    },
+    "public.billing_cycle": {
+      "name": "billing_cycle",
+      "schema": "public",
+      "values": [
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.manual_plan_override": {
+      "name": "manual_plan_override",
+      "schema": "public",
+      "values": [
+        "FREE",
+        "PRO",
+        "ENTERPRISE",
+        "CUSTOM"
+      ]
+    },
+    "public.subscription_plan": {
+      "name": "subscription_plan",
+      "schema": "public",
+      "values": [
+        "PRO",
+        "ENTERPRISE"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "trialing",
+        "past_due",
+        "paused",
+        "canceled"
+      ]
+    },
+    "public.dashboard_scope": {
+      "name": "dashboard_scope",
+      "schema": "public",
+      "values": [
+        "MINE",
+        "GROUP"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT",
+        "UPDATED"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/_journal.json
+++ b/src/db/schema/out/meta/_journal.json
@@ -113,6 +113,20 @@
       "when": 1787135740056,
       "tag": "0015_watery_hulk",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1787228007292,
+      "tag": "0016_wandering_lilith",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1787232375463,
+      "tag": "0017_hot_mysterio",
+      "breakpoints": true
     }
   ]
 }

--- a/src/routes/bankHolidayRouter.ts
+++ b/src/routes/bankHolidayRouter.ts
@@ -1,9 +1,44 @@
 import { Router } from "express";
 import { tryCatch } from "../middleware/tryCatch.js";
 import { handleGetBankHolidays } from "../controllers/bankHoliday/handleGetBankHolidays.js";
+import { handleGetBankHolidayCountries } from "../controllers/bankHoliday/handleGetBankHolidayCountries.js";
 
 export const bankHolidayRouter = (): Router => {
   const app = Router();
+
+  /**
+   * @openapi
+   * /api/bank-holidays/countries:
+   *   get:
+   *     tags:
+   *       - BankHolidays
+   *     summary: List countries with a supported public holiday dataset
+   *     description: |
+   *       Returns every country the holiday dataset can compute public
+   *       holidays for. Codes are ISO 3166-1 alpha-2 and are the only values
+   *       accepted by `PUT /api/group/{groupId}/holiday-country`.
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       '200':
+   *         description: Array of supported countries
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 type: object
+   *                 properties:
+   *                   code:
+   *                     type: string
+   *                     example: CZ
+   *                   name:
+   *                     type: string
+   *                     example: Czech Republic
+   *       '401':
+   *         description: Unauthorized - missing or invalid authentication
+   */
+  app.get("/countries", tryCatch(handleGetBankHolidayCountries));
 
   /**
    * @openapi
@@ -12,6 +47,11 @@ export const bankHolidayRouter = (): Router => {
    *     tags:
    *       - BankHolidays
    *     summary: List bank holidays for a country (and optional region) and year
+   *     description: |
+   *       Serves from the `bank_holidays` table. On the first request for a
+   *       supported country and year the public holidays are computed from the
+   *       bundled dataset and cached in the table. Unsupported countries
+   *       return an empty array.
    *     security:
    *       - bearerAuth: []
    *     parameters:

--- a/src/routes/groupRouter.ts
+++ b/src/routes/groupRouter.ts
@@ -5,9 +5,11 @@ import { handleGetGroups } from "../controllers/group/handleGetGroups.js";
 import { handleGetGroup } from "../controllers/group/handleGetGroup.js";
 import { handlePutGroupQuotas } from "../controllers/group/handlePutGroupQuotas.js";
 import { handlePutGroupWorkingDays } from "../controllers/group/handlePutGroupWorkingDays.js";
+import { handlePutGroupHolidayCountry } from "../controllers/group/handlePutGroupHolidayCountry.js";
 import { bodyValidationMiddleware } from "../middleware/validationMiddleware.js";
 import {
   validatePutGroupApprovers,
+  validatePutGroupHolidayCountry,
   validatePutGroupQuotas,
   validatePutGroupWorkingDays,
 } from "../services/group/types.js";
@@ -212,6 +214,65 @@ export const groupRouter = (): Router => {
     "/:groupId/working-days",
     bodyValidationMiddleware(validatePutGroupWorkingDays),
     tryCatch(handlePutGroupWorkingDays)
+  );
+
+  /**
+   * @openapi
+   * /api/group/{groupId}/holiday-country:
+   *   put:
+   *     tags:
+   *       - Groups
+   *     summary: Set the group's public holiday country
+   *     description: |
+   *       Sets the country whose public holidays are shown on the dashboard
+   *       calendar for everyone in the group. Holidays are display-only: they
+   *       are not counted against quotas and are never exported by calendar
+   *       feeds. `null` disables them. Codes are ISO 3166-1 alpha-2 and must
+   *       be one of `GET /api/bank-holidays/countries`. Requires group admin
+   *       access, or admin of the group's organization.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: groupId
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - holidayCountry
+   *             properties:
+   *               holidayCountry:
+   *                 type: string
+   *                 nullable: true
+   *                 minLength: 2
+   *                 maxLength: 2
+   *                 example: CZ
+   *     responses:
+   *       '200':
+   *         description: The updated group
+   *       '402':
+   *         description: |
+   *           Plan limit reached, or the group is read-only because the plan
+   *           lapsed. `errors[].context` carries
+   *           `{ reason: "PLAN_LIMIT" | "READ_ONLY", limit, current }`.
+   *       '403':
+   *         description: No permission for related group
+   *       '404':
+   *         description: Group not found
+   *       '422':
+   *         description: Unsupported country code
+   */
+  app.put(
+    "/:groupId/holiday-country",
+    bodyValidationMiddleware(validatePutGroupHolidayCountry),
+    tryCatch(handlePutGroupHolidayCountry)
   );
 
   /**

--- a/src/services/DBServices.ts
+++ b/src/services/DBServices.ts
@@ -74,6 +74,7 @@ export type DBServices = Readonly<{
     deleteGroup: typeof groupServices.deleteGroup;
     updateGroupQuotas: typeof groupServices.updateGroupQuotas;
     updateGroupWorkingDays: typeof groupServices.updateGroupWorkingDays;
+    updateGroupHolidayCountry: typeof groupServices.updateGroupHolidayCountry;
     getApprovalUsers: typeof groupServices.getApprovalUsers;
     getGroupsWhereUserCanApprove: typeof groupServices.getGroupsWhereUserCanApprove;
     countLiveGroupsForOrganization: typeof groupServices.countLiveGroupsForOrganization;
@@ -113,6 +114,7 @@ export type DBServices = Readonly<{
   };
   bankHoliday: {
     listBankHolidays: typeof bankHolidayServices.listBankHolidays;
+    insertBankHolidays: typeof bankHolidayServices.insertBankHolidays;
   };
   notification: {
     listNotificationsForUser: typeof notificationServices.listNotificationsForUser;
@@ -235,6 +237,7 @@ export const createDBServices = (): DBServices => {
       deleteGroup: groupServices.deleteGroup,
       updateGroupQuotas: groupServices.updateGroupQuotas,
       updateGroupWorkingDays: groupServices.updateGroupWorkingDays,
+      updateGroupHolidayCountry: groupServices.updateGroupHolidayCountry,
       getApprovalUsers: groupServices.getApprovalUsers,
       getGroupsWhereUserCanApprove: groupServices.getGroupsWhereUserCanApprove,
       countLiveGroupsForOrganization: groupServices.countLiveGroupsForOrganization,
@@ -274,6 +277,7 @@ export const createDBServices = (): DBServices => {
     },
     bankHoliday: {
       listBankHolidays: bankHolidayServices.listBankHolidays,
+      insertBankHolidays: bankHolidayServices.insertBankHolidays,
     },
     notification: {
       listNotificationsForUser: notificationServices.listNotificationsForUser,

--- a/src/services/bankHoliday/bankHolidayServices.ts
+++ b/src/services/bankHoliday/bankHolidayServices.ts
@@ -32,9 +32,10 @@ export const listBankHolidays = async (
 };
 
 /**
- * Inserts bank holiday rows, ignoring any that already exist. Conflict-free by
- * the `(country, region, date)` unique index, so concurrent first-time fills
- * for the same country and year are safe.
+ * Inserts bank holiday rows, ignoring any that already exist. Concurrent
+ * first-time fills are safe because of the partial unique index on
+ * `(country, date) WHERE region IS NULL` — the `(country, region, date)`
+ * index alone never fires for the NULL-region rows the dataset writes.
  */
 export const insertBankHolidays = async (
   rows: BankHolidayInsertType[],

--- a/src/services/bankHoliday/bankHolidayServices.ts
+++ b/src/services/bankHoliday/bankHolidayServices.ts
@@ -1,7 +1,7 @@
-import { db } from "../../db/db.js";
+import { db, type DbTransaction } from "../../db/db.js";
 import { bankHolidays } from "../../db/schema/bank-holiday-schema.js";
 import { and, asc, eq, gte, lt } from "drizzle-orm";
-import type { BankHolidayType } from "./types.js";
+import type { BankHolidayInsertType, BankHolidayType } from "./types.js";
 
 /**
  * Lists bank holidays for the given country (and optional region) in a single
@@ -29,4 +29,17 @@ export const listBankHolidays = async (
     .from(bankHolidays)
     .where(and(...filters))
     .orderBy(asc(bankHolidays.date));
+};
+
+/**
+ * Inserts bank holiday rows, ignoring any that already exist. Conflict-free by
+ * the `(country, region, date)` unique index, so concurrent first-time fills
+ * for the same country and year are safe.
+ */
+export const insertBankHolidays = async (
+  rows: BankHolidayInsertType[],
+  tx?: DbTransaction
+): Promise<void> => {
+  if (rows.length === 0) return;
+  await (tx ?? db).insert(bankHolidays).values(rows).onConflictDoNothing();
 };

--- a/src/services/bankHoliday/holidayDataset.ts
+++ b/src/services/bankHoliday/holidayDataset.ts
@@ -1,0 +1,66 @@
+import Holidays from "date-holidays";
+import { generateRandomUUID } from "../../utils/generateUUID.js";
+import type { BankHolidayInsertType } from "./types.js";
+
+export type HolidayCountry = {
+  code: string;
+  name: string;
+};
+
+// Holidays instances parse the full country ruleset on construction, so both
+// the country list and per-country instances are memoized for the process.
+const instances = new Map<string, Holidays>();
+
+let countriesCache: HolidayCountry[] | undefined;
+let countryCodesCache: Set<string> | undefined;
+
+const loadCountries = (): HolidayCountry[] => {
+  if (!countriesCache) {
+    const raw = new Holidays().getCountries("en");
+    countriesCache = Object.entries(raw)
+      .map(([code, name]) => ({ code, name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    countryCodesCache = new Set(countriesCache.map((c) => c.code));
+  }
+  return countriesCache;
+};
+
+export const getSupportedCountries = (): HolidayCountry[] => loadCountries();
+
+export const isSupportedCountry = (code: string): boolean => {
+  loadCountries();
+  return countryCodesCache!.has(code);
+};
+
+/**
+ * Computes the public holidays of a country for one calendar year. Returns
+ * rows ready for insertion into `bank_holidays`; an unsupported country code
+ * yields an empty array rather than throwing.
+ */
+export const computePublicHolidays = (country: string, year: number): BankHolidayInsertType[] => {
+  if (!isSupportedCountry(country)) {
+    return [];
+  }
+
+  let hd = instances.get(country);
+  if (!hd) {
+    // No language override on purpose: holiday names stay in the country's own
+    // language ("Nový rok", not "New Year's Day") — that is what the people in
+    // that country call the day. Only the country picker is English.
+    hd = new Holidays(country);
+    instances.set(country, hd);
+  }
+
+  const seen = new Set<string>();
+  const rows: BankHolidayInsertType[] = [];
+  for (const holiday of hd.getHolidays(year)) {
+    if (holiday.type !== "public") continue;
+    // `date` is a local "YYYY-MM-DD HH:mm:ss" string; slicing it avoids the
+    // timezone shifts a Date round-trip would introduce.
+    const date = holiday.date.slice(0, 10);
+    if (seen.has(date)) continue;
+    seen.add(date);
+    rows.push({ id: generateRandomUUID(), date, name: holiday.name, country });
+  }
+  return rows;
+};

--- a/src/services/bankHoliday/tests/holidayDataset.test.ts
+++ b/src/services/bankHoliday/tests/holidayDataset.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+  computePublicHolidays,
+  getSupportedCountries,
+  isSupportedCountry,
+} from "../holidayDataset.js";
+
+describe("getSupportedCountries", () => {
+  it("returns code/name pairs sorted by name", () => {
+    const countries = getSupportedCountries();
+
+    expect(countries.length).toBeGreaterThan(50);
+    for (const country of countries.slice(0, 5)) {
+      expect(country.code).toMatch(/^[A-Z]{2}$/);
+      expect(country.name.length).toBeGreaterThan(0);
+    }
+    const names = countries.map((c) => c.name);
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it("returns English names, matching the API doc", () => {
+    const byCode = new Map(getSupportedCountries().map((c) => [c.code, c.name]));
+
+    expect(byCode.get("CZ")).toBe("Czech Republic");
+    expect(byCode.get("DE")).toBe("Germany");
+  });
+});
+
+describe("isSupportedCountry", () => {
+  it("accepts common countries", () => {
+    expect(isSupportedCountry("CZ")).toBe(true);
+    expect(isSupportedCountry("DE")).toBe(true);
+    expect(isSupportedCountry("US")).toBe(true);
+  });
+
+  it("rejects unknown codes", () => {
+    expect(isSupportedCountry("XX")).toBe(false);
+    expect(isSupportedCountry("")).toBe(false);
+  });
+});
+
+describe("computePublicHolidays", () => {
+  it("returns public holidays with plain YYYY-MM-DD dates", () => {
+    const rows = computePublicHolidays("CZ", 2026);
+
+    expect(rows.length).toBeGreaterThan(5);
+    for (const row of rows) {
+      expect(row.date).toMatch(/^2026-\d{2}-\d{2}$/);
+      expect(row.country).toBe("CZ");
+      expect(row.name.length).toBeGreaterThan(0);
+      expect(row.id.length).toBeGreaterThan(0);
+    }
+    expect(rows.map((r) => r.date)).toContain("2026-01-01");
+  });
+
+  it("never emits two rows for the same date", () => {
+    const rows = computePublicHolidays("US", 2026);
+    const dates = rows.map((r) => r.date);
+
+    expect(new Set(dates).size).toBe(dates.length);
+  });
+
+  it("returns an empty array for an unsupported country", () => {
+    expect(computePublicHolidays("XX", 2026)).toEqual([]);
+  });
+});

--- a/src/services/group/groupServices.ts
+++ b/src/services/group/groupServices.ts
@@ -115,6 +115,21 @@ export const updateGroupWorkingDays = async (
   return row;
 };
 
+export const updateGroupHolidayCountry = async (
+  groupId: string,
+  holidayCountry: string | null
+): Promise<GroupType | undefined> => {
+  const [row] = await db
+    .update(groups)
+    .set({
+      holidayCountry,
+    })
+    .where(and(eq(groups.id, groupId), isNull(groups.deletedAt)))
+    .returning();
+
+  return row;
+};
+
 export const updateGroupQuotas = async (
   groupId: string,
   newVacation: number,

--- a/src/services/group/types.ts
+++ b/src/services/group/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isSupportedCountry } from "../bankHoliday/holidayDataset.js";
 
 export type GroupType = {
   id: string;
@@ -7,6 +8,7 @@ export type GroupType = {
   defaultVacationDays: number;
   defaultHomeOfficeDays: number;
   workingDays: number[];
+  holidayCountry: string | null;
   managerUserId: string;
   mainApprovalUser: string | null;
   tempApprovalUser: string | null;
@@ -41,6 +43,19 @@ export const validatePutGroupWorkingDays = z.object({
 });
 
 export type ValidatedPutGroupWorkingDaysType = z.infer<typeof validatePutGroupWorkingDays>;
+
+// Validated against the holiday dataset, not just the alpha-2 shape — a code
+// we cannot compute holidays for would silently show nothing on the dashboard.
+export const validatePutGroupHolidayCountry = z.object({
+  holidayCountry: z
+    .string()
+    .length(2)
+    .transform((value) => value.toUpperCase())
+    .refine(isSupportedCountry, { message: "Unsupported country code" })
+    .nullable(),
+});
+
+export type ValidatedPutGroupHolidayCountryType = z.infer<typeof validatePutGroupHolidayCountry>;
 
 // better-auth user ids are opaque non-UUID strings. The main approver is
 // required: a group without one can never decide on a request.

--- a/src/tests/e2e/bankHoliday.e2e.test.ts
+++ b/src/tests/e2e/bankHoliday.e2e.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { setupTestEnvironment, cleanupTestData, type TestContext } from "./helpers/testSetup.js";
+import { authCookieFor } from "./helpers/authHelper.js";
+import { db } from "../../db/db.js";
+import { bankHolidays } from "../../db/schema/bank-holiday-schema.js";
+import { groups } from "../../db/schema/group-schema.js";
+import { eq } from "drizzle-orm";
+
+const YEAR = new Date().getFullYear();
+
+describe("Bank holidays E2E", () => {
+  let context: TestContext;
+  let cookie: string;
+
+  beforeAll(async () => {
+    context = await setupTestEnvironment();
+    // user1 owns the group's organization, so they hold group admin rights.
+    cookie = await authCookieFor(context.user1.id);
+    // Self-heal from an interrupted previous run; the first test asserts on
+    // an empty table.
+    await db.delete(bankHolidays);
+  });
+
+  afterAll(async () => {
+    await db.delete(bankHolidays);
+    await cleanupTestData();
+  });
+
+  describe("GET /api/bank-holidays", () => {
+    it("fills the table from the dataset on first request", async () => {
+      const before = await db.select().from(bankHolidays).where(eq(bankHolidays.country, "CZ"));
+      expect(before).toHaveLength(0);
+
+      const response = await request(context.app)
+        .get(`/api/bank-holidays?country=CZ&year=${YEAR}`)
+        .set("Cookie", cookie)
+        .expect(200);
+
+      expect(response.body.length).toBeGreaterThan(5);
+      expect(response.body[0]).toMatchObject({ country: "CZ" });
+      expect(response.body.map((h: { date: string }) => h.date)).toContain(`${YEAR}-01-01`);
+
+      const stored = await db.select().from(bankHolidays).where(eq(bankHolidays.country, "CZ"));
+      expect(stored).toHaveLength(response.body.length);
+    });
+
+    it("serves the cached rows on subsequent requests", async () => {
+      const first = await request(context.app)
+        .get(`/api/bank-holidays?country=CZ&year=${YEAR}`)
+        .set("Cookie", cookie)
+        .expect(200);
+      const second = await request(context.app)
+        .get(`/api/bank-holidays?country=CZ&year=${YEAR}`)
+        .set("Cookie", cookie)
+        .expect(200);
+
+      expect(second.body).toEqual(first.body);
+    });
+
+    it("never duplicates rows: repeat and region-filtered requests leave the table unchanged", async () => {
+      await request(context.app)
+        .get(`/api/bank-holidays?country=CZ&year=${YEAR}`)
+        .set("Cookie", cookie)
+        .expect(200);
+      const filled = await db.select().from(bankHolidays).where(eq(bankHolidays.country, "CZ"));
+
+      // A region-filtered miss on a cached country must not trigger a refill.
+      const regionResponse = await request(context.app)
+        .get(`/api/bank-holidays?country=CZ&year=${YEAR}&region=PR`)
+        .set("Cookie", cookie)
+        .expect(200);
+      expect(regionResponse.body).toEqual([]);
+
+      await request(context.app)
+        .get(`/api/bank-holidays?country=CZ&year=${YEAR}`)
+        .set("Cookie", cookie)
+        .expect(200);
+
+      const after = await db.select().from(bankHolidays).where(eq(bankHolidays.country, "CZ"));
+      expect(after).toHaveLength(filled.length);
+      expect(new Set(after.map((r) => r.date)).size).toBe(after.length);
+    });
+
+    it("returns an empty array for an unsupported country", async () => {
+      const response = await request(context.app)
+        .get(`/api/bank-holidays?country=ZZ&year=${YEAR}`)
+        .set("Cookie", cookie)
+        .expect(200);
+
+      expect(response.body).toEqual([]);
+    });
+  });
+
+  describe("GET /api/bank-holidays/countries", () => {
+    it("lists supported countries", async () => {
+      const response = await request(context.app)
+        .get("/api/bank-holidays/countries")
+        .set("Cookie", cookie)
+        .expect(200);
+
+      expect(response.body.length).toBeGreaterThan(50);
+      expect(response.body).toContainEqual(expect.objectContaining({ code: "CZ" }));
+    });
+  });
+
+  describe("PUT /api/group/:groupId/holiday-country", () => {
+    it("persists the country, upper-cased, and returns it on group reads", async () => {
+      const putResponse = await request(context.app)
+        .put(`/api/group/${context.group.id}/holiday-country`)
+        .set("Cookie", cookie)
+        .send({ holidayCountry: "cz" })
+        .expect(200);
+
+      expect(putResponse.body.holidayCountry).toBe("CZ");
+
+      const getResponse = await request(context.app)
+        .get(`/api/group/${context.group.id}`)
+        .set("Cookie", cookie)
+        .expect(200);
+
+      expect(getResponse.body.holidayCountry).toBe("CZ");
+    });
+
+    it("clears the country with null", async () => {
+      const response = await request(context.app)
+        .put(`/api/group/${context.group.id}/holiday-country`)
+        .set("Cookie", cookie)
+        .send({ holidayCountry: null })
+        .expect(200);
+
+      expect(response.body.holidayCountry).toBeNull();
+
+      const [row] = await db.select().from(groups).where(eq(groups.id, context.group.id));
+      expect(row?.holidayCountry).toBeNull();
+    });
+
+    it("rejects an unsupported country code with 422", async () => {
+      await request(context.app)
+        .put(`/api/group/${context.group.id}/holiday-country`)
+        .set("Cookie", cookie)
+        .send({ holidayCountry: "XX" })
+        .expect(422);
+    });
+
+    it("refuses a caller without group admin rights", async () => {
+      const outsiderCookie = await authCookieFor(context.user2.id);
+
+      await request(context.app)
+        .put(`/api/group/${context.group.id}/holiday-country`)
+        .set("Cookie", outsiderCookie)
+        .send({ holidayCountry: "CZ" })
+        .expect(403);
+    });
+  });
+});

--- a/src/tests/e2e/calendarFeed.e2e.test.ts
+++ b/src/tests/e2e/calendarFeed.e2e.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { setupTestEnvironment, cleanupTestData, type TestContext } from "./helpers/testSetup.js";
+import { authCookieFor } from "./helpers/authHelper.js";
+import { db } from "../../db/db.js";
+import { bankHolidays } from "../../db/schema/bank-holiday-schema.js";
+import { groups } from "../../db/schema/group-schema.js";
+import { groupUsers } from "../../db/schema/group-users-schema.js";
+import { vacation, vacationType } from "../../db/schema/vacation-schema.js";
+import { eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+
+const YEAR = new Date().getFullYear();
+
+// A working day comfortably inside the feed window (all future + 12 months back).
+const vacationDay = (() => {
+  const day = new Date();
+  day.setUTCDate(day.getUTCDate() + 14);
+  while (day.getUTCDay() === 0 || day.getUTCDay() === 6) day.setUTCDate(day.getUTCDate() + 1);
+  return day.toISOString().slice(0, 10);
+})();
+
+describe("Calendar feed E2E", () => {
+  let context: TestContext;
+  let cookie: string;
+  let feedToken: string;
+
+  beforeAll(async () => {
+    context = await setupTestEnvironment();
+    cookie = await authCookieFor(context.user1.id);
+
+    // TEAM scope requires membership, and the org-owner manager holds no row.
+    await db.insert(groupUsers).values({
+      id: uuidv4(),
+      userId: context.user1.id,
+      groupId: context.group.id,
+      viewAccess: true,
+      adminAccess: true,
+      approverAccess: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await db.update(groups).set({ holidayCountry: "CZ" }).where(eq(groups.id, context.group.id));
+
+    // Warm the holiday cache so rows exist that a leaky feed could pick up.
+    await request(context.app)
+      .get(`/api/bank-holidays?country=CZ&year=${YEAR}`)
+      .set("Cookie", cookie)
+      .expect(200);
+
+    await db.insert(vacation).values({
+      id: uuidv4(),
+      userId: context.user1.id,
+      groupId: context.group.id,
+      requestedDay: vacationDay,
+      vacationType: vacationType.Vacation,
+      approvedAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // The feed deliberately *includes* BANK_HOLIDAY, the worst case: holidays
+    // must still stay out because they are never vacation rows.
+    const created = await request(context.app)
+      .post("/api/calendar-sync")
+      .set("Cookie", cookie)
+      .send({
+        name: "Team feed",
+        scope: "TEAM",
+        teamIds: [context.group.id],
+        types: [
+          { type: "VACATION", color: "blue" },
+          { type: "BANK_HOLIDAY", color: "green" },
+        ],
+      })
+      .expect(201);
+
+    const match = (created.body.feedUrl as string).match(
+      /\/calendars\/(flx_live_[a-f0-9]{40})\.ics$/
+    );
+    expect(match).not.toBeNull();
+    feedToken = match![1]!;
+  });
+
+  afterAll(async () => {
+    await db.delete(bankHolidays);
+    await cleanupTestData();
+  });
+
+  it("exports approved vacations but never bank holidays", async () => {
+    const stored = await db.select().from(bankHolidays).where(eq(bankHolidays.country, "CZ"));
+    expect(stored.length).toBeGreaterThan(5);
+
+    const response = await request(context.app).get(`/calendars/${feedToken}.ics`).expect(200);
+    const body = response.text || String(response.body);
+
+    expect(body).toContain("BEGIN:VCALENDAR");
+    expect(body).toContain(vacationDay.replaceAll("-", ""));
+    expect((body.match(/BEGIN:VEVENT/g) ?? []).length).toBe(1);
+    for (const holiday of stored) {
+      expect(body).not.toContain(holiday.name);
+    }
+  });
+});


### PR DESCRIPTION
## What

Each group can opt into a country's public holidays, shown on the dashboard calendar only.

- `groups.holiday_country` (nullable, ISO 3166-1 alpha-2), set via `PUT /api/group/:groupId/holiday-country` — group-admin/org-admin gated, billing-guarded, audited; codes validated against the dataset (422 otherwise, null clears).
- `GET /api/bank-holidays` now lazily fills the previously empty `bank_holidays` table from the new `date-holidays` dependency on the first request per (country, year), then serves from the table. Holiday names deliberately stay in the country's own language.
- `GET /api/bank-holidays/countries` returns the supported `{code, name}` list (English names) for the frontend picker.
- Migrations: `0016` adds the column; `0017` adds a partial unique index on `(country, date) WHERE region IS NULL` — the existing `(country, region, date)` index never fires for NULL-region rows, so concurrent first fills would otherwise duplicate every holiday.

**ICS stays holiday-free by construction**: the feed reads only `vacation` rows and holidays never become one. `src/tests/e2e/calendarFeed.e2e.test.ts` pins this by configuring a feed that *includes* `BANK_HOLIDAY` and asserting zero holiday events next to a real vacation.

## Review findings addressed

Two independent pre-merge review rounds. Fixed: the NULL-region duplicate-insert hole (blocker → partial index + no refill on region-filtered misses, with unit and e2e coverage), native-language country names contradicting the OpenAPI doc (→ `getCountries("en")`), e2e self-healing cleanup. Deliberately deferred with a tracked follow-up: the cache has no refresh path after a `date-holidays` upgrade (accepted v1 tradeoff; manual `DELETE` per country+year is the escape hatch).

## Verified

545 unit + 185 e2e tests green, lint/tsc clean. Exercised live: lazy fill (13 CZ rows for 2026 on first request, no duplicates on repeats or region-filtered queries), the group setting round-trip including 422/403 paths, and the ICS feed above.

## Reproduce

`npm run db:migrate`, `npm run dev:be`, seed via `npm run dev:scenario`, then set a country on a group and hit `GET /api/bank-holidays?country=CZ`.

## Deploy notes

- Prod schema is applied by hand: `ALTER TABLE "groups" ADD COLUMN "holiday_country" text;` and `CREATE UNIQUE INDEX "bank_holidays_country_date_no_region_uidx" ON "bank_holidays" ("country","date") WHERE "region" is null;`
- **Deploy before** the frontend PR of the same branch name https://github.com/Daniel88dev/flexi-day/pull/64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added supported-country listings for bank holidays.
  - Bank holidays are generated and cached automatically when requested.
  - Groups can configure or disable a public-holiday country.
  - Added validation for supported country codes and required permissions.

- **Bug Fixes**
  - Prevented duplicate country-wide holidays for the same date.
  - Preserved correct holiday behavior for regional filters and unsupported countries.

- **Tests**
  - Added unit and end-to-end coverage for holiday generation, caching, configuration, validation, authorization, and calendar feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->