### PR TITLE
feat(auth): upgrade better-auth to 1.7 and re-key the account table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,15 +77,22 @@ migration, apply it locally, confirm the app still works, then give the user the
 stop. The prod target refuses to start unless stdin is a terminal, so an agent shell cannot put DDL
 on the live database even by accident, and `--yes` does not get around it.
 
-| Command                    | Target                                      | Who runs it             |
-| -------------------------- | ------------------------------------------- | ----------------------- |
-| `npm run db:migrate:local` | the `DATABASE` in `.env`                    | anyone                  |
-| `npm run db:status:prod`   | prints the applied ledger, writes nothing   | anyone                  |
-| `npm run db:migrate:prod`  | RDS, connection string from Secrets Manager | the user, at a terminal |
+| Command                    | Target                                         | Who runs it             |
+| -------------------------- | ---------------------------------------------- | ----------------------- |
+| `npm run db:migrate:local` | the `DATABASE` in `.env`                       | anyone                  |
+| `npm run db:status:prod`   | prints the applied ledger, writes nothing      | anyone                  |
+| `npm run db:baseline:prod` | records a squashed baseline as applied, no DDL | the user, at a terminal |
+| `npm run db:migrate:prod`  | RDS, connection string from Secrets Manager    | the user, at a terminal |
 
 The prod target pins the RDS CA bundle and connects with `sslmode=verify-full`. The connection
 string is never printed and never passed as a command-line argument, where `ps` would hand it to
 every other local user; psql gets the parts through libpq's `PG*` variables.
+
+`--baseline` is for the other kind of ledger drift: a squashed history, where the database ran the
+original migrations and `0000_init` has since been rewritten to stand for all of them. Drizzle
+compares only the newest ledger row, so it would replay the baseline over a live schema and fail on
+the first `CREATE TYPE ... already exists`. `--baseline` records it as applied instead. It refuses
+on a database with no `account` table, where the baseline is a real migration that has to run.
 
 `--reset` drops the schema, the data and the ledger, then migrates from scratch. On prod it demands
 the typed phrase even with `--yes`, because unattended is never the right way to drop a production

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,11 @@ records. Notifications go out after the commit, never inside it.
 
 ## Migrations
 
+**In progress:** [`docs/better-auth-1.7-migration.md`](docs/better-auth-1.7-migration.md) — the 1.7
+upgrade re-keys the `account` table and needs a maintenance window with a specific deploy order
+(App Runner will not pick up the new image on resume by itself). Read it before deploying or
+migrating anything auth-related, and delete it once production is on 1.7.
+
 `npm run db:generate` writes a new file into `src/db/schema/out/`. `scripts/db-migrate.sh` applies
 it, and its header documents every flag.
 

--- a/docs/better-auth-1.7-migration.md
+++ b/docs/better-auth-1.7-migration.md
@@ -1,0 +1,172 @@
+# better-auth 1.7 migration runbook
+
+One-off. Delete this file once production is on 1.7.
+
+better-auth 1.7 stops keying an account by `providerId` and keys it by
+`(issuer, accountId)` instead. That adds a `NOT NULL` column to a table the auth
+code reads on every sign-in, which is why this upgrade needs a window rather
+than an ordinary deploy. Upstream guide:
+<https://better-auth.com/docs/guides/1-7-upgrade-guide>.
+
+## Why a window is unavoidable
+
+CD promotes the moving tag on every push to `main` and App Runner pulls it
+automatically, while `db:migrate:prod` is run by hand from a terminal. Neither
+order is safe on its own:
+
+- **Code first.** The drizzle adapter selects an explicit column list that now
+  contains `issuer`. Against an un-migrated database every account read is
+  `column account.issuer does not exist` — email sign-in, the social callback,
+  list-accounts and password reset all 500.
+- **Migration first.** The still-running 1.6 image writes account rows without
+  `issuer`, so every sign-up and every `/link-social` fails on a not-null
+  violation.
+
+Sessions already issued keep working throughout — `customSession` does not read
+the account table. What is down is the entry surface: signing in, signing up,
+linking, and password reset.
+
+**This deploy is one-way.** Once `issuer` is `NOT NULL`, rolling the image back
+to 1.6 breaks every account write, because 1.6 does not know to populate it. The
+snapshot from step 3 is the only rollback.
+
+## Sequence
+
+App Runner is the trap here. `terraform/apprunner.tf` sets `min_size = 1` and the
+service floor is one instance, so there is no scaling to zero; and while
+`auto_deployments_enabled = true`, **a paused service does not pick up images
+pushed while it was paused** — resuming redeploys the version from before the
+pause. CD only pushes to ECR (`.github/workflows/cd.yml` has no
+`start-deployment`), so the 1.7 image needs an explicit push after resuming.
+Follow the order below exactly.
+
+1. Announce the window. Ten minutes; the table is small but step 4 is manual.
+2. Get a psql on prod. `db:status:prod` only prints the ledger and
+   `scripts/db-migrate.sh` never prints the connection string, so assemble it
+   from Secrets Manager yourself — RDS is `publicly_accessible` — and export
+   `PGHOST/PGUSER/PGPASSWORD/PGDATABASE` rather than passing a URL that `ps`
+   would leak.
+3. Run the pre-flight in the next section. Fix what it reports **before**
+   pausing anything; every one of its failures aborts the migration.
+4. `aws apprunner pause-service`. Take an RDS snapshot once it is paused — step
+   6 rewrites keys and deletes rows, and this snapshot is the only rollback.
+5. Merge the backend PR so CD builds and pushes the 1.7 image to ECR. It will
+   not deploy while paused; that is expected.
+6. `npm run db:migrate:prod`.
+7. `aws apprunner resume-service`, then **`aws apprunner start-deployment`** —
+   resume alone brings back 1.6, which would fail every account write against
+   the new `NOT NULL` column.
+8. Verify before reopening: `/health`, one real email sign-in, and one
+   `list-accounts` on an account that had a Google link.
+9. Merge the frontend PR. It only speaks the 1.7 shapes, so it goes after the
+   backend is confirmed, never before.
+10. Send the emails from the next section, then drop
+    `account_issuer_migration_dropped`.
+
+## Pre-flight
+
+Read-only, run before the window. Each query maps to a way the migration aborts
+or loses data.
+
+```sql
+-- 1. Every provider needs a rule. Anything outside credential/google/microsoft
+--    stops the migration at "no mapping for provider_id".
+SELECT provider_id, count(*) FROM account GROUP BY provider_id;
+
+-- 2. Duplicates on the POST-backfill key, which is what guard 2 checks. Two
+--    Microsoft rows with different `sub` can share an `oid`, and two credential
+--    rows for one user collapse onto the same key once account_id is realigned,
+--    so grouping on the current (provider_id, account_id) would miss both.
+--    This mirrors the migration's own decode, including its error handling, so
+--    the two cannot disagree. Prints nothing when there is nothing to fix.
+DO $$
+DECLARE r record; payload jsonb; segment text; k_iss text; k_acc text; found int := 0;
+BEGIN
+  CREATE TEMP TABLE preflight_keys (dup_issuer text, dup_account_id text) ON COMMIT DROP;
+  FOR r IN SELECT provider_id, account_id, user_id, id_token FROM account LOOP
+    IF r.provider_id = 'credential' THEN
+      k_iss := 'local:credential'; k_acc := r.user_id;
+    ELSIF r.provider_id = 'google' THEN
+      k_iss := 'https://accounts.google.com'; k_acc := r.account_id;
+    ELSE
+      payload := NULL;
+      segment := translate(split_part(coalesce(r.id_token, ''), '.', 2), '-_', '+/');
+      IF length(segment) > 0 THEN
+        BEGIN
+          payload := convert_from(
+            decode(rpad(segment, (length(segment) + 3) / 4 * 4, '='), 'base64'), 'UTF8')::jsonb;
+        EXCEPTION WHEN others THEN payload := NULL;
+        END;
+      END IF;
+      k_iss := payload ->> 'iss'; k_acc := payload ->> 'oid';
+    END IF;
+    IF k_iss IS NOT NULL AND k_acc IS NOT NULL THEN
+      INSERT INTO preflight_keys VALUES (k_iss, k_acc);
+    END IF;
+  END LOOP;
+
+  FOR r IN SELECT dup_issuer, dup_account_id, count(*) AS n FROM preflight_keys
+           GROUP BY 1, 2 HAVING count(*) > 1 LOOP
+    found := found + 1;
+    RAISE NOTICE 'DUPLICATE KEY: % / % appears % times', r.dup_issuer, r.dup_account_id, r.n;
+  END LOOP;
+  IF found = 0 THEN RAISE NOTICE 'no duplicate keys - guard 2 will pass'; END IF;
+END $$;
+
+-- 3. Credential rows the migration will realign. Informational, but a non-zero
+--    count means query 2 above is the one that matters.
+SELECT count(*) FROM account WHERE provider_id = 'credential' AND account_id <> user_id;
+```
+
+Resolve any row query 2 returns by hand before the window. Add an `UPDATE` to
+`0001_account_issuer.sql` for any provider query 1 turns up — do not improvise
+in psql during the outage.
+
+## What the backfill does to each provider
+
+| `provider_id` | `issuer`                      | `account_id`                | outcome                       |
+| ------------- | ----------------------------- | --------------------------- | ----------------------------- |
+| `credential`  | `local:credential`            | realigned to the user id    | preserved                     |
+| `google`      | `https://accounts.google.com` | unchanged — still `sub`     | preserved                     |
+| `microsoft`   | `iss` claim from `id_token`   | `oid` claim from `id_token` | preserved, re-keyed           |
+| `microsoft`   | — (no decodable `id_token`)   | —                           | **row deleted**, must re-link |
+
+Microsoft moves both halves of its key: 1.6 stored `account_id` as the pairwise
+`sub`, and 1.7 looks the account up by the directory `oid` under the tenant's own
+`iss`. Both claims are in the `id_token` better-auth already stored verbatim —
+only access and refresh tokens are passed through `setTokenUtil`, and this app
+sets no `advanced.encryptOAuthTokens` — and 1.6's Microsoft provider refused to
+create an account without one, so in practice every row can be re-keyed.
+
+A row whose token is missing or undecodable has no recoverable key, and is
+deleted rather than left behind: a stale row strands the user on
+`account not linked`, because the lookup misses and `disableImplicitLinking`
+refuses the implicit re-link at sign-in. Deleting makes the settings card say
+"Not connected", which is true.
+
+**Recovery for anyone in that last row is password reset, not re-linking.**
+Re-linking goes through `/link-social`, which needs a session they cannot get.
+Password reset works even for a user who never had a password: the request does
+not require a credential account, and completing it creates one. Tell affected
+users that, and do not tell them to "just reconnect".
+
+The migration writes every dropped link to `account_issuer_migration_dropped`
+before deleting it, so the list is exact and survives the window — a
+`RAISE NOTICE` would not, since `drizzle-kit migrate` installs no notice
+listener on the pg client. After step 8:
+
+```sql
+SELECT email, legacy_account_id, reason FROM account_issuer_migration_dropped
+ORDER BY email;
+```
+
+`reason` distinguishes the three cases the migration cannot recover from: no
+`id_token` stored, a payload that did not decode, and a payload without `iss`
+or `oid`. Drop the table once the emails are out.
+
+## Afterwards
+
+`src/tests/db/accountIssuer.test.ts` pins both halves of every provider's key —
+the issuer literals in the SQL and the subject claim each provider resolves — to
+better-auth's own declarations, so a later upgrade that changes either one fails
+a test instead of quietly stranding accounts.

