### PR TITLE
docs: tell agents where issues, triage labels and domain docs live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,3 +110,20 @@ and response schemas, auth requirements, error codes, parameter validation. Foll
 `src/config.ts` parses and validates every environment variable, and throws at startup when one is
 missing or invalid. Read it rather than a list here. Three blocks are opt-in and stay that way:
 `DEV_TOOLS_*`, `SUPPORT_ADMIN_USER_IDS`, and `PADDLE_*` — see [`docs/invariants.md`](docs/invariants.md).
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in this repo's GitHub Issues, reached with the `gh` CLI. See
+[`docs/agents/issue-tracker.md`](docs/agents/issue-tracker.md).
+
+### Triage labels
+
+The five canonical triage roles, each label string equal to its name. See
+[`docs/agents/triage-labels.md`](docs/agents/triage-labels.md).
+
+### Domain docs
+
+Single-context: `CONTEXT.md` and `docs/adr/` at the repo root. See
+[`docs/agents/domain.md`](docs/agents/domain.md).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,47 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the
+codebase.
+
+**Layout: single-context.** One `CONTEXT.md` and one `docs/adr/`, both at the repo root.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the glossary and boundaries for this repo.
+- **`docs/adr/`** — the ADRs touching the area you are about to work in.
+
+If either doesn't exist, **proceed silently**. Don't flag its absence; don't suggest creating it
+upfront. The `/domain-modeling` skill creates them lazily when terms or decisions actually get
+resolved.
+
+## File structure
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-....md
+│   └── 0002-....md
+└── src/
+```
+
+This repo ships independently, so everything scoped to it stays inside it. When you are working
+from the `flexi-day-workspace` checkout rather than a bare clone, decisions that span repos —
+API contracts, SES template naming, auth topology — live in the workspace root's `docs/adr/`
+instead, and the root `CONTEXT-MAP.md` points at each repo's `CONTEXT.md`.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a
+test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary
+explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing
+language the project doesn't use (reconsider) or there's a real gap (note it for
+`/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -16,7 +16,7 @@ resolved.
 
 ## File structure
 
-```
+```text
 /
 ├── CONTEXT.md
 ├── docs/adr/

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -5,7 +5,9 @@ Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all o
 ## Conventions
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **Read an issue**: `gh issue view <number> --comments` to read it yourself. To feed it to a
+  filter, `gh issue view <number> --json title,body,labels,comments --jq '{title, body, labels: [.labels[].name], comments: [.comments[].body]}'`
+  — `--comments` renders text, so `--jq` needs `--json` to have anything to match against.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
@@ -20,7 +22,12 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
 
 - **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
-- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **List external PRs for triage**: `gh pr list --json` has no `authorAssociation` field and fails
+  with `Unknown JSON field`. Get the association from search instead —
+  `gh search prs --repo <owner>/<repo> --state open --json number,author,authorAssociation` — keep
+  only `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR` or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`),
+  then pull the bodies for the survivors with
+  `gh pr view <number> --json number,title,body,labels,author,comments`.
 - **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
 
 GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
@@ -40,6 +47,13 @@ Used by `/wayfinder`. The **map** is a single issue with **child** issues as tic
 - **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
 - **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
 - **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
-- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Frontier query**: list the map's open children with
+  `gh issue list --state open --limit 200 --json number,assignees,blockedBy`, scoped to the map's
+  sub-issues / task list. Pass `--limit` explicitly — the default is 30, so a map with more
+  children silently loses its tail. Drop any child with an assignee or an open blocker
+  (`blockedBy` non-empty, or an open issue in the `Blocked by` line). `gh issue list` returns
+  results by recency, not map order, so **re-sort the survivors into the map's child order**
+  before picking; first in map order wins. The REST spelling of the same data is
+  `issue_dependencies_summary.blocked_by`, reachable only through `gh api` — `--json` rejects it.
 - **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
 - **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -12,4 +12,19 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
+## Provisioning the labels
+
+Only `wontfix` exists on this repo today — it ships with GitHub's default set. The other four do
+not, and `gh issue edit --add-label` fails on a label that isn't there rather than creating it.
+
+Before applying one for the first time, check and create it:
+
+```bash
+gh label list --json name --jq '.[].name' | grep -qx '<label>' \
+  || gh label create '<label>' --description '<meaning from the table above>'
+```
+
+If creation fails — most often no write access on a fork — say so and leave the issue unlabelled.
+Never invent a near-miss name to work around it; a label nobody queries for is worse than none.
+
 Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Adds `docs/agents/` and an `## Agent skills` section to `CLAUDE.md`, so the engineering skills work from a bare clone of this repo rather than only from the `flexi-day-workspace` checkout.

- **`docs/agents/issue-tracker.md`** — GitHub Issues via the `gh` CLI, repo inferred from the remote. PRs-as-a-request-surface is off. Read by `to-tickets`, `to-spec`, `triage`, `wayfinder`.
- **`docs/agents/triage-labels.md`** — the five canonical triage roles, each label string equal to its name. Of these only `wontfix` exists on the repo today; `/triage` creates the rest on first use.
- **`docs/agents/domain.md`** — single-context layout (`CONTEXT.md` + `docs/adr/` at the root), with a note that cross-repo ADRs live at the workspace root when working from that checkout.

Docs only — no code, no CI, no behaviour change. Prettier reports every new file clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrPmNbE8YbGdaZp4A58gSn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using the GitHub issue tracker, including issue workflows and triage labels.
  * Documented repository domain structure, required reference materials, glossary usage, and ADR boundaries.
  * Added definitions and application guidance for five canonical triage roles.
  * Documented Wayfinder map and child-ticket conventions, including dependencies, ownership, and resolution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->