### PR TITLE
chore: keep vitest out of .claude/worktrees

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,11 +5,12 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.test.ts"],
-    exclude: ["src/**/*.e2e.test.ts", "**/node_modules/**", "**/dist/**"],
+    // .claude/worktrees holds full checkouts of this repo; their tests are not ours to run.
+    exclude: ["src/**/*.e2e.test.ts", "**/node_modules/**", "**/dist/**", "**/.claude/**"],
     coverage: {
       provider: "istanbul",
       reporter: ["text", "json", "html"],
-      exclude: ["**/node_modules/**", "**/dist/**", "**/coverage/**", "**/*.config.*"],
+      exclude: ["**/node_modules/**", "**/dist/**", "**/coverage/**", "**/*.config.*", "**/.claude/**"],
     },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,13 @@ export default defineConfig({
     coverage: {
       provider: "istanbul",
       reporter: ["text", "json", "html"],
-      exclude: ["**/node_modules/**", "**/dist/**", "**/coverage/**", "**/*.config.*", "**/.claude/**"],
+      exclude: [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/coverage/**",
+        "**/*.config.*",
+        "**/.claude/**",
+      ],
     },
   },
 });

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.e2e.test.ts"],
+    // .claude/worktrees holds full checkouts of this repo; their tests are not ours to run.
+    exclude: ["**/node_modules/**", "**/dist/**", "**/.claude/**"],
     // Every e2e file talks to the same database and truncates shared tables on
     // teardown, so running two files at once lets one wipe the other's rows.
     fileParallelism: false,


### PR DESCRIPTION
## What

Adds `**/.claude/**` to the excludes in `vitest.config.ts` and `vitest.e2e.config.ts`, so neither suite reaches into the agent worktree checkouts under `.claude/worktrees`.

Both configs were already safe by accident: `include` is root-relative, so `src/**/*.test.ts` never matched `.claude/worktrees/*/src`. Making the exclude explicit means the guard survives someone widening `include`. The e2e config had no `exclude` at all and now has one.

Companion to Daniel88dev/flexi-day#74, which fixes the real leak on the frontend.

## Verification

- `npx vitest list --run | grep -c '.claude'` → 0, for both configs
- `npm test` → 60 files, 558 tests, all passing
- e2e not run; it needs a live database