--- a/docs/better-auth-1.7-migration.md
+++ b/docs/better-auth-1.7-migration.md
@@ -52,7 +52,13 @@ Follow the order below exactly.
    6 rewrites keys and deletes rows, and this snapshot is the only rollback.
 5. Merge the backend PR so CD builds and pushes the 1.7 image to ECR. It will
    not deploy while paused; that is expected.
-6. `npm run db:migrate:prod`.
+6. `npm run db:status:prod`. If the ledger still holds the pre-squash entries —
+   ten rows ending 2026-06-14 rather than one row for `0000_init` — run
+   `npm run db:baseline:prod` first. The squash rewrote `0000_init` into a
+   baseline standing for all ten, and drizzle only compares the newest ledger
+   row, so it would otherwise replay the whole baseline over the live schema and
+   die on `CREATE TYPE ... already exists`. `--baseline` records the baseline as
+   applied; it writes no DDL and touches no data. Then `npm run db:migrate:prod`.
 7. `aws apprunner resume-service`, then **`aws apprunner start-deployment`** —
    resume alone brings back 1.6, which would fail every account write against
    the new `NOT NULL` column.
@@ -76,6 +82,12 @@ Read-only, run before the window. Each query maps to a way the migration aborts
 or loses data.
 
 ```sql
+-- 0. The ledger. One row for 0000_init means it is reconciled; the pre-squash
+--    entries mean `npm run db:baseline:prod` is needed before step 6.
+--    (`npm run db:status:prod` prints this.)
+SELECT id, left(hash, 12), to_timestamp(created_at / 1000) FROM drizzle.__drizzle_migrations
+ORDER BY created_at;
+
 -- 1. Every provider needs a rule. Anything outside credential/google/microsoft
 --    stops the migration at "no mapping for provider_id".
 SELECT provider_id, count(*) FROM account GROUP BY provider_id;

--- a/docs/better-auth-1.7-migration.md
+++ b/docs/better-auth-1.7-migration.md
@@ -56,8 +56,15 @@ Follow the order below exactly.
 7. `aws apprunner resume-service`, then **`aws apprunner start-deployment`** —
    resume alone brings back 1.6, which would fail every account write against
    the new `NOT NULL` column.
-8. Verify before reopening: `/health`, one real email sign-in, and one
-   `list-accounts` on an account that had a Google link.
+8. Verify before reopening: `/health`, one real email sign-in, one
+   `list-accounts` on an account that had a Google link, and — this is the one
+   that proves the re-key — a returning **Microsoft** sign-in on an account the
+   migration re-keyed. Google and credential rows only gained a column; the
+   Microsoft rows had both halves of their key rewritten, so they are the only
+   ones where a wrong value shows up as `account not linked` rather than as
+   nothing at all. Pick an address from
+   `SELECT u.email FROM account a JOIN "user" u ON u.id = a.user_id
+WHERE a.provider_id = 'microsoft'` before step 4.
 9. Merge the frontend PR. It only speaks the 1.7 shapes, so it goes after the
    backend is confirmed, never before.
 10. Send the emails from the next section, then drop
@@ -160,9 +167,18 @@ SELECT email, legacy_account_id, reason FROM account_issuer_migration_dropped
 ORDER BY email;
 ```
 
-`reason` distinguishes the three cases the migration cannot recover from: no
-`id_token` stored, a payload that did not decode, and a payload without `iss`
-or `oid`. Drop the table once the emails are out.
+`reason` distinguishes the four cases the migration cannot recover from: no
+`id_token` stored, a payload that did not decode, a payload without `iss` or
+`oid`, and claims that are not shaped like Entra's (the migration will not key
+an account on an issuer that is not `https://<host>/<tenant guid>/v2.0` or an
+`oid` that is not a GUID, since that column is mutable and the value becomes
+half of an identity). Drop the table once the emails are out.
+
+If that list is ever long enough that mass password resets are not acceptable,
+the upstream guide's alternative is to source the missing `oid` values from a
+trusted Microsoft Entra directory export and load them before step 6, instead of
+letting the migration delete those rows. Nothing here needed that, but the
+option is real and this is where it would go.
 
 ## Afterwards
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,6 +30,19 @@ export default [
   // 3) TypeScript rules with type-aware linting
   ...tseslint.configs.recommendedTypeChecked,
 
+  // 3b) Plain JS/MJS is not in the tsconfig project, so the type-aware rules
+  // cannot run on it and throw rather than skip. Standalone scripts still get
+  // the base JS rules.
+  {
+    files: ["**/*.js", "**/*.mjs", "**/*.cjs"],
+    ...tseslint.configs.disableTypeChecked,
+    languageOptions: {
+      ...tseslint.configs.disableTypeChecked.languageOptions,
+      sourceType: "module",
+      globals: { ...globals.node },
+    },
+  },
+
   // 4) Project-specific config
   {
     files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@paddle/paddle-node-sdk": "^3.10.0",
         "@sentry/node": "^10.70.0",
         "@sentry/profiling-node": "^10.70.0",
-        "better-auth": "^1.6.29",
+        "better-auth": "^1.7.1",
         "cors": "^2.8.5",
         "croner": "^10.0.1",
         "date-holidays": "^3.35.0",
@@ -634,12 +634,12 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.29.tgz",
-      "integrity": "sha512-hkUxePo548G0Y247had36TcfsH7E+cofcTc2UivMAbjkdLPKn1ZUk6Pjkc/kvk9xTbWYCUDX6JA9emJc0Gnufg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-eZ9lqcnVLMZ3QtUByRo4VZqkB1ESyRddd9NfWjBdDPgh+jcwLScoIUAqhtHLR8zaSUJZah8OLGlkzObyPdUH7A==",
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@opentelemetry/semantic-conventions": "^1.41.1",
         "@standard-schema/spec": "^1.1.0",
         "zod": "^4.3.6"
       },
@@ -663,14 +663,14 @@
       }
     },
     "node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.29.tgz",
