### PR TITLE
fix(dev): clear support_access rows before deleting seeded users

### DIFF
--- a/src/services/dev/devSeedServices.ts
+++ b/src/services/dev/devSeedServices.ts
@@ -7,6 +7,7 @@ import { groups } from "../../db/schema/group-schema.js";
 import { organizations } from "../../db/schema/organization-schema.js";
 import { subscriptions } from "../../db/schema/subscription-schema.js";
 import { changesSchema } from "../../db/schema/changes-schema.js";
+import { supportAccess } from "../../db/schema/support-access-schema.js";
 import { vacation, vacationType } from "../../db/schema/vacation-schema.js";
 import { vacationEvents, vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { createDBServices } from "../DBServices.js";
@@ -267,8 +268,8 @@ export type ResetSummary = { users: number; groups: number };
 /**
  * Deletes only seeded data. Groups go first because `groups.manager_user_id`
  * and the approval columns reference `user` without a cascade, as do
- * `changes.changing_user_id`; everything else hangs off one of those two
- * deletes via ON DELETE CASCADE.
+ * `changes.changing_user_id` and `support_access.user_id`; everything else
+ * hangs off one of those deletes via ON DELETE CASCADE.
  */
 export const resetDevData = async (): Promise<ResetSummary> => {
   const domain = devDomain();
@@ -283,6 +284,10 @@ export const resetDevData = async (): Promise<ResetSummary> => {
 
   return db.transaction(async (tx) => {
     await tx.delete(changesSchema).where(inArray(changesSchema.changingUserId, ids));
+
+    // The support audit trail deliberately has no cascade so a deleted staff
+    // account cannot erase it; seeded rows have to be cleared explicitly.
+    await tx.delete(supportAccess).where(inArray(supportAccess.userId, ids));
 
     const deletedGroups = await tx
       .delete(groups)


### PR DESCRIPTION
## What

`resetDevData` now deletes the seeded users' `support_access` rows inside the reset transaction, before the `user` delete.

## Why

`npm run dev:reset` (POST `/api/dev/reset`) returned a 500 once a seeded account had touched the platform-support surface:

```
update or delete on table "user" violates foreign key constraint
"support_access_user_id_user_id_fk" on table "support_access"
```

`support_access.user_id` references `user` with **no** cascade on purpose — the schema comment spells it out: the table audits platform staff reading customer data, so deleting the staff account must not erase the trail. That makes it the reset helper's job to clear seeded rows explicitly. It was added after the helper was written, so nothing did, and the whole transaction rolled back.

## Audit of the other FKs

I checked every foreign key pointing at `user` in the live schema (26 of them) and its delete rule. Only four are `NO ACTION`; the rest are `CASCADE` or `SET NULL`:

| Table.column | Covered by |
|---|---|
| `changes.changing_user_id` | already deleted first |
| `groups.manager_user_id` / `main_approval_user` / `temp_approval_user` | already deleted |
| `organizations.owner_user_id` | already deleted (with `subscriptions`) |
| `support_access.user_id` | **the new delete** |

So `support_access` was the only gap. No schema change or migration is needed.

## Verification

Set up the actual failing precondition rather than a synthetic row: ran `dev:scenario`, then had the guard write a genuine audit row by signing in as `owner@dev.local` and calling `GET /api/support/organizations` (the account had to be allowlisted and 2FA-flagged for `requireSupportAdmin` to reach `recordSupportAccess`). Then:

- Against the **unfixed** build: `✖ Internal Server Error`, all 4 dev users still present (transaction rolled back, nothing lost).
- Against the **fixed** build: `deleted 4 users and 1 teams`; afterwards 0 dev users and 0 `support_access` rows, with non-dev accounts, groups and orgs untouched.
- Clean end-to-end repeat of `npm run dev:scenario` → `npm run dev:reset`: 200.
- `npm test` — 558 passed (60 files). Lint and `tsc --noEmit` clean.

## Note for the reviewer

Out of scope here, but adjacent and worth knowing: `groups.organization_id` also references `organizations` with `NO ACTION`, and reset deletes groups filtered by manager/approver only. A group inside a dev-owned org whose manager is a *non-dev* user would fail the org delete the same way. Seeding never produces that shape today, so I left it alone rather than widen the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development data resets now correctly remove support-access audit records associated with seeded users.
  * Prevents reset failures caused by audit records that do not automatically cascade when users are deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->