### PR TITLE
docs: restructure CLAUDE.md into invariants + context, and gate CI on eslint + prettier

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,6 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(gh pr *)",
-      "Bash(gh api *)",
-      "Bash(npm run *)"
-    ],
+    "allow": ["Bash(gh pr *)", "Bash(gh api *)", "Bash(npm run *)"],
     "deny": [
       "NotebookEdit",
       "CronCreate",
@@ -24,5 +20,20 @@
   "disableClaudeAiConnectors": true,
   "disableWorkflows": true,
   "disableBundledSkills": true,
-  "disableArtifact": true
+  "disableArtifact": true,
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; npx --no-install prettier --write --ignore-unknown \"$f\"; } 2>/dev/null || true",
+            "statusMessage": "Formatting with prettier...",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,25 @@
       "Bash(gh pr *)",
       "Bash(gh api *)",
       "Bash(npm run *)"
+    ],
+    "deny": [
+      "NotebookEdit",
+      "CronCreate",
+      "CronDelete",
+      "CronList",
+      "PushNotification",
+      "ReportFindings",
+      "ScheduleWakeup"
     ]
-  }
+  },
+  "deniedMcpServers": [
+    {
+      "serverName": "claude-in-chrome"
+    }
+  ],
+  "skillListingMaxDescChars": 250,
+  "disableClaudeAiConnectors": true,
+  "disableWorkflows": true,
+  "disableBundledSkills": true,
+  "disableArtifact": true
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr *)",
+      "Bash(gh api *)",
+      "Bash(npm run *)"
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,33 @@ on:
     branches: [main]
 
 jobs:
+  checks:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format
+        run: npm run format:check
+
   tests:
     name: Tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,10 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 .idea/
-/CLAUDE.md
+
+# Claude Code: share config, keep machine-local permissions out
+.claude/settings.local.json
+.claude/worktrees/
 
 # Terraform files
 *.tfstate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,12 +36,24 @@ callable and testable outside the timer.
 ## Database access goes through DBServices
 
 `createDBServices()` (`src/services/DBServices.ts`) returns one typed object with a property per
-domain (`vacation`, `group`, `groupUser`, `organization`, `report`, …). Controllers take it rather
-than importing `db` directly. Each domain lives in `src/services/{domain}/` as
-`{domain}Services.ts` plus a `types.ts` holding its TypeScript types and Zod schemas.
+domain (`vacation`, `group`, `groupUser`, `organization`, `report`, …). Each domain lives in
+`src/services/{domain}/` as `{domain}Services.ts` plus a `types.ts` holding its TypeScript types
+and Zod schemas.
 
-Use Drizzle's `db.transaction(...)` when a write must be atomic. Anything that appends a
-`vacation_events` row belongs in the same transaction as the change it records.
+**The controller owns the transaction boundary.** A write handler imports `db`, opens
+`db.transaction(async (tx) => ...)`, and threads that `tx` through every service call and guard
+inside it, so the whole request commits or rolls back together:
+
+```typescript
+const approved = await db.transaction(async (tx) => {
+  const vacationData = await services.vacation.getVacationById(vacationId, tx);
+  await assertMayDecide(auth.userId, [vacationData], "approve", tx);
+  return services.vacation.approveVacation(vacationId, auth.userId, tx);
+});
+```
+
+Anything that appends a `vacation_events` row belongs in the same transaction as the change it
+records. Notifications go out after the commit, never inside it.
 
 ## Route conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in `flexi-day-be`, the Express 5 + TypeScript + Drizzle + Better