-      "integrity": "sha512-IdvrqHnnRNKqz6KOSII3rZNiTzv1pmVmx5xGRGZdVm8W3OYi98an5kIovao/b3GZh2nHGTzdeTfMSSZNCyGXBg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.7.1.tgz",
+      "integrity": "sha512-qlqNyg5V9bXHSP68/vtlsiZayhR4hgvEGiS/E3SIj8bCpWWFGmyQkxJbQCqpBmC7vT30wE/kNtJMHIgnV3rkiw==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.29",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
-        "drizzle-orm": "^0.45.2"
+        "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0"
       },
       "peerDependenciesMeta": {
         "drizzle-orm": {
@@ -679,12 +679,12 @@
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.29.tgz",
-      "integrity": "sha512-n87hHC/miSaUaKdnQygz+2wlj2KI2rsGazDPaKF0wbH8i87um9HPDWyz3VdbkqPN79e0qbVfMR9pY7GZQm/X8w==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.7.1.tgz",
+      "integrity": "sha512-yWCpE1cZpMUj37nD6JFDK+GDR8zS37L5WI73il3qbU9TXtWsxUQKc/5c3IHsHizWQsmcQI8uv2pAFKxsRDa+AQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.29",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "kysely": "^0.28.17 || ^0.29.0"
       },
@@ -695,22 +695,22 @@
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.29.tgz",
-      "integrity": "sha512-F1yLUbNTc/pikEaTlgWOgYlT2RDSi2dV1ysWxacRmQhYtLGYAun1JgU7TDdcEjts+wrLcm+JzRzt5F+ZgNfz9A==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.7.1.tgz",
+      "integrity": "sha512-6NX1yv88DeqdoG7owYFqKwlrDGaIPhsC52JUGrUgeGVKyOq8a/6hHlHsqG1C2FwT23SHQiKVYCEAG9N6aH5OvQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.29",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.29.tgz",
-      "integrity": "sha512-gyOpfBBCpe2wDnv9CY2T0jirC4oTqk3i5svWYBGkGTAFrKsfJA516NMOs001PiHsEDf/JttZapQv5dkoPD0x2w==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.7.1.tgz",
+      "integrity": "sha512-9ILTcNqhG37QK//qR4UhYLyKzNqq6w6zVTf5KX6xkiTjNcV7Oh1yS31lkIJEVTqRNcy9AoV6FZMW6Bbsm8IMDA==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.29",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "mongodb": "^6.0.0 || ^7.0.0"
       },
@@ -721,12 +721,12 @@
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.29.tgz",
-      "integrity": "sha512-W5lr8AYXwa68qhS7PEpEsisF7ASs9rWJyczoZr8+vYypPBmGMq1Yf8bYJ9ig95zj1wdaQGim2ZSYs8hxZeaKVQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.7.1.tgz",
+      "integrity": "sha512-ZiUcafQ85InAofcUjyGgCPjKLfQjXr9SvDmMjuFUW8oEbreA6C6GaFAEA77VuV2doZUQlzvQQ4gCoTmS28W92A==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.29",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
@@ -741,12 +741,12 @@
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.29.tgz",
-      "integrity": "sha512-zW1GRIBR/sn83siG+xK4ll/gzfTRxVh6rcpzzjYkR2W9/DkDMwEotl/Mz8OW0Gr2KpuhEkfwiVGH9zp/cyK4Pg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.7.1.tgz",
+      "integrity": "sha512-kLKjMfFlTbyt49DGeI9okHAsn0MtBZcMoQYKaEdgR0H3BHzqqyzePcQz/hxAmRgjB4p/6inise3zJwhX0sgXrQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.29",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1"
       }
@@ -3583,27 +3583,27 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.29.tgz",
-      "integrity": "sha512-7i2kOry+Jb1mRUR14kCDVS23GCKUGWxayZRXULbNz/6nFLPT6XSuGJVrwo/d+Qfq/iubA0/4Acw2/eg/tPCCnA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.7.1.tgz",
+      "integrity": "sha512-g8WlTQijxXWJjPVZfFu1+EJg9cwwHrKDmIkcYMzx8CzYA+tDxl6NI7qQbKkbgw5UtHILsT5VH+RMzFzwnVJqAg==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.6.29",
-        "@better-auth/drizzle-adapter": "1.6.29",
-        "@better-auth/kysely-adapter": "1.6.29",
-        "@better-auth/memory-adapter": "1.6.29",
-        "@better-auth/mongo-adapter": "1.6.29",
-        "@better-auth/prisma-adapter": "1.6.29",
-        "@better-auth/telemetry": "1.6.29",
+        "@better-auth/core": "1.7.1",
+        "@better-auth/drizzle-adapter": "1.7.1",
+        "@better-auth/kysely-adapter": "1.7.1",
+        "@better-auth/memory-adapter": "1.7.1",
+        "@better-auth/mongo-adapter": "1.7.1",
+        "@better-auth/prisma-adapter": "1.7.1",
+        "@better-auth/telemetry": "1.7.1",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1",
-        "@noble/ciphers": "^2.1.1",
-        "@noble/hashes": "^2.0.1",
+        "@noble/ciphers": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "better-call": "1.4.0",
         "defu": "^6.1.4",
-        "jose": "^6.1.3",
+        "jose": "^6.2.3",
         "kysely": "^0.28.17 || ^0.29.0",
-        "nanostores": "^1.1.1",
+        "nanostores": "^1.3.0",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -3613,8 +3613,8 @@
         "@tanstack/react-start": "^1.0.0",
         "@tanstack/solid-start": "^1.0.0",
         "better-sqlite3": "^12.0.0",
-        "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": "^0.45.2",
+        "drizzle-kit": ">=0.31.4 || >=1.0.0-beta.1",
+        "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0",
         "mongodb": "^6.0.0 || ^7.0.0",
         "mysql2": "^3.0.0",
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -5888,9 +5888,9 @@
       "license": "MIT"
     },
     "node_modules/jose": {
-      "version": "6.2.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
-      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -6724,9 +6724,9 @@
       }
     },
     "node_modules/nanostores": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.5.0.tgz",
-      "integrity": "sha512-E0SrU7uLV/k4E6YbBIpQNDnRj00vgE5wlutM1sYVSAXDtHQosiRCGS9eKMKyiGg4ChXfDiJmTB+NCR3yXr6UAw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.5.2.tgz",
+      "integrity": "sha512-B0UbxzK1s0CN8Xht6r+7iT5+xV8PTaRERR1nATeplRv1Rw5YLWfVAid0hkqY3EceqpG4RjTk8GAwIxQY39Rnwg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:migrate:local": "./scripts/db-migrate.sh local",
     "db:migrate:prod": "./scripts/db-migrate.sh prod",
+    "db:baseline:prod": "./scripts/db-migrate.sh prod --baseline",
     "db:status:prod": "./scripts/db-migrate.sh prod --status"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@paddle/paddle-node-sdk": "^3.10.0",
     "@sentry/node": "^10.70.0",
     "@sentry/profiling-node": "^10.70.0",
-    "better-auth": "^1.6.29",
+    "better-auth": "^1.7.1",
     "cors": "^2.8.5",
     "croner": "^10.0.1",
     "date-holidays": "^3.35.0",

--- a/scripts/db-migrate.sh
+++ b/scripts/db-migrate.sh
@@ -31,12 +31,14 @@ shift || true
 
 DO_RESET=0
 DO_STATUS=0
+DO_BASELINE=0
 ASSUME_YES=0
 
 for arg in "$@"; do
   case "$arg" in
     --reset) DO_RESET=1 ;;
     --status) DO_STATUS=1 ;;
+    --baseline) DO_BASELINE=1 ;;
     --yes | -y) ASSUME_YES=1 ;;
     *)
       echo "Unknown option: $arg" >&2
@@ -173,7 +175,7 @@ case "$TARGET" in
   local) DATABASE_URL="$(resolve_local_url)" ;;
   prod) DATABASE_URL="$(resolve_prod_url)" ;;
   *)
-    echo "usage: $0 <local|prod> [--status] [--reset] [--yes]" >&2
+    echo "usage: $0 <local|prod> [--status] [--baseline] [--reset] [--yes]" >&2
     exit 2
     ;;
 esac
@@ -203,6 +205,65 @@ if [[ "$TARGET" == "prod" && ! -t 0 && "${DB_MIGRATE_CI:-0}" != "1" ]]; then
   exit 3
 fi
 
