### PR TITLE
feat: return member count and caller membership on the group list

### DIFF
--- a/src/controllers/group/handleGetGroups.ts
+++ b/src/controllers/group/handleGetGroups.ts
@@ -15,17 +15,29 @@ const services = createDBServices();
 export const handleGetGroups = async (req: Request, res: Response) => {
   const auth = getAuth(req);
 
-  const groups = (await services.groupUser.getAllGroupsForUser(auth.userId)).map(
-    (group) => group.groupId
+  const memberships = await services.groupUser.getAllGroupsForUser(auth.userId);
+  const membershipByGroup = new Map(memberships.map((m) => [m.groupId, m]));
+  const groupIds = memberships.map((m) => m.groupId);
+
+  const result = await services.group.getAllGroups(groupIds);
+
+  const [badges, memberCounts] = await Promise.all([
+    resolveOrganizationBadges(result.map((group) => group.organizationId)),
+    services.groupUser.countMembersByGroup(groupIds),
+  ]);
+
+  return res.status(200).json(
+    result.map((group) => {
+      const membership = membershipByGroup.get(group.id);
+      return {
+        ...group,
+        organization: badges.get(group.organizationId) ?? null,
+        memberCount: memberCounts.get(group.id) ?? 0,
+        membership: {
+          adminAccess: membership?.adminAccess ?? false,
+          approverAccess: membership?.approverAccess ?? false,
+        },
+      };
+    })
   );
-
-  const result = await services.group.getAllGroups(groups);
-
-  const badges = await resolveOrganizationBadges(result.map((group) => group.organizationId));
-
-  return res
-    .status(200)
-    .json(
-      result.map((group) => ({ ...group, organization: badges.get(group.organizationId) ?? null }))
-    );
 };

--- a/src/controllers/group/tests/handleGetGroups.test.ts
+++ b/src/controllers/group/tests/handleGetGroups.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockGetAllGroupsForUser,
+  mockGetAllGroups,
+  mockCountMembersByGroup,
+  mockResolveOrganizationBadges,
+} = vi.hoisted(() => ({
+  mockGetAllGroupsForUser: vi.fn(),
+  mockGetAllGroups: vi.fn(),
+  mockCountMembersByGroup: vi.fn(),
+  mockResolveOrganizationBadges: vi.fn(),
+}));
+
+vi.mock("../../../middleware/authSession.js", () => ({ getAuth: vi.fn() }));
+
+vi.mock("../../../services/organization/organizationBadge.js", () => ({
+  resolveOrganizationBadges: mockResolveOrganizationBadges,
+}));
+
+vi.mock("../../../services/DBServices.js", () => ({
+  createDBServices: () => ({
+    group: { getAllGroups: mockGetAllGroups },
+    groupUser: {
+      getAllGroupsForUser: mockGetAllGroupsForUser,
+      countMembersByGroup: mockCountMembersByGroup,
+    },
+  }),
+}));
+
+import { handleGetGroups } from "../handleGetGroups.js";
+import { getAuth } from "../../../middleware/authSession.js";
+import { makeReqRes, mockAuthData } from "../../../tests/testUtils.js";
+
+const groupA = { id: "group-a", organizationId: "org-1", groupName: "Alpha" };
+const groupB = { id: "group-b", organizationId: "org-2", groupName: "Beta" };
+
+const badge = { id: "org-1", name: "Acme", plan: "PRO", status: "active", active: true };
+
+describe("handleGetGroups", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getAuth).mockReturnValue(mockAuthData);
+    mockGetAllGroupsForUser.mockResolvedValue([
+      { groupId: "group-a", adminAccess: true, approverAccess: false },
+      { groupId: "group-b", adminAccess: false, approverAccess: true },
+    ]);
+    mockGetAllGroups.mockResolvedValue([groupA, groupB]);
+    mockCountMembersByGroup.mockResolvedValue(
+      new Map([
+        ["group-a", 4],
+        ["group-b", 1],
+      ])
+    );
+    mockResolveOrganizationBadges.mockResolvedValue(new Map([["org-1", badge]]));
+  });
+
+  const call = async () => {
+    const { req, res } = makeReqRes({});
+    await handleGetGroups(req, res);
+    return vi.mocked(res.json).mock.calls[0]?.[0] as {
+      id: string;
+      organization: unknown;
+      memberCount: number;
+      membership: { adminAccess: boolean; approverAccess: boolean };
+    }[];
+  };
+
+  it("carries the member count per group", async () => {
+    const result = await call();
+
+    expect(result.map((g) => g.memberCount)).toEqual([4, 1]);
+  });
+
+  it("carries the caller's own membership flags per group", async () => {
+    const [first, second] = await call();
+
+    expect(first?.membership).toEqual({ adminAccess: true, approverAccess: false });
+    expect(second?.membership).toEqual({ adminAccess: false, approverAccess: true });
+  });
+
+  it("falls back to zero members and no rights when the maps miss a group", async () => {
+    mockCountMembersByGroup.mockResolvedValue(new Map());
+    mockGetAllGroupsForUser.mockResolvedValue([
+      { groupId: "group-a", adminAccess: true, approverAccess: false },
+    ]);
+    mockGetAllGroups.mockResolvedValue([groupA, groupB]);
+
+    const [, second] = await call();
+
+    expect(second?.memberCount).toBe(0);
+    expect(second?.membership).toEqual({ adminAccess: false, approverAccess: false });
+  });
+
+  it("resolves the organization badge, null when the org has none", async () => {
+    const [first, second] = await call();
+
+    expect(first?.organization).toEqual(badge);
+    expect(second?.organization).toBeNull();
+  });
+});

