### PR TITLE
feat: read-only platform-support surface behind an env allowlist

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -218,7 +218,9 @@ const parseSupport = (): SupportConfig | undefined => {
   // UUIDs; anything else is a typo or a pasted email. Failing at boot beats an
   // allowlist that silently never matches.
   for (const id of userIds) {
-    if (!/^[A-Za-z0-9-]{16,64}$/.test(id)) {
+    const isBetterAuthId = /^[A-Za-z0-9]{32}$/.test(id);
+    const isUuid = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(id);
+    if (!isBetterAuthId && !isUuid) {
       throw new Error(
         `SUPPORT_ADMIN_USER_IDS contains "${id}", which does not look like a user id`
       );

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,11 @@ type PaddleConfig = {
   };
 };
 
+type SupportConfig = {
+  /** User ids allowed on `/api/support/*` and flagged `supportAdmin` in the session. */
+  userIds: string[];
+};
+
 type DevToolsConfig = {
   /** Shared secret every `/api/dev/*` request must present as `x-dev-token`. */
   token: string;
@@ -73,6 +78,8 @@ type Config = {
   paddle?: PaddleConfig;
   /** Local seeding/session surface. `undefined` means the routes do not exist. */
   dev?: DevToolsConfig;
+  /** Platform-support read surface. `undefined` means the routes do not exist. */
+  support?: SupportConfig;
 };
 
 const VALID_ENVS = ["production", "dev", "test"] as const;
@@ -187,6 +194,40 @@ const parseDevTools = (): DevToolsConfig | undefined => {
   };
 };
 
+/**
+ * Allowlist for the read-only support surface (`/api/support/*`). An env var
+ * rather than a DB flag on purpose: no API can ever grant it, so there is no
+ * privilege-escalation surface — it changes only via deploy. Unset means the
+ * router is never mounted and the surface does not exist.
+ */
+const parseSupport = (): SupportConfig | undefined => {
+  const raw = process.env.SUPPORT_ADMIN_USER_IDS;
+  if (!raw) return undefined;
+
+  const userIds = [
+    ...new Set(
+      raw
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean)
+    ),
+  ];
+  if (userIds.length === 0) return undefined;
+
+  // better-auth ids are 32-char alphanumeric and dev-seeded ones are dashed
+  // UUIDs; anything else is a typo or a pasted email. Failing at boot beats an
+  // allowlist that silently never matches.
+  for (const id of userIds) {
+    if (!/^[A-Za-z0-9-]{16,64}$/.test(id)) {
+      throw new Error(
+        `SUPPORT_ADMIN_USER_IDS contains "${id}", which does not look like a user id`
+      );
+    }
+  }
+
+  return { userIds };
+};
+
 export const config: Config = {
   api: {
     port: (() => {
@@ -236,6 +277,7 @@ export const config: Config = {
   },
   paddle: parsePaddle(),
   dev: parseDevTools(),
+  support: parseSupport(),
 };
 
 export type { PaddleConfig };

--- a/src/controllers/support/handleGetGroupDetail.ts
+++ b/src/controllers/support/handleGetGroupDetail.ts
@@ -1,0 +1,19 @@
+import type { Request, Response } from "express";
+import { getGroupDetailForSupport } from "../../services/support/supportServices.js";
+import AppError from "../../utils/appError.js";
+
+export const handleGetGroupDetail = async (req: Request, res: Response) => {
+  const groupId = req.params.groupId ?? "";
+  const detail = await getGroupDetailForSupport(groupId);
+
+  if (!detail) {
+    throw new AppError({
+      message: "Group not found",
+      code: 404,
+      logging: true,
+      context: { groupId: req.params.groupId },
+    });
+  }
+
+  return res.status(200).json(detail);
+};

--- a/src/controllers/support/handleGetOrganizationDetail.ts
+++ b/src/controllers/support/handleGetOrganizationDetail.ts
@@ -1,0 +1,19 @@
+import type { Request, Response } from "express";
+import { getOrganizationDetailForSupport } from "../../services/support/supportServices.js";
+import AppError from "../../utils/appError.js";
+
+export const handleGetOrganizationDetail = async (req: Request, res: Response) => {
+  const organizationId = req.params.organizationId ?? "";
+  const detail = await getOrganizationDetailForSupport(organizationId);
+
+  if (!detail) {
+    throw new AppError({
+      message: "Organization not found",
+      code: 404,
+      logging: true,
+      context: { organizationId: req.params.organizationId },
+    });
+  }
+
+  return res.status(200).json(detail);
+};

--- a/src/controllers/support/handleSearchOrganizations.ts
+++ b/src/controllers/support/handleSearchOrganizations.ts
@@ -1,0 +1,11 @@
+import type { Request, Response } from "express";
+import { searchOrganizationsForSupport } from "../../services/support/supportServices.js";
+
+export const handleSearchOrganizations = async (req: Request, res: Response) => {
+  const raw = req.query.query;
+  const query = typeof raw === "string" ? raw.slice(0, 200) : undefined;
+
+  const organizations = await searchOrganizationsForSupport(query);
+
+  return res.status(200).json({ organizations });
+};

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -11,6 +11,7 @@ import { calendarSync, calendarSyncTeams, calendarSyncTypes } from "./calendar-s
 import { vacationEvents } from "./vacation-event-schema.js";
 import { userSettings } from "./user-settings-schema.js";
 import { reportExports } from "./report-export-schema.js";
+import { supportAccess } from "./support-access-schema.js";
 import { organizations } from "./organization-schema.js";
 import { organizationUsers } from "./organization-users-schema.js";
 import { subscriptions } from "./subscription-schema.js";
@@ -36,6 +37,7 @@ export const schema = {
   calendarSyncTeams,
   calendarSyncTypes,
   reportExports,
+  supportAccess,
   organizations,
   organizationUsers,
   subscriptions,

--- a/src/db/schema/out/0018_striped_robin_chapel.sql
+++ b/src/db/schema/out/0018_striped_robin_chapel.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "support_access" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"method" varchar(8) NOT NULL,
+	"path" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "support_access" ADD CONSTRAINT "support_access_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "support_access_user_id_idx" ON "support_access" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "support_access_created_at_idx" ON "support_access" USING btree ("created_at");

--- a/src/db/schema/out/meta/0018_snapshot.json
+++ b/src/db/schema/out/meta/0018_snapshot.json
@@ -1,0 +1,3107 @@
+{
+  "id": "919dcd1a-1ffd-4471-a283-ac90a19e7c71",
+  "prevId": "bb7ffe5f-3194-4b8a-a0fc-5b09b2a9ae67",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_two_factor_user_id": {
+          "name": "idx_two_factor_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_two_factor_secret": {
+          "name": "idx_two_factor_secret",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_date_no_region_uidx": {
+          "name": "bank_holidays_country_date_no_region_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"bank_holidays\".\"region\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_mirrors": {
+      "name": "group_mirrors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_group_id": {
+          "name": "target_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_mirrors_user_source_target_uniq": {
+          "name": "group_mirrors_user_source_target_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_mirrors\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_target_group_id": {
+          "name": "idx_group_mirrors_target_group_id",
+          "columns": [
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_user_id": {
+          "name": "idx_group_mirrors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_mirrors_user_id_user_id_fk": {
+          "name": "group_mirrors_user_id_user_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_source_group_id_groups_id_fk": {
+          "name": "group_mirrors_source_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_target_group_id_groups_id_fk": {
+          "name": "group_mirrors_target_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "target_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "holiday_country": {
+          "name": "holiday_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_organization_id": {
+          "name": "idx_groups_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_organization_id_organizations_id_fk": {
+          "name": "groups_organization_id_organizations_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approver_access": {
+          "name": "approver_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invite_link_group_id": {
+          "name": "idx_invite_link_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_group_email_open_uniq": {
+          "name": "invite_link_group_email_open_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_link\".\"used_at\" IS NULL AND \"invite_link\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_link_invited_by_user_id_user_id_fk": {
+          "name": "invite_link_invited_by_user_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_organizations_owner_user_id": {
+          "name": "uq_organizations_owner_user_id",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_users": {
+      "name": "organization_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "organization_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_users_org_id_user_id_uniq": {
+          "name": "organization_users_org_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organization_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_users_user_id": {
+          "name": "idx_organization_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_users_organization_id": {
+          "name": "idx_organization_users_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_users_organization_id_organizations_id_fk": {
+          "name": "organization_users_organization_id_organizations_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_users_user_id_user_id_fk": {
+          "name": "organization_users_user_id_user_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_users_granted_by_user_id_user_id_fk": {
+          "name": "organization_users_granted_by_user_id_user_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paddle_events": {
+      "name": "paddle_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_exports_user_id_idx": {
+          "name": "report_exports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_exports_created_at_idx": {
+          "name": "report_exports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_user_id_user_id_fk": {
+          "name": "report_exports_user_id_user_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_subscription_id": {
+          "name": "paddle_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "subscription_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "billing_cycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_group_slots": {
+          "name": "extra_group_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_override": {
+          "name": "manual_plan_override",
+          "type": "manual_plan_override",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_groups": {
+          "name": "manual_max_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_members_per_group": {
+          "name": "manual_max_members_per_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_until": {
+          "name": "manual_plan_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_subscriptions_organization_id": {
+          "name": "uq_subscriptions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_paddle_subscription_id": {
+          "name": "idx_subscriptions_paddle_subscription_id",
+          "columns": [
+            {
+              "expression": "paddle_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_organization_id_organizations_id_fk": {
+          "name": "subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.support_access": {
+      "name": "support_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_access_user_id_idx": {
+          "name": "support_access_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_access_created_at_idx": {
+          "name": "support_access_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_access_user_id_user_id_fk": {
+          "name": "support_access_user_id_user_id_fk",
+          "tableFrom": "support_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboard_scope": {
+          "name": "dashboard_scope",
+          "type": "dashboard_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MINE'"
+        },
+        "dashboard_group_id": {
+          "name": "dashboard_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_settings_dashboard_group_id_groups_id_fk": {
+          "name": "user_settings_dashboard_group_id_groups_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "dashboard_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "carried_over_days": {
+          "name": "carried_over_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        },
+        "user_year_quotas_related_year_range_chk": {
+          "name": "user_year_quotas_related_year_range_chk",
+          "value": "\"user_year_quotas\".\"related_year\"::int BETWEEN 2025 AND 2100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "half_day": {
+          "name": "half_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_user_id": {
+          "name": "deleted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vacation\".\"deleted_at\" IS NULL AND \"vacation\".\"rejected_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_deleted_by_user_id_user_id_fk": {
+          "name": "vacation_deleted_by_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deleted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_created_by_user_id_user_id_fk": {
+          "name": "vacation_created_by_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.organization_role": {
+      "name": "organization_role",
+      "schema": "public",
+      "values": [
+        "ADMIN"
+      ]
+    },
+    "public.billing_cycle": {
+      "name": "billing_cycle",
+      "schema": "public",
+      "values": [
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.manual_plan_override": {
+      "name": "manual_plan_override",
+      "schema": "public",
+      "values": [
+        "FREE",
+        "PRO",
+        "ENTERPRISE",
+        "CUSTOM"
+      ]
+    },
+    "public.subscription_plan": {
+      "name": "subscription_plan",
+      "schema": "public",
+      "values": [
+        "PRO",
+        "ENTERPRISE"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "trialing",
+        "past_due",
+        "paused",
+        "canceled"
+      ]
+    },
+    "public.dashboard_scope": {
+      "name": "dashboard_scope",
+      "schema": "public",
+      "values": [
+        "MINE",
+        "GROUP"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT",
+        "UPDATED"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/_journal.json
+++ b/src/db/schema/out/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1787232375463,
       "tag": "0017_hot_mysterio",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1787248108265,
+      "tag": "0018_striped_robin_chapel",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/support-access-schema.ts
+++ b/src/db/schema/support-access-schema.ts
@@ -1,0 +1,29 @@
+import { index, pgTable, text, timestamp, varchar } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema.js";
+
+/**
+ * Audit trail of the platform-support read surface (`/api/support/*`). One row
+ * per request, written by `requireSupportAdmin` before the handler runs.
+ * Write-only by design — nothing in the product reads it back; it exists so
+ * "who looked at whose data, when" can be answered after the fact.
+ */
+export const supportAccess = pgTable(
+  "support_access",
+  {
+    id: text("id").primaryKey(),
+    // No ON DELETE cascade, unlike `report_exports`: that table audits tenant
+    // users reading their own groups, this one audits platform staff reading
+    // anyone's data — deleting the staff account must not erase the trail.
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id),
+    method: varchar("method", { length: 8 }).notNull(),
+    /** Path plus query string, so the audited row names the exact target. */
+    path: text("path").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index("support_access_user_id_idx").on(table.userId),
+    index("support_access_created_at_idx").on(table.createdAt),
+  ]
+);

--- a/src/middleware/supportGuard.ts
+++ b/src/middleware/supportGuard.ts
@@ -31,9 +31,12 @@ export const requireSupportAdmin = async (req: Request, _res: Response, next: Ne
     }
 
     if (!config.support?.userIds.includes(auth.userId)) {
+      // baseUrl+path, not originalUrl: the search endpoint's query string
+      // carries free text that has no business in a log line. The audit row
+      // below keeps the full target on purpose — see the schema comment.
       logger.warn("supportGuard rejected non-allowlisted request", {
         userId: auth.userId,
-        path: req.originalUrl,
+        path: `${req.baseUrl}${req.path}`,
       });
       return next(new AppError({ message: "Not found", code: 404 }));
     }

--- a/src/middleware/supportGuard.ts
+++ b/src/middleware/supportGuard.ts
@@ -1,0 +1,69 @@
+import type { NextFunction, Request, Response } from "express";
+import { eq } from "drizzle-orm";
+import { config } from "../config.js";
+import { db } from "../db/db.js";
+import { user } from "../db/schema/auth-schema.js";
+import { recordSupportAccess } from "../services/support/supportServices.js";
+import AppError from "../utils/appError.js";
+import { logger } from "./logger.js";
+
+/**
+ * Gate for `/api/support/*`. The router is only mounted when `config.support`
+ * exists, so this is the second line of defence rather than the first. Runs
+ * after `authSession`.
+ *
+ * Non-allowlisted callers get a 404, not a 403 — the `supportAdmin` flag in
+ * the session payload is the only thing a normal user ever sees of this
+ * surface, and a probing one learns nothing from the response.
+ *
+ * The 2FA requirement is on the account, not the session: this surface reads
+ * every customer's data, so a password alone must not open it. Checked per
+ * request rather than cached — support traffic is a handful of requests.
+ */
+export const requireSupportAdmin = async (req: Request, _res: Response, next: NextFunction) => {
+  try {
+    // Not `getAuth` from authSession.js: that module imports the whole
+    // better-auth graph, and this guard needs only the already-populated
+    // `req.auth`.
+    const auth = req.auth;
+    if (!auth) {
+      return next(new AppError({ message: "Unauthorized", code: 401, logging: true }));
+    }
+
+    if (!config.support?.userIds.includes(auth.userId)) {
+      logger.warn("supportGuard rejected non-allowlisted request", {
+        userId: auth.userId,
+        path: req.originalUrl,
+      });
+      return next(new AppError({ message: "Not found", code: 404 }));
+    }
+
+    const [row] = await db
+      .select({ twoFactorEnabled: user.twoFactorEnabled })
+      .from(user)
+      .where(eq(user.id, auth.userId))
+      .limit(1);
+
+    if (!row?.twoFactorEnabled) {
+      return next(
+        new AppError({
+          message: "Two-factor authentication is required for support access",
+          code: 403,
+          logging: true,
+          context: { userId: auth.userId },
+        })
+      );
+    }
+
+    // Before the handler, so even a request that later fails is on record.
+    await recordSupportAccess({
+      userId: auth.userId,
+      method: req.method,
+      path: req.originalUrl,
+    });
+
+    return next();
+  } catch (err) {
+    return next(err);
+  }
+};

--- a/src/routes/supportRouter.ts
+++ b/src/routes/supportRouter.ts
@@ -1,0 +1,110 @@
+import { Router } from "express";
+import { tryCatch } from "../middleware/tryCatch.js";
+import { requireSupportAdmin } from "../middleware/supportGuard.js";
+import { handleSearchOrganizations } from "../controllers/support/handleSearchOrganizations.js";
+import { handleGetOrganizationDetail } from "../controllers/support/handleGetOrganizationDetail.js";
+import { handleGetGroupDetail } from "../controllers/support/handleGetGroupDetail.js";
+
+/**
+ * Platform-support read surface. Only mounted when `SUPPORT_ADMIN_USER_IDS`
+ * is set; every request passes `requireSupportAdmin` (allowlist + 2FA) and is
+ * written to the `support_access` audit table. Read-only by design — support
+ * debugging never writes customer data, and adding a mutating route here
+ * would need its own justification, not just this router's guard.
+ */
+export const supportRouter = (): Router => {
+  const app = Router();
+
+  app.use(requireSupportAdmin);
+
+  /**
+   * @openapi
+   * /api/support/organizations:
+   *   get:
+   *     tags:
+   *       - Support
+   *     summary: Search organizations across the whole platform
+   *     description: |
+   *       Support-allowlist only (404 for anyone else, 403 without 2FA on the
+   *       account). Matches organization name, owner name or email, or an
+   *       exact organization id; without `query`, the newest organizations.
+   *       Every call is written to the `support_access` audit table.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: query
+   *         schema:
+   *           type: string
+   *           maxLength: 200
+   *     responses:
+   *       '200':
+   *         description: '`{ organizations }` with owner, live group count and plan'
+   *       '403':
+   *         description: Allowlisted caller without two-factor enabled
+   *       '404':
+   *         description: Caller is not on the support allowlist
+   */
+  app.get("/organizations", tryCatch(handleSearchOrganizations));
+
+  /**
+   * @openapi
+   * /api/support/organizations/{organizationId}:
+   *   get:
+   *     tags:
+   *       - Support
+   *     summary: Organization detail for support debugging
+   *     description: |
+   *       Support-allowlist only. Owner, resolved plan entitlements, all
+   *       groups **including deleted ones**, and the administrator list.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: organizationId
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       '200':
+   *         description: Organization, owner, plan, groups, admins
+   *       '403':
+   *         description: Allowlisted caller without two-factor enabled
+   *       '404':
+   *         description: Not allowlisted, or no such organization
+   */
+  app.get("/organizations/:organizationId", tryCatch(handleGetOrganizationDetail));
+
+  /**
+   * @openapi
+   * /api/support/groups/{groupId}:
+   *   get:
+   *     tags:
+   *       - Support
+   *     summary: Group detail for support debugging
+   *     description: |
+   *       Support-allowlist only. Group settings, members including removed
+   *       ones, quota rows for every year, and the latest 200 vacation rows
+   *       with their state timestamps. `note` and `rejectionReason` are
+   *       deliberately excluded — they can carry personal detail debugging
+   *       never needs.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: groupId
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       '200':
+   *         description: Group, members, quotas, vacations
+   *       '403':
+   *         description: Allowlisted caller without two-factor enabled
+   *       '404':
+   *         description: Not allowlisted, or no such group
+   */
+  app.get("/groups/:groupId", tryCatch(handleGetGroupDetail));
+
+  return app;
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ import { requestContext } from "./middleware/requestContext.js";
 import { billingRouter } from "./routes/billingRouter.js";
 import { organizationRouter } from "./routes/organizationRouter.js";
 import { handlePaddleWebhook } from "./controllers/billing/handlePaddleWebhook.js";
+import { supportRouter } from "./routes/supportRouter.js";
 
 export const createServer = () => {
   const app = express();
@@ -104,6 +105,13 @@ export const createServer = () => {
   app.use("/api/reports", reportRouter());
   app.use("/api/billing", billingRouter());
   app.use("/api/organization", organizationRouter());
+
+  // Platform-support read surface. `config.support` is undefined unless the
+  // deploy explicitly carries an allowlist, so for everyone else these routes
+  // simply do not exist.
+  if (config.support) {
+    app.use("/api/support", supportRouter());
+  }
 
   // Public, token-authenticated iCalendar feed. Deliberately NOT behind
   // `authSession`: calendar clients subscribe with just the secret token in

--- a/src/services/support/supportServices.ts
+++ b/src/services/support/supportServices.ts
@@ -1,0 +1,251 @@
+import { and, count, desc, eq, ilike, inArray, isNull, or } from "drizzle-orm";
+import { db } from "../../db/db.js";
+import { user } from "../../db/schema/auth-schema.js";
+import { groups } from "../../db/schema/group-schema.js";
+import { groupUsers } from "../../db/schema/group-users-schema.js";
+import { organizations } from "../../db/schema/organization-schema.js";
+import { subscriptions } from "../../db/schema/subscription-schema.js";
+import { supportAccess } from "../../db/schema/support-access-schema.js";
+import { userYearQuotas } from "../../db/schema/user-year-quotas-schema.js";
+import { vacation } from "../../db/schema/vacation-schema.js";
+import { generateRandomUUID } from "../../utils/generateUUID.js";
+import { resolveEntitlements } from "../billing/entitlements.js";
+import { getSubscriptionForOrganization } from "../billing/subscriptionServices.js";
+import { listOrganizationAdmins } from "../organization/organizationServices.js";
+import type {
+  SupportGroupDetail,
+  SupportOrganizationDetail,
+  SupportOrganizationListItem,
+} from "./types.js";
+
+const SEARCH_LIMIT = 50;
+const VACATION_LIMIT = 200;
+
+/**
+ * These reads exist only behind `requireSupportAdmin` and take their scope as
+ * an explicit id instead of deriving it from the caller — support looks at
+ * organizations the caller does not belong to. They must stay read-only; the
+ * one write in this module is the audit row.
+ */
+export const recordSupportAccess = async (input: {
+  userId: string;
+  method: string;
+  path: string;
+}): Promise<void> => {
+  await db.insert(supportAccess).values({
+    id: generateRandomUUID(),
+    userId: input.userId,
+    method: input.method.slice(0, 8),
+    path: input.path.slice(0, 2048),
+  });
+};
+
+export const searchOrganizationsForSupport = async (
+  query: string | undefined
+): Promise<SupportOrganizationListItem[]> => {
+  const trimmed = query?.trim();
+  // `%`/`_` in the term would act as wildcards inside ILIKE — an admin
+  // searching "a_b@x.com" must not match "axb@x.com".
+  const pattern = trimmed ? `%${trimmed.replace(/([\\%_])/g, "\\$1")}%` : undefined;
+
+  const rows = await db
+    .select({
+      id: organizations.id,
+      name: organizations.name,
+      ownerUserId: organizations.ownerUserId,
+      ownerName: user.name,
+      ownerEmail: user.email,
+      createdAt: organizations.createdAt,
+    })
+    .from(organizations)
+    .innerJoin(user, eq(organizations.ownerUserId, user.id))
+    .where(
+      pattern
+        ? or(
+            ilike(organizations.name, pattern),
+            ilike(user.email, pattern),
+            ilike(user.name, pattern),
+            eq(organizations.id, trimmed as string)
+          )
+        : undefined
+    )
+    .orderBy(desc(organizations.createdAt))
+    .limit(SEARCH_LIMIT);
+
+  if (rows.length === 0) return [];
+  const organizationIds = rows.map((row) => row.id);
+
+  const groupCounts = await db
+    .select({ organizationId: groups.organizationId, liveGroups: count() })
+    .from(groups)
+    .where(and(inArray(groups.organizationId, organizationIds), isNull(groups.deletedAt)))
+    .groupBy(groups.organizationId);
+
+  // Full rows, not just the `plan` column: manual overrides (comped accounts,
+  // Enterprise Custom) live in other columns and only `resolveEntitlements`
+  // answers what the organization actually runs on.
+  const subs = await db
+    .select()
+    .from(subscriptions)
+    .where(inArray(subscriptions.organizationId, organizationIds));
+
+  const countByOrg = new Map(groupCounts.map((row) => [row.organizationId, row.liveGroups]));
+  const subByOrg = new Map(subs.map((row) => [row.organizationId, row]));
+  const now = new Date();
+
+  return rows.map((row) => {
+    const sub = subByOrg.get(row.id);
+    return {
+      ...row,
+      liveGroups: countByOrg.get(row.id) ?? 0,
+      plan: resolveEntitlements(sub ?? null, now).plan,
+      status: sub?.status ?? null,
+    };
+  });
+};
+
+export const getOrganizationDetailForSupport = async (
+  organizationId: string
+): Promise<SupportOrganizationDetail | undefined> => {
+  const [row] = await db
+    .select({
+      id: organizations.id,
+      name: organizations.name,
+      billingEmail: organizations.billingEmail,
+      paddleCustomerId: organizations.paddleCustomerId,
+      createdAt: organizations.createdAt,
+      ownerUserId: organizations.ownerUserId,
+      ownerName: user.name,
+      ownerEmail: user.email,
+    })
+    .from(organizations)
+    .innerJoin(user, eq(organizations.ownerUserId, user.id))
+    .where(eq(organizations.id, organizationId))
+    .limit(1);
+
+  if (!row) return undefined;
+
+  const subscription = await getSubscriptionForOrganization(organizationId);
+  const entitlements = resolveEntitlements(subscription ?? null, new Date());
+
+  // Deleted groups included on purpose — "my group disappeared" is exactly
+  // the kind of report this surface exists to debug.
+  const orgGroups = await db
+    .select({
+      id: groups.id,
+      groupName: groups.groupName,
+      managerUserId: groups.managerUserId,
+      deletedAt: groups.deletedAt,
+      createdAt: groups.createdAt,
+    })
+    .from(groups)
+    .where(eq(groups.organizationId, organizationId))
+    .orderBy(desc(groups.createdAt));
+
+  const groupIds = orgGroups.map((group) => group.id);
+  const memberCounts =
+    groupIds.length === 0
+      ? []
+      : await db
+          .select({ groupId: groupUsers.groupId, members: count() })
+          .from(groupUsers)
+          .where(and(inArray(groupUsers.groupId, groupIds), isNull(groupUsers.deletedAt)))
+          .groupBy(groupUsers.groupId);
+  const membersByGroup = new Map(memberCounts.map((row) => [row.groupId, row.members]));
+
+  return {
+    organization: {
+      id: row.id,
+      name: row.name,
+      billingEmail: row.billingEmail,
+      paddleCustomerId: row.paddleCustomerId,
+      createdAt: row.createdAt,
+    },
+    owner: { userId: row.ownerUserId, name: row.ownerName, email: row.ownerEmail },
+    plan: { ...entitlements, status: subscription?.status ?? null },
+    groups: orgGroups.map((group) => ({
+      ...group,
+      members: membersByGroup.get(group.id) ?? 0,
+    })),
+    admins: await listOrganizationAdmins(organizationId),
+  };
+};
+
+export const getGroupDetailForSupport = async (
+  groupId: string
+): Promise<SupportGroupDetail | undefined> => {
+  const [row] = await db
+    .select({
+      id: groups.id,
+      groupName: groups.groupName,
+      organizationId: groups.organizationId,
+      organizationName: organizations.name,
+      managerUserId: groups.managerUserId,
+      mainApprovalUser: groups.mainApprovalUser,
+      tempApprovalUser: groups.tempApprovalUser,
+      defaultVacationDays: groups.defaultVacationDays,
+      defaultHomeOfficeDays: groups.defaultHomeOfficeDays,
+      workingDays: groups.workingDays,
+      holidayCountry: groups.holidayCountry,
+      deletedAt: groups.deletedAt,
+      createdAt: groups.createdAt,
+    })
+    .from(groups)
+    .innerJoin(organizations, eq(groups.organizationId, organizations.id))
+    .where(eq(groups.id, groupId))
+    .limit(1);
+
+  if (!row) return undefined;
+
+  // Removed members included, flagged by `deletedAt` — leaver bugs (quota
+  // rows or mirrors surviving a removal) need the history visible.
+  const members = await db
+    .select({
+      userId: groupUsers.userId,
+      name: user.name,
+      email: user.email,
+      viewAccess: groupUsers.viewAccess,
+      adminAccess: groupUsers.adminAccess,
+      approverAccess: groupUsers.approverAccess,
+      controlledUser: groupUsers.controlledUser,
+      deletedAt: groupUsers.deletedAt,
+    })
+    .from(groupUsers)
+    .innerJoin(user, eq(groupUsers.userId, user.id))
+    .where(eq(groupUsers.groupId, groupId))
+    .orderBy(user.name);
+
+  const quotas = await db
+    .select({
+      userId: userYearQuotas.userId,
+      relatedYear: userYearQuotas.relatedYear,
+      vacationDays: userYearQuotas.vacationDays,
+      homeOfficeDays: userYearQuotas.homeOfficeDays,
+      carriedOverDays: userYearQuotas.carriedOverDays,
+    })
+    .from(userYearQuotas)
+    .where(eq(userYearQuotas.groupId, groupId))
+    .orderBy(desc(userYearQuotas.relatedYear));
+
+  const vacations = await db
+    .select({
+      id: vacation.id,
+      userId: vacation.userId,
+      userName: user.name,
+      requestedDay: vacation.requestedDay,
+      vacationType: vacation.vacationType,
+      halfDay: vacation.halfDay,
+      approvedAt: vacation.approvedAt,
+      approvedBy: vacation.approvedBy,
+      rejectedAt: vacation.rejectedAt,
+      deletedAt: vacation.deletedAt,
+      createdAt: vacation.createdAt,
+    })
+    .from(vacation)
+    .innerJoin(user, eq(vacation.userId, user.id))
+    .where(eq(vacation.groupId, groupId))
+    .orderBy(desc(vacation.requestedDay))
+    .limit(VACATION_LIMIT);
+
+  return { group: row, members, quotas, vacations };
+};

--- a/src/services/support/types.ts
+++ b/src/services/support/types.ts
@@ -1,0 +1,96 @@
+import type { Entitlements } from "../billing/entitlements.js";
+import type { OrganizationAdminListItem } from "../organization/types.js";
+
+export type SupportOrganizationListItem = {
+  id: string;
+  name: string;
+  ownerUserId: string;
+  ownerName: string;
+  ownerEmail: string;
+  liveGroups: number;
+  /** Resolved entitlement plan — "FREE" when there is no subscription row. */
+  plan: string;
+  status: string | null;
+  createdAt: Date;
+};
+
+export type SupportGroupListItem = {
+  id: string;
+  groupName: string;
+  managerUserId: string;
+  members: number;
+  deletedAt: Date | null;
+  createdAt: Date;
+};
+
+export type SupportOrganizationDetail = {
+  organization: {
+    id: string;
+    name: string;
+    billingEmail: string;
+    paddleCustomerId: string | null;
+    createdAt: Date;
+  };
+  owner: { userId: string; name: string; email: string };
+  plan: Entitlements & { status: string | null };
+  groups: SupportGroupListItem[];
+  admins: OrganizationAdminListItem[];
+};
+
+export type SupportGroupMember = {
+  userId: string;
+  name: string;
+  email: string;
+  viewAccess: boolean;
+  adminAccess: boolean;
+  approverAccess: boolean;
+  controlledUser: boolean;
+  deletedAt: Date | null;
+};
+
+export type SupportQuotaRow = {
+  userId: string;
+  relatedYear: string;
+  vacationDays: number;
+  homeOfficeDays: number;
+  carriedOverDays: number;
+};
+
+/**
+ * Deliberately without `note` and `rejectionReason`: they can carry personal
+ * detail ("medical appointment") that debugging a state bug never needs.
+ */
+export type SupportVacationRow = {
+  id: string;
+  userId: string;
+  userName: string;
+  requestedDay: string;
+  vacationType: string;
+  halfDay: boolean;
+  approvedAt: Date | null;
+  approvedBy: string | null;
+  rejectedAt: Date | null;
+  deletedAt: Date | null;
+  createdAt: Date;
+};
+
+export type SupportGroupDetail = {
+  group: {
+    id: string;
+    groupName: string;
+    organizationId: string;
+    organizationName: string;
+    managerUserId: string;
+    mainApprovalUser: string | null;
+    tempApprovalUser: string | null;
+    defaultVacationDays: number;
+    defaultHomeOfficeDays: number;
+    workingDays: number[];
+    holidayCountry: string | null;
+    deletedAt: Date | null;
+    createdAt: Date;
+  };
+  members: SupportGroupMember[];
+  quotas: SupportQuotaRow[];
+  vacations: SupportVacationRow[];
+};

--- a/src/tests/config.supportAdmins.test.ts
+++ b/src/tests/config.supportAdmins.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The env gate for the platform-support surface allowlist.
+ * Test library/framework: Vitest
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+/** Config is evaluated once at import, so each case needs a fresh module graph. */
+const loadConfig = async (env: Record<string, string | undefined>) => {
+  process.env = { ...ORIGINAL_ENV, ...env };
+  vi.resetModules();
+  const mod = await import("../config.js");
+  return (mod as { config: { support?: { userIds: string[] } } }).config;
+};
+
+// Pinned so the developer's own `.env` (read by dotenv inside config.ts)
+// cannot change what is under test.
+const BASE = {
+  NODE_ENV: "dev",
+  PORT: "8080",
+  DATABASE: "postgres://localhost:5432/flexi-day",
+  BETTER_AUTH_SECRET: "secret",
+  BETTER_AUTH_URL: "http://localhost:8080",
+  DEV_TOOLS_ENABLED: "false",
+  SUPPORT_ADMIN_USER_IDS: "",
+};
+
+const ID_A = "e9dl7v5efgnn0cjrmn7hqz3aswwqxg2b";
+const ID_B = "k2mfp8w1qrtz5xcvbn3hjl7dysagu4e6";
+
+describe("config support allowlist", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("is off when the variable is unset or empty", async () => {
+    expect((await loadConfig({ ...BASE })).support).toBeUndefined();
+    expect((await loadConfig({ ...BASE, SUPPORT_ADMIN_USER_IDS: " , ," })).support).toBeUndefined();
+  });
+
+  it("splits, trims and de-duplicates the list", async () => {
+    const config = await loadConfig({
+      ...BASE,
+      SUPPORT_ADMIN_USER_IDS: ` ${ID_A} ,${ID_B},${ID_A}`,
+    });
+    expect(config.support?.userIds).toEqual([ID_A, ID_B]);
+  });
+
+  it("throws at boot on an entry that is not a user id", async () => {
+    await expect(
+      loadConfig({ ...BASE, SUPPORT_ADMIN_USER_IDS: "owner@dev.local" })
+    ).rejects.toThrow(/does not look like a user id/);
+  });
+});

--- a/src/tests/config.supportAdmins.test.ts
+++ b/src/tests/config.supportAdmins.test.ts
@@ -51,9 +51,23 @@ describe("config support allowlist", () => {
     expect(config.support?.userIds).toEqual([ID_A, ID_B]);
   });
 
+  it("accepts a dev-seeded dashed UUID", async () => {
+    const uuid = "88bf2347-3d61-47e2-90ea-0d2b800f4e72";
+    const config = await loadConfig({ ...BASE, SUPPORT_ADMIN_USER_IDS: uuid });
+    expect(config.support?.userIds).toEqual([uuid]);
+  });
+
   it("throws at boot on an entry that is not a user id", async () => {
-    await expect(
-      loadConfig({ ...BASE, SUPPORT_ADMIN_USER_IDS: "owner@dev.local" })
-    ).rejects.toThrow(/does not look like a user id/);
+    for (const bad of [
+      "owner@dev.local",
+      // Dash-only and wrong-length values must not slip through as ids.
+      "----------------",
+      "88bf2347-3d61-47e2-90ea",
+      "e9dl7v5efgnn0cjrmn7hqz3aswwqxg2", // 31 chars
+    ]) {
+      await expect(loadConfig({ ...BASE, SUPPORT_ADMIN_USER_IDS: bad })).rejects.toThrow(
+        /does not look like a user id/
+      );
+    }
   });
 });

--- a/src/tests/e2e/helpers/testSetup.ts
+++ b/src/tests/e2e/helpers/testSetup.ts
@@ -11,6 +11,7 @@ import { eq } from "drizzle-orm";
 import { organizations } from "../../../db/schema/organization-schema.js";
 import { subscriptions } from "../../../db/schema/subscription-schema.js";
 import { paddleEvents } from "../../../db/schema/paddle-event-schema.js";
+import { supportAccess } from "../../../db/schema/support-access-schema.js";
 import { ensureOrganizationForUser } from "../../../services/organization/organizationServices.js";
 
 export interface TestUser {
@@ -134,6 +135,8 @@ export async function cleanupTestData() {
     await db.delete(subscriptions);
     await db.delete(organizations);
     await db.delete(paddleEvents);
+    // Before `user`: support_access deliberately has no ON DELETE cascade.
+    await db.delete(supportAccess);
     await db.delete(user);
 
     // Clear cache

--- a/src/tests/e2e/supportSurface.e2e.test.ts
+++ b/src/tests/e2e/supportSurface.e2e.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Lock-down tests for the platform-support read surface's data invariants
+ * (see CLAUDE.md "Platform-Support Surface"). Runs against a real database.
+ * Test library/framework: Vitest
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { v4 as uuidv4 } from "uuid";
+import { eq } from "drizzle-orm";
+import { db } from "../../db/db.js";
+import { user } from "../../db/schema/auth-schema.js";
+import { groups } from "../../db/schema/group-schema.js";
+import { organizations } from "../../db/schema/organization-schema.js";
+import { vacation } from "../../db/schema/vacation-schema.js";
+import { supportAccess } from "../../db/schema/support-access-schema.js";
+import {
+  getGroupDetailForSupport,
+  recordSupportAccess,
+  searchOrganizationsForSupport,
+} from "../../services/support/supportServices.js";
+import { cleanupTestData } from "./helpers/testSetup.js";
+
+describe("support surface data invariants", () => {
+  const ownerId = uuidv4();
+  const orgId = uuidv4();
+  const groupId = uuidv4();
+
+  beforeAll(async () => {
+    await cleanupTestData();
+    await db.insert(user).values({
+      id: ownerId,
+      email: `support-owner-${ownerId}@dev.local`,
+      name: "Support Owner a_b",
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Support Org a_b",
+      ownerUserId: ownerId,
+      billingEmail: `support-owner-${ownerId}@dev.local`,
+    });
+    await db.insert(groups).values({
+      id: groupId,
+      organizationId: orgId,
+      groupName: "Support Group",
+      managerUserId: ownerId,
+    });
+    await db.insert(vacation).values({
+      id: uuidv4(),
+      userId: ownerId,
+      groupId,
+      requestedDay: "2026-08-03",
+      note: "medical appointment",
+      rejectedAt: new Date(),
+      rejectedBy: ownerId,
+      rejectionReason: "private reason",
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  it("group detail never carries note or rejectionReason", async () => {
+    const detail = await getGroupDetailForSupport(groupId);
+    expect(detail).toBeDefined();
+    expect(detail!.vacations).toHaveLength(1);
+    const row = detail!.vacations[0] as unknown as Record<string, unknown>;
+    expect(row).not.toHaveProperty("note");
+    expect(row).not.toHaveProperty("rejectionReason");
+    // The state timestamps themselves must survive — they are the point.
+    expect(row.rejectedAt).toBeTruthy();
+  });
+
+  it("escapes ILIKE wildcards in the search term", async () => {
+    const underscore = await searchOrganizationsForSupport("a_b");
+    expect(underscore.map((o) => o.id)).toContain(orgId);
+
+    // "_" is escaped, so it must not act as a single-character wildcard —
+    // unescaped, "S_pport" would match "Support Org a_b".
+    const wildcardAbuse = await searchOrganizationsForSupport("S_pport");
+    expect(wildcardAbuse.map((o) => o.id)).not.toContain(orgId);
+
+    // A bare "%" must not turn into match-everything.
+    const percent = await searchOrganizationsForSupport("%");
+    expect(percent).toHaveLength(0);
+  });
+
+  it("audit rows block deleting the audited user instead of vanishing with it", async () => {
+    await recordSupportAccess({
+      userId: ownerId,
+      method: "GET",
+      path: "/api/support/organizations",
+    });
+
+    await expect(db.delete(user).where(eq(user.id, ownerId))).rejects.toThrow();
+
+    const rows = await db.select().from(supportAccess).where(eq(supportAccess.userId, ownerId));
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/src/tests/middleware/supportGuard.test.ts
+++ b/src/tests/middleware/supportGuard.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the supportGuard middleware.
+ * Test library/framework: Vitest
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+
+vi.mock("../../config.js", () => ({
+  config: { support: undefined as { userIds: string[] } | undefined },
+}));
+
+vi.mock("../../middleware/logger.js", () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+const selectResult = vi.hoisted(() => ({ rows: [] as { twoFactorEnabled: boolean | null }[] }));
+
+vi.mock("../../db/db.js", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve(selectResult.rows) }),
+      }),
+    }),
+  },
+}));
+
+const recordSupportAccess = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock("../../services/support/supportServices.js", () => ({
+  recordSupportAccess,
+}));
+
+import { requireSupportAdmin } from "../../middleware/supportGuard.js";
+import { config } from "../../config.js";
+import AppError from "../../utils/appError.js";
+
+const ADMIN_ID = "e9dl7v5efgnn0cjrmn7hqz3aswwqxg2b";
+
+const makeReq = (userId: string): Request =>
+  ({
+    auth: {
+      sessionId: "s",
+      userId,
+      userName: "n",
+      userEmail: "e@example.com",
+      emailVerified: true,
+    },
+    method: "GET",
+    originalUrl: "/api/support/organizations",
+  } as unknown as Request);
+
+const run = async (req: Request) => {
+  const next = vi.fn() as unknown as NextFunction & { mock: { calls: unknown[][] } };
+  await requireSupportAdmin(req, {} as Response, next);
+  return next;
+};
+
+const errorFrom = (next: { mock: { calls: unknown[][] } }): AppError =>
+  next.mock.calls[0]![0] as AppError;
+
+describe("requireSupportAdmin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (config as { support?: { userIds: string[] } }).support = { userIds: [ADMIN_ID] };
+    selectResult.rows = [{ twoFactorEnabled: true }];
+  });
+
+  it("passes an allowlisted 2FA-enabled caller and audits the request", async () => {
+    const next = await run(makeReq(ADMIN_ID));
+    expect(next).toHaveBeenCalledWith();
+    expect(recordSupportAccess).toHaveBeenCalledWith({
+      userId: ADMIN_ID,
+      method: "GET",
+      path: "/api/support/organizations",
+    });
+  });
+
+  it("404s a caller who is not on the allowlist", async () => {
+    const next = await run(makeReq("someoneelse00000000000000000000x"));
+    const err = errorFrom(next);
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.statusCode).toBe(404);
+    expect(recordSupportAccess).not.toHaveBeenCalled();
+  });
+
+  it("404s everyone when the allowlist is not configured", async () => {
+    (config as { support?: { userIds: string[] } }).support = undefined;
+    const next = await run(makeReq(ADMIN_ID));
+    expect(errorFrom(next).statusCode).toBe(404);
+  });
+
+  it("403s an allowlisted caller without two-factor enabled", async () => {
+    selectResult.rows = [{ twoFactorEnabled: false }];
+    const next = await run(makeReq(ADMIN_ID));
+    expect(errorFrom(next).statusCode).toBe(403);
+    expect(recordSupportAccess).not.toHaveBeenCalled();
+  });
+
+  it("403s when the user row is missing", async () => {
+    selectResult.rows = [];
+    const next = await run(makeReq(ADMIN_ID));
+    expect(errorFrom(next).statusCode).toBe(403);
+  });
+});

--- a/src/tests/middleware/supportGuard.test.ts
+++ b/src/tests/middleware/supportGuard.test.ts
@@ -33,6 +33,7 @@ vi.mock("../../services/support/supportServices.js", () => ({
 
 import { requireSupportAdmin } from "../../middleware/supportGuard.js";
 import { config } from "../../config.js";
+import { logger } from "../../middleware/logger.js";
 import AppError from "../../utils/appError.js";
 
 const ADMIN_ID = "e9dl7v5efgnn0cjrmn7hqz3aswwqxg2b";
@@ -47,7 +48,9 @@ const makeReq = (userId: string): Request =>
       emailVerified: true,
     },
     method: "GET",
-    originalUrl: "/api/support/organizations",
+    baseUrl: "/api/support",
+    path: "/organizations",
+    originalUrl: "/api/support/organizations?query=jane%40acme.com",
   } as unknown as Request);
 
 const run = async (req: Request) => {
@@ -66,22 +69,28 @@ describe("requireSupportAdmin", () => {
     selectResult.rows = [{ twoFactorEnabled: true }];
   });
 
-  it("passes an allowlisted 2FA-enabled caller and audits the request", async () => {
+  it("passes an allowlisted 2FA-enabled caller and audits the full request target", async () => {
     const next = await run(makeReq(ADMIN_ID));
     expect(next).toHaveBeenCalledWith();
+    // The audit row keeps the query string on purpose — for the search
+    // endpoint the query IS the target the trail exists to record.
     expect(recordSupportAccess).toHaveBeenCalledWith({
       userId: ADMIN_ID,
       method: "GET",
-      path: "/api/support/organizations",
+      path: "/api/support/organizations?query=jane%40acme.com",
     });
   });
 
-  it("404s a caller who is not on the allowlist", async () => {
+  it("404s a caller who is not on the allowlist without logging the query string", async () => {
     const next = await run(makeReq("someoneelse00000000000000000000x"));
     const err = errorFrom(next);
     expect(err).toBeInstanceOf(AppError);
     expect(err.statusCode).toBe(404);
     expect(recordSupportAccess).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith("supportGuard rejected non-allowlisted request", {
+      userId: "someoneelse00000000000000000000x",
+      path: "/api/support/organizations",
+    });
   });
 
   it("404s everyone when the allowlist is not configured", async () => {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -4,7 +4,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { and, eq, ne } from "drizzle-orm";
 import { db } from "../db/db.js";
 import { account as accountTable, user as userTable } from "../db/schema/auth-schema.js";
-import { haveIBeenPwned, openAPI, twoFactor } from "better-auth/plugins";
+import { customSession, haveIBeenPwned, openAPI, twoFactor } from "better-auth/plugins";
 import { config } from "../config.js";
 import { emailSender } from "../services/email/index.js";
 import { logger } from "../middleware/logger.js";
@@ -199,5 +199,17 @@ export const auth = betterAuth({
         },
       },
     }),
+    // Last on purpose (better-auth infers session fields added by earlier
+    // plugins into this callback). Rides on the session fetch the client
+    // already makes, so the frontend learns whether to render the support UI
+    // without any extra request. A UI hint only — the enforcement is
+    // `requireSupportAdmin` on /api/support/*.
+    customSession(({ user, session }) =>
+      Promise.resolve({
+        user,
+        session,
+        supportAdmin: config.support?.userIds.includes(user.id) ?? false,
+      })
+    ),
   ],
 });


### PR DESCRIPTION
## What

`/api/support/*` — a read-only, cross-tenant surface for the platform owner to inspect any organization or group when debugging customer reports:

- `GET /api/support/organizations?query=` — search by org name, owner name/email, or exact org id
- `GET /api/support/organizations/:id` — owner, resolved plan entitlements, all groups (deleted included), admins
- `GET /api/support/groups/:id` — settings, members (removed included), quotas, latest 200 vacation rows

## Design decisions

- **Env allowlist, not a DB flag.** `SUPPORT_ADMIN_USER_IDS` parses into `config.support`; unset means the router is never mounted. No API can grant the role, so there is no escalation surface. Malformed entries throw at boot.
- **Dedicated reads, no bypass.** Nothing was added to `assertGroupAdmin` / `isOrganizationAdmin` — the support services take explicit ids behind their own guard.
- **Guard:** 404 for non-allowlisted callers (surface stays invisible), 403 for an allowlisted account without 2FA, audit row (`support_access`) written before every handler. The audit FK has **no ON DELETE cascade** — deleting the staff account must not erase the trail.
- **Frontend discovery via session.** A `customSession` plugin adds `supportAdmin` to the get-session payload the SPA already fetches — normal users make zero extra requests and never see a 404.
- **Privacy:** vacation rows exclude `note` and `rejectionReason`; ILIKE wildcards in the search term are escaped.

## Review findings addressed (3 rounds of independent review)

- audit FK cascade removed (would have erased the trail on account deletion)
- ILIKE `%`/`_` escaping added
- e2e lock-down tests added for the note/rejectionReason exclusion, the FK behavior and the escaping
- `customSession` moved to the end of the plugin list (better-auth type-inference ordering)

Not fixed (accepted): the guard's JSON 404 is distinguishable from Express's HTML 404 by a signed-in prober — reveals only that the deployment has the surface enabled, not who is on the allowlist.

## Verified

- 553 unit + 188 e2e tests green (3 new e2e lock-down tests, 8 new unit tests)
- Exercised live against the local stack: allowlisted owner with 2FA → 200s with correct data; without 2FA → 403; non-allowlisted member → 404; unknown ids → 404; audit rows written; search filtering incl. wildcard-escape behavior
- Companion frontend PR: Daniel88dev/flexi-day#65

## Rollout (deploy this before the frontend PR)

1. Apply `src/db/schema/out/0018_striped_robin_chapel.sql` to prod as raw SQL (the drizzle ledger is stale in prod — do not run `db:migrate`).
2. Set `SUPPORT_ADMIN_USER_IDS=<owner user id>` on the backend.
3. The owner account must have 2FA enabled or every support request 403s.

Without step 1, support requests fail closed (500 on the audit insert) — no data exposure, but the surface is dead until the table exists.

## Repro

`npm run dev:scenario`, add `SUPPORT_ADMIN_USER_IDS=<owner id from the seed>` to `.env`, restart the backend, then `curl` the endpoints with the seeded owner's session cookie (`npm run dev:login owner@dev.local`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a protected support surface for searching organizations and viewing organization and group details.
  * Support access requires approved administrator access and two-factor authentication.
  * Added session status indicating support-administrator access.
  * Added configurable support-administrator access and audit logging for support requests.
  * Support details include billing, subscriptions, groups, memberships, quotas, and troubleshooting information.

* **Bug Fixes**
  * Sensitive vacation notes and rejection reasons are excluded from support responses.

* **Tests**
  * Added coverage for authorization, configuration, auditing, search behavior, and sensitive-data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->