+# Squashing the migration history rewrites 0000_init into a baseline that stands
+# for every migration before it. A database that already ran the originals still
+# has their ledger rows, and drizzle only compares the newest one — so it sees a
+# baseline newer than anything applied and replays it over a live schema, which
+# dies on the first `CREATE TYPE ... already exists`. This records the baseline
+# as applied instead of running it. It writes no DDL and touches no data.
+if [[ "$DO_BASELINE" == "1" ]]; then
+  need psql
+  need shasum
+  BASELINE_TAG="$(node -e "
+    const j = require('./src/db/schema/out/meta/_journal.json');
+    process.stdout.write(j.entries[0].tag);
+  ")"
+  BASELINE_MILLIS="$(node -e "
+    const j = require('./src/db/schema/out/meta/_journal.json');
+    process.stdout.write(String(j.entries[0].when));
+  ")"
+  BASELINE_FILE="src/db/schema/out/${BASELINE_TAG}.sql"
+  [[ -f "$BASELINE_FILE" ]] || die "no baseline file at $BASELINE_FILE"
+  # Same input drizzle hashes: the raw file, sha256, hex.
+  BASELINE_HASH="$(shasum -a 256 "$BASELINE_FILE" | cut -d' ' -f1)"
+
+  export_pg_env "$DATABASE_URL"
+
+  # Refuse on an empty database. There the baseline is a real migration that has
+  # to run, and marking it applied would leave a schema that never got created.
+  if ! psql -tAc "select to_regclass('public.account') is not null" | grep -q '^t$'; then
+    die "this database has no 'account' table, so the baseline has not been applied — run a normal migrate, not --baseline"
+  fi
+
+  echo
+  echo "Baseline: $BASELINE_TAG"
+  echo "  hash:   $BASELINE_HASH"
+  echo "  millis: $BASELINE_MILLIS"
+  psql -v ON_ERROR_STOP=1 -c "
+    select count(*) as ledger_rows_to_replace from drizzle.__drizzle_migrations
+     where created_at < ${BASELINE_MILLIS};"
+
+  confirm "This REPLACES the pre-baseline ledger rows above with one row for ${BASELINE_TAG}. No DDL, no data change." \
+    "baseline" 1
+
+  psql -v ON_ERROR_STOP=1 -1 <<SQL
+create schema if not exists drizzle;
+create table if not exists drizzle.__drizzle_migrations (
+  id serial primary key,
+  hash text not null,
+  created_at bigint
+);
+delete from drizzle.__drizzle_migrations where created_at < ${BASELINE_MILLIS};
+insert into drizzle.__drizzle_migrations (hash, created_at)
+select '${BASELINE_HASH}', ${BASELINE_MILLIS}
+ where not exists (
+   select 1 from drizzle.__drizzle_migrations where created_at = ${BASELINE_MILLIS}
+ );
+SQL
+  echo "ledger reconciled; run a normal migrate next"
+  exit 0
+fi
+
 if [[ "$DO_RESET" == "1" ]]; then
   need psql
   reset_force=0
@@ -222,6 +283,4 @@ if [[ "$TARGET" == "prod" && "$DO_RESET" != "1" ]]; then
   confirm "About to apply pending migrations to PRODUCTION." "yes"
 fi
 
-DATABASE="$DATABASE_URL" npx drizzle-kit migrate
-
-echo "migrations applied"
+DATABASE="$DATABASE_URL" node scripts/drizzle-migrate.mjs

--- a/scripts/drizzle-migrate.mjs
+++ b/scripts/drizzle-migrate.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Applies pending migrations and says so when it fails.
+//
+// `drizzle-kit migrate` exits non-zero with an empty stderr. A production run
+// that hit `type "..." already exists` printed nothing at all and looked like a
+// no-op, which is how a maintenance window got spent on a migration that had
+// not run. The migrator underneath is the same one; only the reporting differs.
+import { drizzle } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import pg from "pg";
+
+const url = process.env.DATABASE;
+if (!url) {
+  console.error("DATABASE is required");
+  process.exit(2);
+}
+
+const pool = new pg.Pool({ connectionString: url });
+const db = drizzle(pool);
+
+try {
+  await migrate(db, { migrationsFolder: "src/db/schema/out" });
+  console.log("migrations applied");
+} catch (err) {
+  console.error("");
+  console.error("migration FAILED, nothing was committed:");
+  console.error(`  ${err.message?.split("\n")[0] ?? err}`);
+  if (err.cause?.message) console.error(`  cause: ${err.cause.message}`);
+  if (/already exists/.test(err.cause?.message ?? "")) {
+    console.error("");
+    console.error("  This looks like the squashed baseline being replayed over a");
+    console.error("  database that already has those objects. Check the ledger with");
+    console.error("  `--status`: if it holds the pre-squash entries, reconcile it with");
+    console.error("  `--baseline` before migrating. See docs/better-auth-1.7-migration.md.");
+  }
+  process.exitCode = 1;
+} finally {
+  await pool.end();
+}

--- a/src/db/schema/auth-schema.ts
+++ b/src/db/schema/auth-schema.ts
@@ -37,25 +37,36 @@ export const session = pgTable("session", {
     .references(() => user.id, { onDelete: "cascade" }),
 });
 