+Auth backend for Flexi Day, a vacation management product.
+
+## Invariants
+
+[`docs/invariants.md`](docs/invariants.md) — read before changing auth or account linking,
+`/api/dev/*`, `/api/support/*`, a rate limiter, or an org-admin permission check. Each entry states
+what breaks if it is undone; several have tests that fail on regression.
+
+## Domain
+
+[`CONTEXT.md`](CONTEXT.md) — vacation workflow, group and organization structure, invites,
+mirroring, quota rollover, and the schema rows that are not self-describing.
+
+## Imports need `.js` extensions
+
+`"type": "module"` plus `verbatimModuleSyntax: true` means every relative import carries a `.js`
+extension, even when the source is `.ts`:
+
+```typescript
+import { auth } from "../utils/auth.js";
+```
+
+## Layout
+
+`src/routes/` define endpoints → `src/controllers/` handle request/response → `src/services/` hold
+business logic and database access → `src/db/` is the Drizzle schema and client. `src/index.ts`
+creates the server and handles graceful shutdown; `src/server.ts` assembles middleware and routes.
+
+`src/jobs/` schedules background work with croner, started from `src/index.ts` and stopped on
+shutdown. Job modules only schedule and log — the work itself lives in a service, so it stays
+callable and testable outside the timer.
+
+## Database access goes through DBServices
+
+`createDBServices()` (`src/services/DBServices.ts`) returns one typed object with a property per
+domain (`vacation`, `group`, `groupUser`, `organization`, `report`, …). Controllers take it rather
+than importing `db` directly. Each domain lives in `src/services/{domain}/` as
+`{domain}Services.ts` plus a `types.ts` holding its TypeScript types and Zod schemas.
+
+Use Drizzle's `db.transaction(...)` when a write must be atomic. Anything that appends a
+`vacation_events` row belongs in the same transaction as the change it records.
+
+## Route conventions
+
+A protected route composes `authSession` → `bodyValidationMiddleware(schema)` → `tryCatch(handler)`,
+with the Zod schema imported from that domain's `types.ts`. `tryCatch` forwards to `errorMiddleware`,
+which turns `AppError` (`src/utils/appError.ts`: `code`, `message`, `logging`) into the JSON
+response — throw `AppError` rather than writing error responses by hand.
+
+**API docs are generated, so `@openapi` JSDoc on every route stays complete and current** — request
+and response schemas, auth requirements, error codes, parameter validation. Follow
+`src/routes/vacationRouter.ts`.
+
+## Testing
+
+- Unit: `src/**/*.test.ts`, run with `npm test`. Mock database calls and test the logic.
+- E2E: `src/**/*.e2e.test.ts`, run with `npm run test:e2e` — it checks the DB connection first
+  (`src/tests/e2e/check-db.ts`) and reads `.env.e2e.test`. Real database, helpers in
+  `src/tests/e2e/helpers/`, and each test cleans up after itself. `npm run docker:e2e:run` runs
+  the suite against a containerised Postgres, as CI does.
+
+## Configuration
+
+`src/config.ts` parses and validates every environment variable, and throws at startup when one is
+missing or invalid. Read it rather than a list here. Three blocks are opt-in and stay that way:
+`DEV_TOOLS_*`, `SUPPORT_ADMIN_USER_IDS`, and `PADDLE_*` — see [`docs/invariants.md`](docs/invariants.md).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,103 @@
+# Context: flexi-day-be
+
+The vacation/day-off domain as the backend models it. Security and permission boundaries live in
+[`docs/invariants.md`](docs/invariants.md).
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **Vacation** | One booking row for one user, one group, one day. A multi-day request is many rows. |
+| **Vacation event** | Append-only timeline entry per vacation (created / approved / rejected / cancelled / updated). |
+| **Group** | A team. Has a manager, working days, a holiday country, default quotas, and a list of approvers. |
+| **Manager** | The group's owner. Holds no `group_users` row. |
+| **Approver** | May decide member-submitted requests in a group. Main or temp. |
+| **Group admin** | May administer a group: the manager, or an org admin of the owning organization. |
+| **Organization** | Billing owner above groups. One per user, created lazily. |
+| **Org admin** | The organization's owner, or a delegate holding an `organization_users` row. |
+| **Quota** | A user's allowance for one year in one group (`user_year_quotas`). |
+| **Mirror** | A read-side projection of a user's records from one group into another. |
+| **Invite link** | Single-use code binding one email address to one group. |
+
+## Vacation workflow
+
+1. User creates a vacation request for a specific day and group.
+2. The request is pending until an approver decides it.
+3. A group has main approvers and optional temp approvers.
+4. Approval updates vacation status and quota tracking.
+5. Quota changes are logged in `changes`.
+6. Every transition also appends a `vacation_events` row **inside the same transaction**, and
+   `src/services/vacation/vacationNotifier.ts` fans out the email + in-app notification
+   **after** the commit. The notifier swallows and logs its own errors on purpose — a mail
+   failure must never turn a committed change into a 5xx the client would retry. Workflow mail
+   respects `user_settings.emailNotifications`; account mail (email confirmation) does not.
+
+## Group structure
+
+- Groups have a manager (userId) and defined quotas.
+- Users link to groups via `group_users` with role permissions.
+- Each user has yearly quotas per group in `user_year_quotas`.
+- A user may belong to no group at all. `teamName` is optional on
+  `/api/auth/sign-up-with-team`, so an account can exist before it has anywhere to book time
+  off — `handlePostVacation` gates booking on the membership, not on sign-up.
+
+## Organization admins
+
+A second, orthogonal route to group administration. The org owner may delegate ADMIN to one of the
+organization's own people; a delegate then administers **every** group in that organization
+without belonging to any of them. What a delegate may and may not do is a boundary, not a
+convention — see [`docs/invariants.md`](docs/invariants.md#organization-admin-boundary-organization_users).
+
+## Joining a group (`invite_link`)
+
+An admin issues a single-use code with `POST /api/group-user/{groupId}/invites`; it is emailed via
+the `group-invite` SES template and also returned so the admin can pass it on when the mail fails
+(`emailDelivered: false`). A code is **bound to the address it was issued to** —
+`handlePostGroupUser` refuses a redeemer whose session email differs. Rows with a null `email`
+predate email invites and stay unrestricted. Single-use is enforced by the `usedAt IS NULL`
+predicate in the redeeming UPDATE, so concurrent redemptions cannot both win.
+
+## Mirroring (`group_mirrors`)
+
+A user can opt to have their records from a source group displayed inside another group they
+belong to — a manager showing their own approved leave to their team, or several small teams
+feeding one umbrella group. It is a **read-side projection only**: no vacation row is ever copied,
+so a mirrored record is still approved, counted against quotas and reported in its source group
+alone. Two consequences worth keeping intact:
+
+- Mirrored records are never approvable in the target group. Nothing enforces this explicitly —
+  the approval queries key on `vacation.groupId`, and that is why they must keep doing so.
+- `getVacationsForGroup` re-checks active membership of the target group before projecting, so
+  someone who leaves does not keep leaking time off into it.
+
+## Quota rollover
+
+A croner job (`src/jobs/`) rolls unused quota into the new year. `QUOTA_ROLLOVER_ENABLED` toggles it
+(on outside `test`), `QUOTA_ROLLOVER_CRON` sets the schedule (default `0 2 * * *`) and
+`QUOTA_ROLLOVER_TIMEZONE` the zone it runs in (default `Europe/Prague`). Rows it writes to `changes`
+carry a null `changing_user_id`, which is how an automated rollover is told apart from a person.
+
+## Undeliverable recipients
+
+`emailSender` is wrapped by `src/services/email/suppressUndeliverable.ts` so recipients at reserved
+domains — RFC 2606/6761 (`.test`, `.example`, `.invalid`, `.localhost`, `example.com/.net/.org`)
+and RFC 6762 `.local` — are logged as `email.suppressed` and dropped instead of handed to SES. That
+covers the seeded `@dev.local` accounts, whose mail would otherwise hard-bounce and cost the SES
+account sender reputation. The rule keys on the domain alone, **not** on `NODE_ENV` or
+`DEV_SEED_EMAIL_DOMAIN`: pointing the seed domain at a domain you actually own is how you exercise
+real delivery locally, and that has to keep sending. It applies in production too — a
+reserved-domain address there is bad data, and bouncing it helps nobody.
+
+## Schema notes
+
+`src/db/schema/` is mostly self-describing. The rows that are not:
+
+- `changes-schema.ts` — `changing_user_id` is nullable; NULL means the scheduled quota rollover
+  wrote the row rather than a person.
+- `organization-users-schema.ts` — **delegated** org admins only. The owner is
+  `organizations.ownerUserId` and holds no row, so org admin is always owner-or-row.
+- `report-export-schema.ts` / `support-access-schema.ts` — write-only audit trails; nothing reads
+  them back.
+- `user-settings-schema.ts` — a missing row means defaults, not opt-out.
+- `paddle-event-schema.ts` — webhook idempotency, not billing state (that is
+  `subscription-schema.ts`).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,19 +5,19 @@ The vacation/day-off domain as the backend models it. Security and permission bo
 
 ## Glossary
 
-| Term | Meaning |
-|---|---|
-| **Vacation** | One booking row for one user, one group, one day. A multi-day request is many rows. |
-| **Vacation event** | Append-only timeline entry per vacation (created / approved / rejected / cancelled / updated). |
-| **Group** | A team. Has a manager, working days, a holiday country, default quotas, and a list of approvers. |
-| **Manager** | The group's owner. Holds no `group_users` row. |
-| **Approver** | May decide member-submitted requests in a group. Main or temp. |
-| **Group admin** | May administer a group: the manager, or an org admin of the owning organization. |
-| **Organization** | Billing owner above groups. One per user, created lazily. |
-| **Org admin** | The organization's owner, or a delegate holding an `organization_users` row. |
-| **Quota** | A user's allowance for one year in one group (`user_year_quotas`). |
-| **Mirror** | A read-side projection of a user's records from one group into another. |
-| **Invite link** | Single-use code binding one email address to one group. |
+| Term               | Meaning                                                                                          |
+| ------------------ | ------------------------------------------------------------------------------------------------ |
+| **Vacation**       | One booking row for one user, one group, one day. A multi-day request is many rows.              |
+| **Vacation event** | Append-only timeline entry per vacation (created / approved / rejected / cancelled / updated).   |
+| **Group**          | A team. Has a manager, working days, a holiday country, default quotas, and a list of approvers. |
+| **Manager**        | The group's owner. Holds no `group_users` row.                                                   |
+| **Approver**       | May decide member-submitted requests in a group. Main or temp.                                   |
+| **Group admin**    | May administer a group: the manager, or an org admin of the owning organization.                 |
+| **Organization**   | Billing owner above groups. One per user, created lazily.                                        |
+| **Org admin**      | The organization's owner, or a delegate holding an `organization_users` row.                     |
+| **Quota**          | A user's allowance for one year in one group (`user_year_quotas`).                               |
+| **Mirror**         | A read-side projection of a user's records from one group into another.                          |
+| **Invite link**    | Single-use code binding one email address to one group.                                          |
 
 ## Vacation workflow
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,7 +21,8 @@ The vacation/day-off domain as the backend models it. Security and permission bo
 
 ## Vacation workflow
 
-1. User creates a vacation request for a specific day and group.
+1. User creates a vacation request for a group over an inclusive date range (`from`/`to` on
+   `POST /create-vacation`; a single day is `from == to`). One row is stored per day.
 2. The request is pending until an approver decides it.
 3. A group has main approvers and optional temp approvers.
 4. Approval updates vacation status and quota tracking.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -1,0 +1,164 @@
+# Invariants
+
+Rules that hold across `flexi-day-be` and must survive every change. Each entry says what breaks
+if it is undone; most are covered by a test that fails on regression.
+
+## Authentication (`src/utils/auth.ts`)
+
+Better Auth with email/password, mandatory email verification, password reset by email
+(`password-reset` SES template), Have I Been Pwned checks, a Drizzle session adapter, and its own
+rate limit (50 requests / 10s) on top of `credentialsLimiter`.
+
+- **Social sign-in never confers a verified address.** `buildSocialProviders` maps every Google and
+  Microsoft profile to `emailVerified: false`, because both providers' claims attest the _domain_,
+  not the mailbox, and a verified address unlocks invite redemption in `handlePostGroupUser`.
+  Verification comes from our own confirmation email, exactly as for a password sign-up.
+- **Account linking is explicit only.** `accountLinking` trusts both providers — needed at all,
+  since the false `emailVerified` above would otherwise block every link — and then sets
+  `disableImplicitLinking`, so a provider can only be attached from a signed-in session via
+  `POST /link-social` (Settings → Sign-in methods). Without that flag, a directory administrator
+  could set a mail attribute to someone else's address and sign straight into their account.
+  Keep `allowDifferentEmails` and `allowUnlinkingAll` off;
+  `src/tests/utils/accountLinking.test.ts` fails if any of this is undone.
+- **A completed password reset settles the account.** `onPasswordReset` marks the address verified
+  and, when it was _not_ already verified, deletes every non-`credential` `account` row in the same
+  transaction. Both halves are deliberate. Verifying is what makes the new password usable at all
+  (`requireEmailVerification` would otherwise reject it, and social sign-up never verifies). Deleting
+  is what stops the promotion being an escalation: an unverified row can have been created by a
+  provider asserting an address nobody confirmed, social sign-in is not gated on verification, so a
+  surviving link would hand that account — now verified — straight back to whoever planted it. The
+  cost is that a legitimate social-only user who never confirmed their address loses their provider
+  link on reset; the reset email says so, and Settings → Sign-in methods reconnects it.
+  `src/tests/e2e/passwordResetSettles.e2e.test.ts` covers this.
+
+## Local dev surface (`src/routes/devRouter.ts`, `src/middleware/devGuard.ts`, `src/services/dev/`)
+
+`/api/dev/*` seeds verified users, teams, quotas and vacations, and issues session cookies, so the
+frontend can be driven locally without SES email verification. It is gated five ways and must stay
+that way:
+
+1. `server.ts` only mounts the router when `config.dev` is defined.
+2. `parseDevTools()` in `config.ts` returns `undefined` unless `DEV_TOOLS_ENABLED=true`, and
+   **throws at startup** if that is combined with `NODE_ENV=production`.
+3. It also throws if `DATABASE` does not point at localhost.
+4. `devGuard` requires a loopback `socket.remoteAddress` — deliberately not `req.ip`, which follows
+   the spoofable `X-Forwarded-For` because `trust proxy` is on.
+5. `devGuard` requires `x-dev-token` to match `DEV_TOOLS_TOKEN` (timing-safe, ≥16 chars).
+
+Seeding is confined to `DEV_SEED_EMAIL_DOMAIN` (default `dev.local`), which is also the exact scope
+of `POST /api/dev/reset` — there is no unscoped delete. Users are created by inserting `user` +
+`account` rows with better-auth's own `hashPassword`, bypassing `signUpEmail` because that runs the
+haveIBeenPwned check (an outbound call that fails offline) and fires a verification email.
+
+The frontend half is gated too: `/dev-sign-in/` only builds when `NEXT_PUBLIC_DEV_TOOLS=1`, and
+`pageExtensions` in `next.config.ts` keeps `page.dev.tsx` files out of production output entirely.
+
+## Platform-support surface (`src/routes/supportRouter.ts`, `src/middleware/supportGuard.ts`, `src/services/support/`)
+
+`/api/support/*` lets the platform owner inspect any organization or group (cross-tenant,
+read-only) to debug customer reports.
+
+1. **The allowlist is an env var, not a DB flag.** `SUPPORT_ADMIN_USER_IDS` (comma-separated user
+   ids) parses into `config.support`; unset means the router is never mounted. No API can grant the
+   role, so there is no privilege-escalation surface — it changes only via deploy. Malformed
+   entries throw at boot (an allowlist that silently never matches is worse than a crash).
+2. **Dedicated read-only endpoints, not a bypass.** The support reads live in `supportServices.ts`
+   and take their scope as explicit ids. Keep support carve-outs out of `assertGroupAdmin` /
+   `validateUserGroupAccess` / `isOrganizationAdmin` — one there would silently turn every route,
+   including writes, into a superuser route.
+3. **`requireSupportAdmin` 404s non-allowlisted callers** (not 403 — the surface should be
+   invisible to probers) and **403s an allowlisted account without 2FA enabled**. It reads
+   `req.auth` directly rather than importing `authSession.js`, keeping better-auth out of its
+   import graph.
+4. **Every request is audited.** The guard writes a `support_access` row (user, method,
+   path+query) before the handler runs. Write-only, like `report_exports`.
+5. **The frontend learns about the role from the session.** The `customSession` plugin in
+   `auth.ts` adds `supportAdmin` to the get-session payload, so normal users never probe a support
+   endpoint (no 404 noise, no failure-limiter burn, nothing in their network tab). The flag is a
+   UI hint only; the guard re-checks the allowlist on every request.
+6. **Responses exclude `note` and `rejectionReason`** from vacation rows — personal detail that
+   debugging state bugs never needs.
+
+## Rate limiting (`src/middleware/limiter.ts`)
+
+Several limiters, not one, because a single per-IP bucket both throttles real users and
+under-protects the endpoints that matter:
+
+| Limiter                | Mounted on                                      | Key                            | Budget                   |
+| ---------------------- | ----------------------------------------------- | ------------------------------ | ------------------------ |
+| `floodLimiter`         | everything                                      | IP                             | 5000 / 5 min             |
+| `apiFailureLimiter`    | `/api` (before session validation)              | IP                             | 100 **failures** / 5 min |
+| `apiLimiter`           | `/api` (after the auth and dev routes)          | validated user id, IP fallback | 1000 / 5 min             |
+| `credentialsLimiter`   | sign-in / sign-up / reset-password / two-factor | IP                             | 20 **failures** / 15 min |
+| `passwordResetLimiter` | `request-password-reset`                        | IP                             | 5 / 15 min               |
+| `otpSendLimiter`       | `two-factor/send-otp`                           | IP                             | 10 / 15 min              |
+| `calendarFeedLimiter`  | `/calendars/:token.ics`                         | feed token                     | 120 / hour               |
+| `paddleWebhookLimiter` | `/api/webhooks/paddle`                          | IP                             | 5000 / 5 min             |
+
+- **`apiLimiter` keys on the session, not the IP.** Keying on the IP pools every user behind one
+  office NAT, VPN or mobile CGNAT into a single allowance. Custom key generators must run IPs
+  through `ipKeyGenerator` — a bare `req.ip` lets one IPv6 /64 rotate addresses freely.
+- **`credentialsLimiter` covers the whole `/api/auth/two-factor` surface, not just the verify
+  endpoints.** A 6-digit code is far cheaper to guess than a password, and enable / disable /
+  get-totp-uri / generate-backup-codes are password oracles — without the failures-only budget, a
+  stolen session cookie could brute-force the password via `POST /two-factor/disable` and switch
+  2FA off. `otpSendLimiter` exists for `send-otp` for the same reason `passwordResetLimiter` does:
+  the route always answers 200, so failures-only counting never triggers, and what needs bounding
+  is the email it sends.
+- **`passwordResetLimiter` exists because `credentialsLimiter` cannot cover that route.** Asking
+  for a reset answers 200 for every input on purpose (it must reveal nothing about which addresses
+  exist), and `credentialsLimiter` counts only failures — so nothing would ever increment. What
+  needs bounding there is the email it sends, not guessing. It keys on the IP, so it bounds volume
+  per source and **not** per address; a distributed flood at one address is still open.
+- **`credentialsLimiter` sets `skipSuccessfulRequests`.** Only failures count, so a whole team
+  signing in at 9am is unaffected while a password guesser burns the budget.
+- **`calendarFeedLimiter` keys on the token.** Google polls every subscribed feed from a handful of
+  shared ranges, so an IP key would throttle all users at once.
+- **`floodLimiter` skips `OPTIONS` and `/health`.** Preflights are not attack surface (CORS `maxAge`
+  caches them) and the health check must not spend a caller's budget.
+
+The store is in-memory: counters are per-process and reset on deploy. Running more than one instance
+multiplies the effective limits — that needs a shared store before scaling out.
+
+## Organization admin boundary (`organization_users`)
+
+See [`../CONTEXT.md`](../CONTEXT.md) for what an org admin _is_. The boundaries:
+
+- **Owner-or-row.** The owner holds no `organization_users` row, exactly as a group's manager
+  holds no `group_users` row. Querying the table alone answers half the question — always go
+  through `isOrganizationAdmin`.
+- **Administration, never approval.** `assertGroupAdmin` / `validateUserGroupAccess` accept org
+  admins; `getGroupsWhereUserCanApprove` does not, and two routes actively defend the boundary:
+  `handleUpdateGroupUsers` refuses to let any caller raise their **own** permissions (checking
+  every record for them, not just the first — the array may repeat a user), and
+  `handlePutGroupApprovers` refuses a caller acting `viaOrgAdmin` who names themselves. Without
+  both, a delegate could invite themselves in and self-promote to approver.
+
+  **One deliberate carve-out — records on behalf of members.** Managing a member's booking is
+  administration, so org admins (like group admins) may create a booking for a member via
+  `POST /create-vacation` with `userId` — including `autoApprove`, which stamps them as
+  `approvedBy` — edit its per-day fields via `PATCH /api/vacation`, and cancel it
+  (`resolveVacationPermissions` / `handleBulkCancelVacation` resolve admin standing through
+  `resolveGroupAdmin`). Every such write is attributed (`createdByUserId` / `deletedByUserId`,
+  CREATED/APPROVED/UPDATED/CANCELLED timeline events). The boundary itself stands: deciding a
+  **member-submitted** request stays approver-only (`getGroupsWhereUserCanApprove` still excludes
+  org admins, `autoApprove` is refused for self-bookings), and both defenses above remain.
+
+- **Scoped to one organization.** `getAdministrableGroupIds` takes an `organizationId`; mirroring
+  passes it, or someone who owns org A and is a delegate in org B could project B's leave into A.
+- **The grant is scoped to membership.** `handleDeleteGroupUser` revokes it when the user leaves
+  the organization's last group, under a `lockOrganization` — the count spans the org, so a group
+  lock alone lets two concurrent removals each see the other's membership as live.
+- **Billing stays owner-only.** `billingEmail`, granting and revoking admins all go through
+  `assertOrganizationOwner`, and `/api/billing/*` resolves the org by ownership.
+- **Delegates are picked from the organization's own people.** `listOrganizationAdminCandidates`
+  is deliberately not a lookup by email, which would let an owner probe whether an address has an
+  account.
+
+## Billing config is opt-in (`src/config.ts`)
+
+With `PADDLE_API_KEY` unset, `config.paddle` is `undefined` and `/api/billing/*` returns 503. Once
+it is set, every other Paddle variable is required and startup throws without them.
+`PADDLE_ENV=sandbox` combined with `NODE_ENV=production` also throws, so sandbox credentials cannot
+reach production. Secrets are provisioned via Secrets Manager in `terraform/secrets.tf`; price ids
+are public identifiers and ride as plain env vars.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -66,10 +66,12 @@ read-only) to debug customer reports.
    and take their scope as explicit ids. Keep support carve-outs out of `assertGroupAdmin` /
    `validateUserGroupAccess` / `isOrganizationAdmin` — one there would silently turn every route,
    including writes, into a superuser route.