--- a/src/routes/groupRouter.ts
+++ b/src/routes/groupRouter.ts
@@ -72,6 +72,84 @@ export const groupRouter = (): Router => {
    */
   app.post("/", tryCatch(handlePostGroup));
 
+  /**
+   * @openapi
+   * /api/group:
+   *   get:
+   *     tags:
+   *       - Groups
+   *     summary: The caller's groups
+   *     description: |
+   *       Membership-only on purpose: this list also drives the dashboard, the
+   *       calendar and the request dialog, so groups the caller merely
+   *       administers through their organization do not appear (those come from
+   *       `/api/organization`). Ordered by group name. Each group carries its
+   *       organization badge, an active-member headcount and the caller's own
+   *       membership flags.
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       '200':
+   *         description: Groups the caller belongs to
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 type: object
+   *                 properties:
+   *                   id:
+   *                     type: string
+   *                     format: uuid
+   *                   organizationId:
+   *                     type: string
+   *                     format: uuid
+   *                   groupName:
+   *                     type: string
+   *                   defaultVacationDays:
+   *                     type: integer
+   *                   defaultHomeOfficeDays:
+   *                     type: integer
+   *                   workingDays:
+   *                     type: array
+   *                     items:
+   *                       type: integer
+   *                   holidayCountry:
+   *                     type: string
+   *                     nullable: true
+   *                   managerUserId:
+   *                     type: string
+   *                   mainApprovalUser:
+   *                     type: string
+   *                     nullable: true
+   *                   tempApprovalUser:
+   *                     type: string
+   *                     nullable: true
+   *                   deletedAt:
+   *                     type: string
+   *                     format: date-time
+   *                     nullable: true
+   *                   createdAt:
+   *                     type: string
+   *                     format: date-time
+   *                   updatedAt:
+   *                     type: string
+   *                     format: date-time
+   *                   organization:
+   *                     type: object
+   *                     nullable: true
+   *                   memberCount:
+   *                     type: integer
+   *                     description: Active members of the group
+   *                   membership:
+   *                     type: object
+   *                     description: The caller's own membership row flags
+   *                     properties:
+   *                       adminAccess:
+   *                         type: boolean
+   *                       approverAccess:
+   *                         type: boolean
+   */
   app.get("/", tryCatch(handleGetGroups));
 
   /**

--- a/src/services/DBServices.ts
+++ b/src/services/DBServices.ts
@@ -53,6 +53,7 @@ export type DBServices = Readonly<{
     countActiveMembershipsInOrganization: typeof groupUserServices.countActiveMembershipsInOrganization;
     getMembershipPairs: typeof groupUserServices.getMembershipPairs;
     countDistinctUsersInGroups: typeof groupUserServices.countDistinctUsersInGroups;
+    countMembersByGroup: typeof groupUserServices.countMembersByGroup;
   };
   inviteLinks: {
     createInviteLink: typeof groupUserServices.createInviteLink;
@@ -216,6 +217,7 @@ export const createDBServices = (): DBServices => {
       countActiveMembershipsInOrganization: groupUserServices.countActiveMembershipsInOrganization,
       getMembershipPairs: groupUserServices.getMembershipPairs,
       countDistinctUsersInGroups: groupUserServices.countDistinctUsersInGroups,
+      countMembersByGroup: groupUserServices.countMembersByGroup,
     },
     inviteLinks: {
       createInviteLink: groupUserServices.createInviteLink,

--- a/src/services/group/groupServices.ts
+++ b/src/services/group/groupServices.ts
@@ -44,7 +44,8 @@ export const getAllGroups = async (
   return (tx ?? db)
     .select()
     .from(groups)
-    .where(and(inArray(groups.id, groupIds), isNull(groups.deletedAt)));
+    .where(and(inArray(groups.id, groupIds), isNull(groups.deletedAt)))
+    .orderBy(asc(groups.groupName));
 };
 
 export const createGroup = async (

--- a/src/services/groupUser/groupUserServices.ts
+++ b/src/services/groupUser/groupUserServices.ts
@@ -81,13 +81,28 @@ export const deleteGroupUser = async (
   return row;
 };
 
-export const getAllGroupsForUser = async (userId: string): Promise<{ groupId: string }[]> => {
+export const getAllGroupsForUser = async (
+  userId: string
+): Promise<{ groupId: string; adminAccess: boolean; approverAccess: boolean }[]> => {
   return db
     .select({
       groupId: groupUsers.groupId,
+      adminAccess: groupUsers.adminAccess,
+      approverAccess: groupUsers.approverAccess,
     })
     .from(groupUsers)
     .where(and(eq(groupUsers.userId, userId), isNull(groupUsers.deletedAt)));
+};
+
+/** Active-member headcount per group, one grouped query for the whole list. */
+export const countMembersByGroup = async (groupIds: string[]): Promise<Map<string, number>> => {
+  if (groupIds.length === 0) return new Map();
+  const rows = await db
+    .select({ groupId: groupUsers.groupId, members: count() })
+    .from(groupUsers)
+    .where(and(inArray(groupUsers.groupId, groupIds), isNull(groupUsers.deletedAt)))
+    .groupBy(groupUsers.groupId);
+  return new Map(rows.map((row) => [row.groupId, row.members]));
 };
 
 /** The groups the user administers — the reach of any admin-only action. */


### PR DESCRIPTION
## What

`GET /api/group` now returns, per group:

- `memberCount` — active-member headcount, computed with one grouped `count()` query for the whole list (no N+1),
- `membership` — the caller's own `adminAccess` / `approverAccess` flags from the membership row the handler already reads.

The list is also ordered by group name (it previously had no `ORDER BY`, so order was non-deterministic), and the route gains the `@openapi` block it was missing entirely.

## Why

The frontend Groups redesign (Daniel88dev/flexi-day — companion PR linked below) shows a member count and the caller's real role on each group card and gates its admin quick links. Without these fields it would need one detail request per group. The endpoint stays membership-only (org-administered groups still come from `/api/organization`), and `approverAccess` remains outside any admin semantics.

## Review

Two independent review rounds. Round 1 found one nit (the new `@openapi` schema omitted fields the handler's spread actually returns) — fixed, the block now matches the payload column-for-column. Round 2: no findings.

## Verified

- Unit: 558/558 (4 new tests for the count, flags, miss-fallbacks and badge-null case).
- E2E: 188/188, including `organizationAdminApi.e2e.test.ts`, which still proves the list stays membership-only for delegated org admins.
- Exercised live against the redesigned frontend: counts and role badges correct for a manager, a delegated org admin and a plain member.

## Reproduce

`npm run dev:scenario` from the workspace root, then `curl -s localhost:8080/api/group -H "Cookie: <session>"` — each item carries `memberCount` and `membership`.

## Deploy order

Merge/deploy this before the frontend PR. The frontend reads both fields optionally and degrades to the previous card when they are absent, so the ordering is for feature completeness, not correctness.

Companion frontend PR: https://github.com/Daniel88dev/flexi-day/pull/67

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Group listings now include active-member counts and the current user’s admin and approver access.
  * Organization badges are displayed when available.
  * Groups are sorted alphabetically by name.
  * Added API documentation describing group listing responses and access details.

* **Bug Fixes**
  * Missing member counts, permissions, or badges now receive appropriate fallback values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->