-export const account = pgTable("account", {
-  id: text("id").primaryKey(),
-  accountId: text("account_id").notNull(),
-  providerId: text("provider_id").notNull(),
-  userId: text("user_id")
-    .notNull()
-    .references(() => user.id, { onDelete: "cascade" }),
-  accessToken: text("access_token"),
-  refreshToken: text("refresh_token"),
-  idToken: text("id_token"),
-  accessTokenExpiresAt: timestamp("access_token_expires_at", { withTimezone: true }),
-  refreshTokenExpiresAt: timestamp("refresh_token_expires_at", { withTimezone: true }),
-  scope: text("scope"),
-  password: text("password"),
-  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .$onUpdate(() => /* @__PURE__ */ new Date())
-    .notNull(),
-});
+export const account = pgTable(
+  "account",
+  {
+    id: text("id").primaryKey(),
+    accountId: text("account_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    // better-auth 1.7 keys an account by (issuer, accountId), not by provider.
+    // An OIDC provider supplies its own issuer; the rest get a synthetic one
+    // from `createLocalAccountIssuer` / `createOAuthAccountIssuer`.
+    issuer: text("issuer").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    accessToken: text("access_token"),
+    refreshToken: text("refresh_token"),
+    idToken: text("id_token"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at", { withTimezone: true }),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at", { withTimezone: true }),
+    scope: text("scope"),
+    password: text("password"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("idx_account_issuer_account_id").on(table.issuer, table.accountId),
+    index("idx_account_user_id").on(table.userId),
+  ]
+);
 
 // Property names must match better-auth's twoFactor model fields exactly —
 // the drizzle adapter is configured without a schema map, so it resolves the

--- a/src/db/schema/out/0001_account_issuer.sql
+++ b/src/db/schema/out/0001_account_issuer.sql
@@ -70,6 +70,19 @@ BEGIN
     claim_iss := payload ->> 'iss';
     claim_oid := payload ->> 'oid';
 
+    -- The claims are shape-checked, not merely present. This token was handed
+    -- to us by Microsoft's token endpoint over TLS during the code exchange, so
+    -- it is not re-verified here — but it has sat in a mutable column since,
+    -- and an unchecked string from it becomes half of an account's identity.
+    -- Entra v2 issuers are always `https://<host>/<tenant guid>/v2.0` and `oid`
+    -- is always a GUID, so anything else is not a claim we can key an account
+    -- on. Those rows are recorded and dropped rather than trusted.
+    IF claim_iss !~ '^https://[A-Za-z0-9.-]+/[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}/v2\.0$'
+       OR claim_oid !~ '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$' THEN
+      claim_iss := NULL;
+      claim_oid := NULL;
+    END IF;
+
     IF claim_iss IS NOT NULL AND claim_oid IS NOT NULL THEN
       UPDATE "account" SET "issuer" = claim_iss, "account_id" = claim_oid WHERE "id" = r."id";
       rekeyed := rekeyed + 1;
@@ -79,7 +92,9 @@ BEGIN
       SELECT a."user_id", u."email", a."provider_id", a."account_id",
              CASE WHEN r."id_token" IS NULL THEN 'no id_token stored'
                   WHEN payload IS NULL THEN 'id_token payload did not decode'
-                  ELSE 'id_token payload lacks iss or oid' END
+                  WHEN payload ->> 'iss' IS NULL OR payload ->> 'oid' IS NULL
+                    THEN 'id_token payload lacks iss or oid'
+                  ELSE 'id_token iss or oid is not a valid Entra claim' END
       FROM "account" a LEFT JOIN "user" u ON u."id" = a."user_id"
       WHERE a."id" = r."id";
 

--- a/src/db/schema/out/0001_account_issuer.sql
+++ b/src/db/schema/out/0001_account_issuer.sql
@@ -1,0 +1,123 @@
+-- better-auth 1.7 keys an account by (issuer, accountId) instead of by provider.
+-- Backfill follows the mapping in https://better-auth.com/docs/guides/1-7-upgrade-guide:
+-- an OIDC provider contributes its own trusted issuer, everything else gets a
+-- synthetic one. Nullable first so the backfill has somewhere to land.
+ALTER TABLE "account" ADD COLUMN "issuer" text;--> statement-breakpoint
+
+UPDATE "account" SET "issuer" = 'local:credential' WHERE "provider_id" = 'credential';--> statement-breakpoint
+
+-- 1.7 resolves a password sign-in by all three of providerId, issuer and
+-- accountId = the user's own id (sign-in.mjs). Sign-up has always written the
+-- user id here, so this is a no-op on healthy data, but a row that drifted
+-- would stop matching and cost that user password sign-in with no error to
+-- explain it. Realigning costs nothing and cannot collide: user_id is unique
+-- per user, and two credential rows for one user trip the guard below.
+UPDATE "account" SET "account_id" = "user_id"
+WHERE "provider_id" = 'credential' AND "account_id" <> "user_id";--> statement-breakpoint
+
+-- Google's subject is still the `sub` claim in 1.7, so only the issuer is new
+-- and these rows survive intact. The literal is Google's OIDC issuer, pinned to
+-- better-auth's own provider declaration by accountIssuer.test.ts.
+UPDATE "account" SET "issuer" = 'https://accounts.google.com' WHERE "provider_id" = 'google';--> statement-breakpoint
+
+-- A dropped link is a person who has to be told, so the migration records them
+-- rather than announcing a count. `drizzle-kit migrate` installs no `notice`
+-- listener on the pg client, so a RAISE NOTICE here would go nowhere. This
+-- table is deliberately outside the drizzle schema: it is operational, read
+-- after the window to send the emails, then dropped by hand.
+CREATE TABLE IF NOT EXISTS "account_issuer_migration_dropped" (
+  "user_id" text NOT NULL,
+  "email" text,
+  "provider_id" text NOT NULL,
+  "legacy_account_id" text,
+  "reason" text NOT NULL,
+  "dropped_at" timestamptz NOT NULL DEFAULT now()
+);--> statement-breakpoint
+
+-- Microsoft changed both halves of the key: 1.6 stored `account_id` as the
+-- pairwise `sub`, 1.7 looks the account up by the directory `oid` under the
+-- tenant's own `iss`. Both live in the id_token better-auth already persisted
+-- verbatim — only access and refresh tokens go through `setTokenUtil`, and
+-- this app sets no `advanced.encryptOAuthTokens` — and 1.6's Microsoft
+-- provider refused to create an account at all without one, so every row here
+-- has the claims needed to re-key it. A row whose token is missing or
+-- undecodable has no recoverable key and is dropped for a re-link instead;
+-- leaving it would strand the user on `account not linked` with nothing to
+-- click, since `disableImplicitLinking` refuses the implicit re-link.
+DO $$
+DECLARE
+  r record;
+  payload jsonb;
+  claim_iss text;
+  claim_oid text;
+  segment text;
+  rekeyed int := 0;
+  dropped int := 0;
+BEGIN
+  FOR r IN SELECT "id", "id_token" FROM "account" WHERE "provider_id" = 'microsoft' LOOP
+    payload := NULL;
+    segment := translate(split_part(coalesce(r."id_token", ''), '.', 2), '-_', '+/');
+    IF length(segment) > 0 THEN
+      BEGIN
+        payload := convert_from(
+          decode(rpad(segment, (length(segment) + 3) / 4 * 4, '='), 'base64'), 'UTF8'
+        )::jsonb;
+      EXCEPTION WHEN others THEN
+        payload := NULL;
+      END;
+    END IF;
+
+    claim_iss := payload ->> 'iss';
+    claim_oid := payload ->> 'oid';
+
+    IF claim_iss IS NOT NULL AND claim_oid IS NOT NULL THEN
+      UPDATE "account" SET "issuer" = claim_iss, "account_id" = claim_oid WHERE "id" = r."id";
+      rekeyed := rekeyed + 1;
+    ELSE
+      INSERT INTO "account_issuer_migration_dropped"
+        ("user_id", "email", "provider_id", "legacy_account_id", "reason")
+      SELECT a."user_id", u."email", a."provider_id", a."account_id",
+             CASE WHEN r."id_token" IS NULL THEN 'no id_token stored'
+                  WHEN payload IS NULL THEN 'id_token payload did not decode'
+                  ELSE 'id_token payload lacks iss or oid' END
+      FROM "account" a LEFT JOIN "user" u ON u."id" = a."user_id"
+      WHERE a."id" = r."id";
+
+      DELETE FROM "account" WHERE "id" = r."id";
+      dropped := dropped + 1;
+    END IF;
+  END LOOP;
+
+  RAISE NOTICE 'microsoft: % re-keyed from id_token, % dropped with no usable token', rekeyed, dropped;
+END $$;--> statement-breakpoint
+
+-- Any provider added between this file being written and being applied would
+-- reach here unmapped. Fail loudly rather than invent an issuer for it.
+DO $$
+DECLARE unmapped text;
+BEGIN
+  SELECT string_agg(DISTINCT "provider_id", ', ') INTO unmapped
+  FROM "account" WHERE "issuer" IS NULL;
+  IF unmapped IS NOT NULL THEN
+    RAISE EXCEPTION 'account.issuer backfill has no mapping for provider_id: %', unmapped;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- The guide's collision check. The unique index below would fail on its own,
+-- but this names the offending rows instead of just the constraint.
+DO $$
+DECLARE collisions text;
+BEGIN
+  SELECT string_agg(format('%s/%s x%s', "issuer", "account_id", cnt), '; ') INTO collisions
+  FROM (
+    SELECT "issuer", "account_id", COUNT(*) AS cnt
+    FROM "account" GROUP BY "issuer", "account_id" HAVING COUNT(*) > 1
+  ) dupes;
+  IF collisions IS NOT NULL THEN
+    RAISE EXCEPTION 'duplicate (issuer, account_id) rows block the unique index: %', collisions;
+  END IF;
+END $$;--> statement-breakpoint
+
+ALTER TABLE "account" ALTER COLUMN "issuer" SET NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_account_issuer_account_id" ON "account" USING btree ("issuer","account_id");--> statement-breakpoint
+CREATE INDEX "idx_account_user_id" ON "account" USING btree ("user_id");

--- a/src/db/schema/out/meta/0001_snapshot.json
+++ b/src/db/schema/out/meta/0001_snapshot.json
@@ -1,0 +1,3150 @@
+{
+  "id": "7a1ddae5-7555-4f6c-84f7-0d2db6ac9e09",
+  "prevId": "ad32572f-fc47-4866-b9bc-da681417b4dc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_account_issuer_account_id": {
+          "name": "idx_account_issuer_account_id",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_two_factor_user_id": {
+          "name": "idx_two_factor_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_two_factor_secret": {
+          "name": "idx_two_factor_secret",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_holidays": {
+      "name": "bank_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_holidays_country_idx": {
+          "name": "bank_holidays_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_date_idx": {
+          "name": "bank_holidays_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_region_date_uidx": {
+          "name": "bank_holidays_country_region_date_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_holidays_country_date_no_region_uidx": {
+          "name": "bank_holidays_country_date_no_region_uidx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"bank_holidays\".\"region\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync": {
+      "name": "calendar_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "calendar_sync_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ME'"
+        },
+        "distinguish_mine": {
+          "name": "distinguish_mine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_token_uniq": {
+          "name": "calendar_sync_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_sync\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_user_id": {
+          "name": "idx_calendar_sync_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_user_id_user_id_fk": {
+          "name": "calendar_sync_user_id_user_id_fk",
+          "tableFrom": "calendar_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_teams": {
+      "name": "calendar_sync_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_teams_config_group_uniq": {
+          "name": "calendar_sync_teams_config_group_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_teams_config": {
+          "name": "idx_calendar_sync_teams_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_teams_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_sync_teams_group_id_groups_id_fk": {
+          "name": "calendar_sync_teams_group_id_groups_id_fk",
+          "tableFrom": "calendar_sync_teams",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_sync_types": {
+      "name": "calendar_sync_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calendar_sync_id": {
+          "name": "calendar_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mine_color": {
+          "name": "mine_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_sync_types_config_type_uniq": {
+          "name": "calendar_sync_types_config_type_uniq",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vacation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_calendar_sync_types_config": {
+          "name": "idx_calendar_sync_types_config",
+          "columns": [
+            {
+              "expression": "calendar_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk": {
+          "name": "calendar_sync_types_calendar_sync_id_calendar_sync_id_fk",
+          "tableFrom": "calendar_sync_types",
+          "tableTo": "calendar_sync",
+          "columnsFrom": [
+            "calendar_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changes": {
+      "name": "changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "changes_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_detail": {
+          "name": "change_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changing_user_id": {
+          "name": "changing_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "changes_user_id_user_id_fk": {
+          "name": "changes_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_group_id_groups_id_fk": {
+          "name": "changes_group_id_groups_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changes_changing_user_id_user_id_fk": {
+          "name": "changes_changing_user_id_user_id_fk",
+          "tableFrom": "changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changing_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_mirrors": {
+      "name": "group_mirrors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_group_id": {
+          "name": "target_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_mirrors_user_source_target_uniq": {
+          "name": "group_mirrors_user_source_target_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_mirrors\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_target_group_id": {
+          "name": "idx_group_mirrors_target_group_id",
+          "columns": [
+            {
+              "expression": "target_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_mirrors_user_id": {
+          "name": "idx_group_mirrors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_mirrors_user_id_user_id_fk": {
+          "name": "group_mirrors_user_id_user_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_source_group_id_groups_id_fk": {
+          "name": "group_mirrors_source_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_mirrors_target_group_id_groups_id_fk": {
+          "name": "group_mirrors_target_group_id_groups_id_fk",
+          "tableFrom": "group_mirrors",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "target_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_vacation_days": {
+          "name": "default_vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_home_office_days": {
+          "name": "default_home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "working_days": {
+          "name": "working_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{1,2,3,4,5}'"
+        },
+        "holiday_country": {
+          "name": "holiday_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manager_user_id": {
+          "name": "manager_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_approval_user": {
+          "name": "main_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_approval_user": {
+          "name": "temp_approval_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_deleted_at_active": {
+          "name": "idx_groups_deleted_at_active",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"groups\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_organization_id": {
+          "name": "idx_groups_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_organization_id_organizations_id_fk": {
+          "name": "groups_organization_id_organizations_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_manager_user_id_user_id_fk": {
+          "name": "groups_manager_user_id_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "manager_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_main_approval_user_user_id_fk": {
+          "name": "groups_main_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "main_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groups_temp_approval_user_user_id_fk": {
+          "name": "groups_temp_approval_user_user_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "temp_approval_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_users": {
+      "name": "group_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_access": {
+          "name": "view_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_access": {
+          "name": "admin_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approver_access": {
+          "name": "approver_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controlled_user": {
+          "name": "controlled_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_users_group_id_user_id_uniq": {
+          "name": "group_users_group_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_group_id": {
+          "name": "idx_group_users_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_users_user_id": {
+          "name": "idx_group_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_users_group_id_groups_id_fk": {
+          "name": "group_users_group_id_groups_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_users_user_id_user_id_fk": {
+          "name": "group_users_user_id_user_id_fk",
+          "tableFrom": "group_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invite_link_code": {
+          "name": "idx_invite_link_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invite_link_group_id": {
+          "name": "idx_invite_link_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_group_email_open_uniq": {
+          "name": "invite_link_group_email_open_uniq",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_link\".\"used_at\" IS NULL AND \"invite_link\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_group_id_groups_id_fk": {
+          "name": "invite_link_group_id_groups_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_link_invited_by_user_id_user_id_fk": {
+          "name": "invite_link_invited_by_user_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_code_unique": {
+          "name": "invite_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_organizations_owner_user_id": {
+          "name": "uq_organizations_owner_user_id",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_users": {
+      "name": "organization_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "organization_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_users_org_id_user_id_uniq": {
+          "name": "organization_users_org_id_user_id_uniq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organization_users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_users_user_id": {
+          "name": "idx_organization_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_users_organization_id": {
+          "name": "idx_organization_users_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_users_organization_id_organizations_id_fk": {
+          "name": "organization_users_organization_id_organizations_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_users_user_id_user_id_fk": {
+          "name": "organization_users_user_id_user_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_users_granted_by_user_id_user_id_fk": {
+          "name": "organization_users_granted_by_user_id_user_id_fk",
+          "tableFrom": "organization_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paddle_events": {
+      "name": "paddle_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_exports_user_id_idx": {
+          "name": "report_exports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_exports_created_at_idx": {
+          "name": "report_exports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_user_id_user_id_fk": {
+          "name": "report_exports_user_id_user_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paddle_subscription_id": {
+          "name": "paddle_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paddle_customer_id": {
+          "name": "paddle_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "subscription_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "billing_cycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_group_slots": {
+          "name": "extra_group_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_override": {
+          "name": "manual_plan_override",
+          "type": "manual_plan_override",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_groups": {
+          "name": "manual_max_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_max_members_per_group": {
+          "name": "manual_max_members_per_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_plan_until": {
+          "name": "manual_plan_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_subscriptions_organization_id": {
+          "name": "uq_subscriptions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_paddle_subscription_id": {
+          "name": "idx_subscriptions_paddle_subscription_id",
+          "columns": [
+            {
+              "expression": "paddle_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_organization_id_organizations_id_fk": {
+          "name": "subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.support_access": {
+      "name": "support_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_access_user_id_idx": {
+          "name": "support_access_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_access_created_at_idx": {
+          "name": "support_access_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_access_user_id_user_id_fk": {
+          "name": "support_access_user_id_user_id_fk",
+          "tableFrom": "support_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboard_scope": {
+          "name": "dashboard_scope",
+          "type": "dashboard_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MINE'"
+        },
+        "dashboard_group_id": {
+          "name": "dashboard_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_settings_dashboard_group_id_groups_id_fk": {
+          "name": "user_settings_dashboard_group_id_groups_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "dashboard_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_year_quotas": {
+      "name": "user_year_quotas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_year": {
+          "name": "related_year",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vacation_days": {
+          "name": "vacation_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "home_office_days": {
+          "name": "home_office_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "carried_over_days": {
+          "name": "carried_over_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_year_quotas_user_year_uidx": {
+          "name": "user_group_year_quotas_user_year_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_year_quotas_user_id_user_id_fk": {
+          "name": "user_year_quotas_user_id_user_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_year_quotas_group_id_groups_id_fk": {
+          "name": "user_year_quotas_group_id_groups_id_fk",
+          "tableFrom": "user_year_quotas",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_year_quotas_related_year_chk": {
+          "name": "user_year_quotas_related_year_chk",
+          "value": "\"user_year_quotas\".\"related_year\" ~ '^[0-9]{4}$'"
+        },
+        "user_year_quotas_related_year_range_chk": {
+          "name": "user_year_quotas_related_year_range_chk",
+          "value": "\"user_year_quotas\".\"related_year\"::int BETWEEN 2025 AND 2100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vacation_events": {
+      "name": "vacation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vacation_id": {
+          "name": "vacation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "vacation_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vacation_events_vacation_id_idx": {
+          "name": "vacation_events_vacation_id_idx",
+          "columns": [
+            {
+              "expression": "vacation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_events_vacation_id_vacation_id_fk": {
+          "name": "vacation_events_vacation_id_vacation_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "vacation",
+          "columnsFrom": [
+            "vacation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_events_actor_user_id_user_id_fk": {
+          "name": "vacation_events_actor_user_id_user_id_fk",
+          "tableFrom": "vacation_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacation": {
+      "name": "vacation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_day": {
+          "name": "requested_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacation_type": {
+          "name": "vacation_type",
+          "type": "vacation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VACATION'"
+        },
+        "half_day": {
+          "name": "half_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_user_id": {
+          "name": "deleted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requested_day_idx": {
+          "name": "requested_day_idx",
+          "columns": [
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_vacation_user_day": {
+          "name": "uniq_vacation_user_day",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vacation\".\"deleted_at\" IS NULL AND \"vacation\".\"rejected_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacation_user_id_user_id_fk": {
+          "name": "vacation_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_group_id_groups_id_fk": {
+          "name": "vacation_group_id_groups_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacation_approved_by_user_id_fk": {
+          "name": "vacation_approved_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_deleted_by_user_id_user_id_fk": {
+          "name": "vacation_deleted_by_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deleted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_rejected_by_user_id_fk": {
+          "name": "vacation_rejected_by_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vacation_created_by_user_id_user_id_fk": {
+          "name": "vacation_created_by_user_id_user_id_fk",
+          "tableFrom": "vacation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_scope": {
+      "name": "calendar_sync_scope",
+      "schema": "public",
+      "values": [
+        "ME",
+        "TEAM"
+      ]
+    },
+    "public.changes_type": {
+      "name": "changes_type",
+      "schema": "public",
+      "values": [
+        "GROUP",
+        "GROUP_USER",
+        "VACATION",
+        "USER_YEAR_QUOTAS"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "approval_requested",
+        "approval_decided",
+        "calendar_conflict",
+        "balance_low",
+        "comment"
+      ]
+    },
+    "public.organization_role": {
+      "name": "organization_role",
+      "schema": "public",
+      "values": [
+        "ADMIN"
+      ]
+    },
+    "public.billing_cycle": {
+      "name": "billing_cycle",
+      "schema": "public",
+      "values": [
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.manual_plan_override": {
+      "name": "manual_plan_override",
+      "schema": "public",
+      "values": [
+        "FREE",
+        "PRO",
+        "ENTERPRISE",
+        "CUSTOM"
+      ]
+    },
+    "public.subscription_plan": {
+      "name": "subscription_plan",
+      "schema": "public",
+      "values": [
+        "PRO",
+        "ENTERPRISE"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "trialing",
+        "past_due",
+        "paused",
+        "canceled"
+      ]
+    },
+    "public.dashboard_scope": {
+      "name": "dashboard_scope",
+      "schema": "public",
+      "values": [
+        "MINE",
+        "GROUP"
+      ]
+    },
+    "public.vacation_event_type": {
+      "name": "vacation_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELLED",
+        "COMMENT",
+        "UPDATED"
+      ]
+    },
+    "public.vacation_type": {
+      "name": "vacation_type",
+      "schema": "public",
+      "values": [
+        "VACATION",
+        "HOME_OFFICE",
+        "SICK",
+        "BANK_HOLIDAY",
+        "NON_PAID_LEAVE",
+        "PAID_TIME_OFF",
+        "SICK_LEAVE",
+        "STUDY_LEAVE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/schema/out/meta/_journal.json
+++ b/src/db/schema/out/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1787411149632,
       "tag": "0000_init",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1787477515193,
+      "tag": "0001_account_issuer",
+      "breakpoints": true
     }
   ]
 }

--- a/src/services/dev/devSeedServices.ts
+++ b/src/services/dev/devSeedServices.ts
@@ -2,6 +2,7 @@ import crypto from "crypto";
 import { and, eq, inArray, or, sql } from "drizzle-orm";
 import { hashPassword } from "better-auth/crypto";
 import { db } from "../../db/db.js";
+import { createLocalAccountIssuer } from "better-auth/db";
 import { account, user } from "../../db/schema/auth-schema.js";
 import { groups } from "../../db/schema/group-schema.js";
 import { organizations } from "../../db/schema/organization-schema.js";
@@ -101,6 +102,7 @@ export const seedUser = async (input: {
       id: generateRandomUUID(),
       accountId: userId,
       providerId: "credential",
+      issuer: createLocalAccountIssuer("credential"),
       userId,
       password: await hashPassword(password),
       createdAt: new Date(),

--- a/src/tests/db/accountIssuer.test.ts
+++ b/src/tests/db/accountIssuer.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { createLocalAccountIssuer, createOAuthAccountIssuer } from "better-auth/db";
+import { socialProviders } from "better-auth/social-providers";
+import { readFileSync } from "node:fs";
+
+/**
+ * The 0001 backfill hard-codes issuer strings, because SQL cannot call
+ * better-auth. These assertions are what keeps the literals honest: if an
+ * upgrade changes how better-auth derives an issuer, the rows written by the
+ * migration stop matching the rows better-auth looks up, and every affected
+ * user silently loses social sign-in. That failure is invisible in every other
+ * test, so it is pinned here instead.
+ */
+const migration = readFileSync(
+  new URL("../../db/schema/out/0001_account_issuer.sql", import.meta.url),
+  "utf8"
+);
+
+const credentials = { clientId: "test-client", clientSecret: "test-secret" };
+
+describe("account.issuer backfill", () => {
+  it("writes the credential issuer better-auth resolves", () => {
+    expect(createLocalAccountIssuer("credential")).toBe("local:credential");
+    expect(migration).toContain("SET \"issuer\" = 'local:credential'");
+  });
+
+  it("writes Google's own OIDC issuer, not the synthetic one", () => {
+    const google = socialProviders.google(credentials);
+    expect(google.accountIssuer).toBe("https://accounts.google.com");
+    expect(migration).toContain(`SET "issuer" = '${google.accountIssuer}'`);
+    // The synthetic form is what a provider without an issuer would get, and
+    // is exactly the value this migration must NOT write for Google.
+    expect(createOAuthAccountIssuer("google")).toBe("local:oauth:google");
+    expect(migration).not.toContain("local:oauth:google");
+  });
+
+  it("leaves Google's account_id alone, because its subject is still `sub`", () => {
+    // The other half of the key. If a later better-auth hashes or re-pairs the
+    // subject, the backfill would write a correct issuer against a stale
+    // account_id and every Google user would fail to sign in — with the issuer
+    // assertion above still passing. That is the failure this pins down.
+    const google = socialProviders.google(credentials);
+    expect(google.accountSubject({ profile: { sub: "subject-123" } })).toBe("subject-123");
+  });
+
+  it("re-keys Microsoft from the stored id_token rather than dropping the link", () => {
+    const microsoft = socialProviders.microsoft(credentials);
+    // Both halves of Microsoft's key move in 1.7: the issuer is resolved from
+    // the token's own `iss` rather than being a constant, and the subject is
+    // the directory `oid` in place of the pairwise `sub`.
+    const iss = "https://login.microsoftonline.com/tenant-guid/v2.0";
+    expect(typeof microsoft.accountIssuer).toBe("function");
+    expect(microsoft.accountIssuer({ profile: { iss } })).toBe(iss);
+    expect(microsoft.accountSubject({ profile: { oid: "dir-oid-1", sub: "pairwise-1" } })).toBe(
+      "dir-oid-1"
+    );
+    // Matched as one statement, not two loose substrings: asserting the claims
+    // appear somewhere would still pass with the two of them swapped, which is
+    // the mapping error that would strand every Microsoft user.
+    expect(migration).toContain(
+      `UPDATE "account" SET "issuer" = claim_iss, "account_id" = claim_oid`
+    );
+    expect(migration).toContain("claim_iss := payload ->> 'iss'");
+    expect(migration).toContain("claim_oid := payload ->> 'oid'");
+    // A blanket delete would throw away links that the id_token can rebuild.
+    expect(migration).not.toContain(`DELETE FROM "account" WHERE "provider_id" = 'microsoft'`);
+  });
+
+  it("records every dropped link, because a notice from drizzle-kit goes nowhere", () => {
+    // `drizzle-kit migrate` installs no `notice` listener on the pg client, so
+    // the only durable record of who must be emailed is a table.
+    expect(migration).toContain(`INSERT INTO "account_issuer_migration_dropped"`);
+    const recorded = migration.indexOf(`INSERT INTO "account_issuer_migration_dropped"`);
+    const deleted = migration.indexOf(`DELETE FROM "account" WHERE "id" = r."id"`);
+    expect(recorded).toBeGreaterThan(-1);
+    expect(deleted).toBeGreaterThan(recorded);
+  });
+
+  it("adds issuer nullable, backfills, then constrains — never NOT NULL up front", () => {
+    const addColumn = migration.indexOf('ADD COLUMN "issuer" text');
+    const setNotNull = migration.indexOf('ALTER COLUMN "issuer" SET NOT NULL');
+    expect(addColumn).toBeGreaterThan(-1);
+    expect(setNotNull).toBeGreaterThan(addColumn);
+    expect(migration).not.toContain('ADD COLUMN "issuer" text NOT NULL');
+  });
+
+  it("refuses to constrain the column while any provider is unmapped", () => {
+    const guard = migration.indexOf("has no mapping for provider_id");
+    expect(guard).toBeGreaterThan(-1);
+    expect(migration.indexOf('ALTER COLUMN "issuer" SET NOT NULL')).toBeGreaterThan(guard);
+  });
+});

--- a/src/tests/e2e/passwordResetSettles.e2e.test.ts
+++ b/src/tests/e2e/passwordResetSettles.e2e.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterAll, beforeEach } from "vitest";
 import { v4 as uuidv4 } from "uuid";
 import { eq } from "drizzle-orm";
 import { db } from "../../db/db.js";
-import { createLocalAccountIssuer, createOAuthAccountIssuer } from "better-auth/db";
+import { createLocalAccountIssuer } from "better-auth/db";
 import { account, user, verification } from "../../db/schema/auth-schema.js";
 import { auth } from "../../utils/auth.js";
 import { cleanupTestData } from "./helpers/testSetup.js";
@@ -34,16 +34,34 @@ describe("password reset settles the account", () => {
     return id;
   };
 
+  // Rows shaped the way better-auth 1.7 actually writes them. A synthetic
+  // `local:oauth:<provider>` issuer would be a value that cannot occur for
+  // either configured provider, so any future test that resolves an account by
+  // its key would be built on data production never produces.
+  const identity = (userId: string, providerId: string) => {
+    switch (providerId) {
+      case "credential":
+        return { issuer: createLocalAccountIssuer(providerId), accountId: userId };
+      case "google":
+        return { issuer: "https://accounts.google.com", accountId: `google-sub-${userId}` };
+      case "microsoft":
+        return {
+          issuer: `https://login.microsoftonline.com/${MS_TENANT_ID}/v2.0`,
+          accountId: `9f3ab2c1-77de-4f0a-bb31-${userId.replace(/\D/g, "").padStart(12, "0").slice(-12)}`,
+        };
+      default:
+        throw new Error(`no issuer mapping for provider ${providerId}`);
+    }
+  };
+
+  const MS_TENANT_ID = "72f988bf-1234-41af-91ab-2d7cd011db47";
+
   const addAccount = async (userId: string, providerId: string) => {
     await db.insert(account).values({
       id: uuidv4(),
       userId,
       providerId,
-      issuer:
-        providerId === "credential"
-          ? createLocalAccountIssuer(providerId)
-          : createOAuthAccountIssuer(providerId),
-      accountId: `${providerId}-${userId}`,
+      ...identity(userId, providerId),
       createdAt: new Date(),
       updatedAt: new Date(),
     });

--- a/src/tests/e2e/passwordResetSettles.e2e.test.ts
+++ b/src/tests/e2e/passwordResetSettles.e2e.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterAll, beforeEach } from "vitest";
 import { v4 as uuidv4 } from "uuid";
 import { eq } from "drizzle-orm";
 import { db } from "../../db/db.js";
+import { createLocalAccountIssuer, createOAuthAccountIssuer } from "better-auth/db";
 import { account, user, verification } from "../../db/schema/auth-schema.js";
 import { auth } from "../../utils/auth.js";
 import { cleanupTestData } from "./helpers/testSetup.js";
@@ -38,6 +39,10 @@ describe("password reset settles the account", () => {
       id: uuidv4(),
       userId,
       providerId,
+      issuer:
+        providerId === "credential"
+          ? createLocalAccountIssuer(providerId)
+          : createOAuthAccountIssuer(providerId),
       accountId: `${providerId}-${userId}`,
       createdAt: new Date(),
       updatedAt: new Date(),

--- a/src/tests/e2e/twoFactor.e2e.test.ts
+++ b/src/tests/e2e/twoFactor.e2e.test.ts
@@ -6,6 +6,7 @@ import { eq } from "drizzle-orm";
 import { hashPassword } from "better-auth/crypto";
 import { base32 } from "@better-auth/utils/base32";
 import { db } from "../../db/db.js";
+import { createLocalAccountIssuer } from "better-auth/db";
 import { account, twoFactor as twoFactorTable, user } from "../../db/schema/auth-schema.js";
 import { auth } from "../../utils/auth.js";
 import { createServer } from "../../server.js";
@@ -69,6 +70,7 @@ describe("two-factor authentication", () => {
       id: uuidv4(),
       userId,
       providerId: "credential",
+      issuer: createLocalAccountIssuer("credential"),
       accountId: userId,
       password: await hashPassword(password),
       createdAt: new Date(),
@@ -192,6 +194,7 @@ describe("two-factor authentication", () => {
       id: uuidv4(),
       userId: otpUserId,
       providerId: "credential",
+      issuer: createLocalAccountIssuer("credential"),
       accountId: otpUserId,
       password: await hashPassword(password),
       createdAt: new Date(),


### PR DESCRIPTION
Companion to Daniel88dev/flexi-day#70, which cannot ship until this is deployed.

## Why this is not a version bump

better-auth 1.7 stops identifying an account by `providerId` and identifies it by
`(issuer, accountId)`. That adds a `NOT NULL` column to a table the auth code reads on every
sign-in, so it needs a backfill and a maintenance window. Upstream guide:
https://better-auth.com/docs/guides/1-7-upgrade-guide

**[`docs/better-auth-1.7-migration.md`](docs/better-auth-1.7-migration.md) is the runbook. Read it before deploying — the deploy order is not the obvious one.**

## What the backfill does

Each provider moves differently, so each gets its own rule:

| `provider_id` | `issuer` | `account_id` | outcome |
| --- | --- | --- | --- |
| `credential` | `local:credential` | realigned to the user id | preserved |
| `google` | `https://accounts.google.com` | unchanged — still `sub` | preserved |
| `microsoft` | `iss` from the stored `id_token` | `oid` from the stored `id_token` | preserved, re-keyed |
| `microsoft` | no decodable `id_token` | — | row deleted, recorded |

The credential realignment matters: 1.7's password sign-in matches on `accountId == user.id` as a
third condition, so a row that had drifted would silently stop resolving.

Microsoft moves both halves — 1.6 stored the pairwise `sub`, 1.7 looks up the directory `oid` under
the tenant's own `iss`. Both claims are in the `id_token` better-auth already persisted verbatim
(only access and refresh tokens go through `setTokenUtil`, and this app sets no
`advanced.encryptOAuthTokens`), and 1.6's Microsoft provider refused to create an account without
one. So these links are rebuilt rather than dropped. A row whose token will not decode has no
recoverable key and is deleted — leaving it would strand the user on `account not linked` with
nothing to click, since `disableImplicitLinking` refuses the implicit re-link.

Every dropped link is written to `account_issuer_migration_dropped` before the delete, with the
user's email and the reason. A `RAISE NOTICE` would not do — `drizzle-kit migrate` installs no
notice listener on the pg client, so the count would go nowhere and the people owed an email would
be unidentifiable afterwards. Recovery for them is **password reset, not re-linking**: `/link-social`
needs a session they cannot get, while reset creates a credential account when none exists.

## Safety

Two guards refuse to constrain the column — one on any provider the backfill has no rule for, one on
duplicate `(issuer, accountId)`. Drizzle runs the whole file in one transaction, so either abort
leaves the table exactly as it was; I verified that by aborting on seeded duplicates and confirming
the column, the re-keys and the audit table were all rolled back.

`src/tests/db/accountIssuer.test.ts` pins both halves of every provider's key to better-auth's own
declarations. I mutation-tested it: writing Google's synthetic issuer, blanket-deleting Microsoft,
and swapping `iss`/`oid` each fail it.

## Review findings fixed

Three rounds of independent review, all findings addressed:

- Backfill originally wrote `local:oauth:google`; Google declares its own OIDC issuer, so every
  Google user would have lost sign-in.
- Migration originally deleted all Microsoft rows as unrecoverable. They are recoverable from
  `id_token`; it now re-keys them.
- Deploy sequence originally resumed App Runner and assumed CD would deploy. It does not — a paused
  service ignores images pushed while paused, and CD has no `start-deployment`. The runbook now
  resumes *and* triggers a deployment, and verifies before reopening traffic.
- Pre-flight duplicate check grouped on the pre-backfill key, so it could pass while the guard
  aborted mid-window. It now computes the post-backfill key using the migration's own decode logic.
- The Microsoft test could not fail on a swapped `iss`/`oid`. It now matches the full statement.

## Verification

- 565 unit tests, 188 e2e, build, lint and prettier all pass.
- Migration exercised against a scratch Postgres on legacy-shaped data: credential (aligned and
  drifted), Google, Microsoft (valid token, absent token, non-base64 token, valid JSON without the
  claims), multibyte UTF-8 claims, and both duplicate classes.
- Auth flow driven in the browser against the 1.7 pair: sign-in, unlink by row id, 2FA enable →
  TOTP verify → password sign-in with 2FA challenge → disable. All auth calls 200, no console errors.

Note: `src/tests/middleware/limiter.test.ts` flakes roughly 1 run in 5. It does the same on `main`,
so it is pre-existing and not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrPmNbE8YbGdaZp4A58gSn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated authentication support to Better Auth 1.7.1.
  * Improved account identification and linking across credential and social sign-ins.
  * Added safeguards to prevent duplicate or incorrectly matched accounts during migration.

* **Documentation**
  * Added production migration instructions covering deployment sequencing, database backups, verification, rollback limitations, recovery, and cleanup.
  * Added pre-migration checks and guidance for handling affected Microsoft account records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->