-3. **`requireSupportAdmin` 404s non-allowlisted callers** (not 403 — the surface should be
-   invisible to probers) and **403s an allowlisted account without 2FA enabled**. It reads
-   `req.auth` directly rather than importing `authSession.js`, keeping better-auth out of its
-   import graph.
+3. **`requireSupportAdmin` answers three ways.** 401 when `req.auth` is absent, **404 for an
+   authenticated caller not in `config.support.userIds`** (not 403 — the surface should be
+   invisible to probers), and **403 for an allowlisted account without 2FA enabled**. The 2FA
+   check is on the account, not the session, so a password alone never opens this surface. It
+   reads `req.auth` directly rather than importing `authSession.js`, keeping better-auth out of
+   its import graph.
 4. **Every request is audited.** The guard writes a `support_access` row (user, method,
    path+query) before the handler runs. Write-only, like `report_exports`.
 5. **The frontend learns about the role from the session.** The `customSession` plugin in

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,7 @@ export default [
   {
     ignores: [
       "dist/**",
+      ".claude/**",
       "node_modules/**",
       "coverage/**",
       "build/**",

--- a/src/controllers/groupUser/tests/handlePostGroupInvite.test.ts
+++ b/src/controllers/groupUser/tests/handlePostGroupInvite.test.ts
@@ -63,9 +63,8 @@ vi.mock("../../../services/DBServices.js", () => ({
 }));
 
 vi.mock("../../../services/groupUser/inviteNotifier.js", async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import("../../../services/groupUser/inviteNotifier.js")
-  >();
+  const actual =
+    await importOriginal<typeof import("../../../services/groupUser/inviteNotifier.js")>();
   return { ...actual, notifyGroupInvited: mockNotifyGroupInvited };
 });
 

--- a/src/db/schema/auth-schema.ts
+++ b/src/db/schema/auth-schema.ts
@@ -1,4 +1,12 @@
-import { pgTable, text, timestamp, boolean, integer, index, uniqueIndex } from "drizzle-orm/pg-core";
+import {
+  pgTable,
+  text,
+  timestamp,
+  boolean,
+  integer,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
 
 export const user = pgTable("user", {
   id: text("id").primaryKey(),

--- a/src/services/vacation/quotaGuard.ts
+++ b/src/services/vacation/quotaGuard.ts
@@ -58,8 +58,8 @@ const allocationFor = async (check: QuotaCheck, tx: DbTransaction): Promise<numb
 
   const group = await services.group.getGroup(check.groupId, tx);
   return check.leaveType === vacationType.Vacation
-    ? group?.defaultVacationDays ?? 0
-    : group?.defaultHomeOfficeDays ?? 0;
+    ? (group?.defaultVacationDays ?? 0)
+    : (group?.defaultHomeOfficeDays ?? 0);
 };
 
 /**

--- a/src/tests/e2e/billing.e2e.test.ts
+++ b/src/tests/e2e/billing.e2e.test.ts
@@ -185,9 +185,8 @@ describe("billing limits", () => {
   });
 
   it("grants a member no organization until they create a group", async () => {
-    const { getOrganizationForOwner } = await import(
-      "../../services/organization/organizationServices.js"
-    );
+    const { getOrganizationForOwner } =
+      await import("../../services/organization/organizationServices.js");
     expect(await getOrganizationForOwner(member.id)).toBeUndefined();
   });
 });

--- a/src/tests/e2e/twoFactor.e2e.test.ts
+++ b/src/tests/e2e/twoFactor.e2e.test.ts
@@ -51,8 +51,7 @@ describe("two-factor authentication", () => {
     return code;
   };
 
-  const signIn = () =>
-    request(app).post("/api/auth/sign-in/email").send({ email, password });
+  const signIn = () => request(app).post("/api/auth/sign-in/email").send({ email, password });
 
   beforeAll(async () => {
     await cleanupTestData();

--- a/src/tests/middleware/supportGuard.test.ts
+++ b/src/tests/middleware/supportGuard.test.ts
@@ -51,7 +51,7 @@ const makeReq = (userId: string): Request =>
     baseUrl: "/api/support",
     path: "/organizations",
     originalUrl: "/api/support/organizations?query=jane%40acme.com",
-  } as unknown as Request);
+  }) as unknown as Request;
 
 const run = async (req: Request) => {
   const next = vi.fn() as unknown as NextFunction & { mock: { calls: unknown[][] } };


### PR DESCRIPTION
Started as a docs restructure and grew to cover the CI gaps it exposed.

## 1. CLAUDE.md was gitignored and 435 lines long

So it shipped to nobody, and most of it was reference that only some tasks need. Split three ways:

| File | Lines | Holds |
|---|---|---|
| `CLAUDE.md` | 69 | what every backend task needs |
| `docs/invariants.md` | 164 | security and permission boundaries |
| `CONTEXT.md` | 103 | the domain model |

`CLAUDE.md` now carries two pointers, so the reference loads when a task reaches for it rather than on every backend turn. Context cost of a backend session drops from ~6.2k tokens to ~1.2k.

`docs/invariants.md` collects auth and account linking, the `/api/dev/*` gate, the `/api/support/*` design rules, the rate limiter table, the org-admin boundary and the Paddle config rules. Four of those blocks each opened by spelling out a variant of "must not be undone" — one word now covers all of them, which also gives the pointer something concrete to trigger on.

`CONTEXT.md` fills the slot `docs/agents/domain.md` already reserved for it.

### Stale claims removed

Each verified against the code first:

- "Routes (currently only vacation routes)" — there are 14 routers.
- The schema listing named 13 files; `src/db/schema/` has 20.
- The DBServices listing named 5 domains; `createDBServices()` returns 17.

The command list, directory listing and middleware-order list are gone — `package.json`, `ls` and `server.ts` answer those and can't drift.

## 2. eslint was never running in CI

`npm run lint` and `eslint.config.js` both existed; no workflow called them. `format:check` likewise. That's how **7 files drifted out of prettier format** and stayed that way.

Adds a `Lint & Format` job running alongside `Tests` rather than before it — it needs no Postgres service, so it reports a formatting slip in under a minute instead of after migrations and e2e.

Lint currently reports **4 warnings, 0 errors**, so the job passes as-is. Tighten to `--max-warnings 0` separately if you want warnings to block.

The formatting sweep is its own commit so this one stays reviewable.

`eslint.config.js` also now ignores `.claude/**`: agent worktrees live there, so a local `npm run lint` was linting a second copy of the whole source tree and double-reporting every finding.

## 3. Claude config is committed

`.gitignore` no longer hides `/CLAUDE.md`. It now ignores only `.claude/settings.local.json` and `.claude/worktrees/`, so shared config is tracked while machine-local permission grants stay out. `.claude/settings.json` carries the workspace's context-trimming settings plus a prettier-on-edit hook, which the workspace hook couldn't provide to an agent started from inside this repo.

## Verification

Ran the CI equivalent locally before pushing: 558 unit tests, lint, format and build all pass. E2E left to CI, which needs the Postgres service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuzS978Dy1KYpFX6BqAh84