### PR TITLE
refactor: collapse the vacation transitions into one module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ inside it, so the whole request commits or rolls back together:
 
 ```typescript
 const quota = await db.transaction(async (tx) => {
+  await assertGroupAdmin(auth.userId, groupId, tx);
   await assertGroupWritable(groupId, tx);
   return services.userYearQuotas.upsertUserYearQuota(payload, tx);
 });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,13 @@ import { auth } from "../utils/auth.js";
 business logic and database access → `src/db/` is the Drizzle schema and client. `src/index.ts`
 creates the server and handles graceful shutdown; `src/server.ts` assembles middleware and routes.
 
+Those arrows run one way. `src/services/` imports nothing from `src/controllers/`, which is why the
+permission guards live in the services layer rather than beside the handlers that call them:
+`vacation/decisionGuards.ts` and `vacation/vacationPermissions.ts` for who may decide or cancel a
+booking, `groupUser/groupAccess.ts` for standing in a group, `billing/guards.ts` for whether a
+group's plan still allows writes. Controllers import them; so does the transition module, which
+could not if they had stayed a layer up.
+
 `src/jobs/` schedules background work with croner, started from `src/index.ts` and stopped on
 shutdown. Job modules only schedule and log — the work itself lives in a service, so it stays
 callable and testable outside the timer.
@@ -47,20 +54,29 @@ domain (`vacation`, `group`, `groupUser`, `organization`, `report`, …). Each d
 `src/services/{domain}/` as `{domain}Services.ts` plus a `types.ts` holding its TypeScript types
 and Zod schemas.
 
-**The controller owns the transaction boundary.** A write handler imports `db`, opens
+Two rules hold for every write, wherever its transaction is opened. Anything that appends a
+`vacation_events` row belongs in the same transaction as the change it records. Notifications go
+out after the commit, never inside it.
+
+**For the seven vacation transitions, the transition module owns the boundary.** Approve, reject,
+cancel and comment, in their single and bulk forms, open no transaction of their own. They call
+`src/services/vacation/vacationTransitions.ts`, which runs the whole sequence in one place: load,
+authorize, plan guard, quota guard, mutate, lost-race check, event append, commit, then notify. The
+two rules above therefore hold by construction rather than by each route remembering them. A
+transition supplies only what differs, its load, its authorization, its mutation and its own
+not-found and conflict wording, and its controller is left parsing the request and shaping the
+response. Reach for the module for any new vacation state change.
+
+**Every other write handler owns its own boundary.** It imports `db`, opens
 `db.transaction(async (tx) => ...)`, and threads that `tx` through every service call and guard
 inside it, so the whole request commits or rolls back together:
 
 ```typescript
-const approved = await db.transaction(async (tx) => {
-  const vacationData = await services.vacation.getVacationById(vacationId, tx);
-  await assertMayDecide(auth.userId, [vacationData], "approve", tx);
-  return services.vacation.approveVacation(vacationId, auth.userId, tx);
+const quota = await db.transaction(async (tx) => {
+  await assertGroupWritable(groupId, tx);
+  return services.userYearQuotas.upsertUserYearQuota(payload, tx);
 });
 ```
-
-Anything that appends a `vacation_events` row belongs in the same transaction as the change it
-records. Notifications go out after the commit, never inside it.
 
 ## Migrations
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,7 +29,11 @@ The vacation/day-off domain as the backend models it. Security and permission bo
 5. Quota changes are logged in `changes`.
 6. Every transition also appends a `vacation_events` row **inside the same transaction**, and
    `src/services/vacation/vacationNotifier.ts` fans out the email + in-app notification
-   **after** the commit. The notifier swallows and logs its own errors on purpose — a mail
+   **after** the commit. `src/services/vacation/vacationTransitions.ts` is what holds that
+   ordering: approve, reject, cancel and comment, single and bulk alike, all run through its one
+   sequence, so a new transition inherits the ordering instead of restating it. Creating and
+   editing a booking still order it by hand in their own handlers.
+   The notifier swallows and logs its own errors on purpose — a mail
    failure must never turn a committed change into a 5xx the client would retry. Workflow mail
    respects `user_settings.emailNotifications`; account mail (email confirmation) does not.
 

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -140,8 +140,8 @@ See [`../CONTEXT.md`](../CONTEXT.md) for what an org admin _is_. The boundaries:
   administration, so org admins (like group admins) may create a booking for a member via
   `POST /create-vacation` with `userId` — including `autoApprove`, which stamps them as
   `approvedBy` — edit its per-day fields via `PATCH /api/vacation`, and cancel it
-  (`resolveVacationPermissions` / `handleBulkCancelVacation` resolve admin standing through
-  `resolveGroupAdmin`). Every such write is attributed (`createdByUserId` / `deletedByUserId`,
+  (`resolveVacationPermissions` and the cancel transitions in `vacationTransitions.ts` resolve
+  admin standing through `resolveGroupAdmin`). Every such write is attributed (`createdByUserId` / `deletedByUserId`,
   CREATED/APPROVED/UPDATED/CANCELLED timeline events). The boundary itself stands: deciding a
   **member-submitted** request stays approver-only (`getGroupsWhereUserCanApprove` still excludes
   org admins, `autoApprove` is refused for self-bookings), and both defenses above remain.

--- a/src/controllers/billing/tests/guardWiring.test.ts
+++ b/src/controllers/billing/tests/guardWiring.test.ts
@@ -104,7 +104,7 @@ vi.mock("../../../middleware/authSession.js", () => ({
   }),
 }));
 
-vi.mock("../../vacation/decisionGuards.js", () => ({
+vi.mock("../../../services/vacation/decisionGuards.js", () => ({
   assertMayDecide: vi.fn(),
   assertStillPending: vi.fn(),
   mayDecideOwn: vi.fn(),
@@ -121,7 +121,7 @@ vi.mock("../../../services/vacation/vacationNotifier.js", () => ({
   notifyVacationRequested: vi.fn(),
 }));
 
-vi.mock("../../vacation/utils.js", () => ({
+vi.mock("../../../services/vacation/vacationPermissions.js", () => ({
   resolveVacationPermissions: () => ({ canCancel: true, canView: true }),
 }));
 

--- a/src/controllers/billing/tests/guardWiring.test.ts
+++ b/src/controllers/billing/tests/guardWiring.test.ts
@@ -150,10 +150,12 @@ describe("billing guard wiring", () => {
     services.upsertUserYearQuota.mockResolvedValue({ id: "q-1" });
   });
 
+  // The transition module runs every decision through the multi-group form,
+  // which produces the same 402 for one group as the single-group guard did.
   it("handlePostVacationApproval checks the group is writable", async () => {
     const { req, res } = makeReqRes({ params: { id: "3f1b1a2c-0000-4000-8000-000000000000" } });
     await handlePostVacationApproval(req, res);
-    expect(mockAssertGroupWritable).toHaveBeenCalledWith("group-1", {});
+    expect(mockAssertGroupsWritable).toHaveBeenCalledWith(["group-1"], {});
   });
 
   it("handleDeleteVacation checks the group is writable", async () => {

--- a/src/controllers/billing/tests/guardWiring.test.ts
+++ b/src/controllers/billing/tests/guardWiring.test.ts
@@ -123,6 +123,7 @@ vi.mock("../../../services/vacation/vacationNotifier.js", () => ({
 
 vi.mock("../../../services/vacation/vacationPermissions.js", () => ({
   resolveVacationPermissions: () => ({ canCancel: true, canView: true }),
+  resolveCanCancelForList: () => () => true,
 }));
 
 import { handlePostVacationApproval } from "../../vacation/handlePostVacationApproval.js";
@@ -150,7 +151,7 @@ describe("billing guard wiring", () => {
     services.upsertUserYearQuota.mockResolvedValue({ id: "q-1" });
   });
 
-  // The transition module runs every decision through the multi-group form,
+  // The transition module runs every transition through the multi-group form,
   // which produces the same 402 for one group as the single-group guard did.
   it("handlePostVacationApproval checks the group is writable", async () => {
     const { req, res } = makeReqRes({ params: { id: "3f1b1a2c-0000-4000-8000-000000000000" } });
@@ -161,7 +162,7 @@ describe("billing guard wiring", () => {
   it("handleDeleteVacation checks the group is writable", async () => {
     const { req, res } = makeReqRes({ params: { id: "3f1b1a2c-0000-4000-8000-000000000000" } });
     await handleDeleteVacation(req, res);
-    expect(mockAssertGroupWritable).toHaveBeenCalledWith("group-1", {});
+    expect(mockAssertGroupsWritable).toHaveBeenCalledWith(["group-1"], {});
   });
 
   it("handlePostGroup checks the organization may create another group", async () => {

--- a/src/controllers/group/handleGetGroup.ts
+++ b/src/controllers/group/handleGetGroup.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
 import AppError from "../../utils/appError.js";
-import { resolveGroupAccess } from "../groupUser/utils.js";
+import { resolveGroupAccess } from "../../services/groupUser/groupAccess.js";
 import { resolveOrganizationBadges } from "../../services/organization/organizationBadge.js";
 
 const services = createDBServices();

--- a/src/controllers/group/handleGetGroupMirrors.ts
+++ b/src/controllers/group/handleGetGroupMirrors.ts
@@ -2,7 +2,10 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
-import { getAdministrableGroupIds, resolveGroupAdmin } from "../groupUser/utils.js";
+import {
+  getAdministrableGroupIds,
+  resolveGroupAdmin,
+} from "../../services/groupUser/groupAccess.js";
 import AppError from "../../utils/appError.js";
 import { buildUserSummary } from "../../utils/userPresentation.js";
 import type { MirrorCandidate, MirrorMember } from "../../services/groupMirror/types.js";

--- a/src/controllers/group/handlePutGroupApprovers.ts
+++ b/src/controllers/group/handlePutGroupApprovers.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
 import { getAuth } from "../../middleware/authSession.js";
-import { resolveGroupAdmin } from "../groupUser/utils.js";
+import { resolveGroupAdmin } from "../../services/groupUser/groupAccess.js";
 import type { ValidatedPutGroupApproversType } from "../../services/group/types.js";
 import AppError from "../../utils/appError.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";

--- a/src/controllers/group/handlePutGroupHolidayCountry.ts
+++ b/src/controllers/group/handlePutGroupHolidayCountry.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
 import { getAuth } from "../../middleware/authSession.js";
-import { assertGroupAdmin } from "../groupUser/utils.js";
+import { assertGroupAdmin } from "../../services/groupUser/groupAccess.js";
 import type { ValidatedPutGroupHolidayCountryType } from "../../services/group/types.js";
 import AppError from "../../utils/appError.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";

--- a/src/controllers/group/handlePutGroupMirrors.ts
+++ b/src/controllers/group/handlePutGroupMirrors.ts
@@ -3,7 +3,10 @@ import { z } from "zod";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
-import { assertGroupAdmin, getAdministrableGroupIds } from "../groupUser/utils.js";
+import {
+  assertGroupAdmin,
+  getAdministrableGroupIds,
+} from "../../services/groupUser/groupAccess.js";
 import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";
 import type { ValidatedPutGroupMirrorsType } from "../../services/groupMirror/types.js";

--- a/src/controllers/group/handlePutGroupQuotas.ts
+++ b/src/controllers/group/handlePutGroupQuotas.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
 import { getAuth } from "../../middleware/authSession.js";
-import { assertGroupAdmin } from "../groupUser/utils.js";
+import { assertGroupAdmin } from "../../services/groupUser/groupAccess.js";
 import type { ValidatedPutGroupQuotasType } from "../../services/group/types.js";
 import AppError from "../../utils/appError.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";

--- a/src/controllers/group/handlePutGroupWorkingDays.ts
+++ b/src/controllers/group/handlePutGroupWorkingDays.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
 import { getAuth } from "../../middleware/authSession.js";
-import { assertGroupAdmin } from "../groupUser/utils.js";
+import { assertGroupAdmin } from "../../services/groupUser/groupAccess.js";
 import type { ValidatedPutGroupWorkingDaysType } from "../../services/group/types.js";
 import AppError from "../../utils/appError.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";

--- a/src/controllers/group/tests/handlePutGroupHolidayCountry.test.ts
+++ b/src/controllers/group/tests/handlePutGroupHolidayCountry.test.ts
@@ -14,7 +14,7 @@ const {
 
 vi.mock("../../../middleware/authSession.js", () => ({ getAuth: vi.fn() }));
 
-vi.mock("../../groupUser/utils.js", () => ({
+vi.mock("../../../services/groupUser/groupAccess.js", () => ({
   assertGroupAdmin: mockAssertGroupAdmin,
 }));
 

--- a/src/controllers/groupUser/handleDeleteGroupInvite.ts
+++ b/src/controllers/groupUser/handleDeleteGroupInvite.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
-import { assertGroupAdmin } from "./utils.js";
+import { assertGroupAdmin } from "../../services/groupUser/groupAccess.js";
 import AppError from "../../utils/appError.js";
 
 const services = createDBServices();

--- a/src/controllers/groupUser/handleDeleteGroupUser.ts
+++ b/src/controllers/groupUser/handleDeleteGroupUser.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
-import { assertGroupAdmin } from "./utils.js";
+import { assertGroupAdmin } from "../../services/groupUser/groupAccess.js";
 import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";
 

--- a/src/controllers/groupUser/handleGetGroupInvites.ts
+++ b/src/controllers/groupUser/handleGetGroupInvites.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
-import { assertGroupAdmin } from "./utils.js";
+import { assertGroupAdmin } from "../../services/groupUser/groupAccess.js";
 
 const services = createDBServices();
 

--- a/src/controllers/groupUser/handleGetGroupUsers.ts
+++ b/src/controllers/groupUser/handleGetGroupUsers.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
-import { validateUserGroupAccess } from "./utils.js";
+import { validateUserGroupAccess } from "../../services/groupUser/groupAccess.js";
 import { z } from "zod";
 import AppError from "../../utils/appError.js";
 

--- a/src/controllers/groupUser/handlePostGroupInvite.ts
+++ b/src/controllers/groupUser/handlePostGroupInvite.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
-import { assertGroupAdmin } from "./utils.js";
+import { assertGroupAdmin } from "../../services/groupUser/groupAccess.js";
 import type { ValidatedPostGroupInviteType } from "../../services/groupUser/types.js";
 import AppError from "../../utils/appError.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";

--- a/src/controllers/groupUser/handleUpdateGroupUsers.ts
+++ b/src/controllers/groupUser/handleUpdateGroupUsers.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
 import type { ValidatedPutGroupUserUpdateType } from "../../services/groupUser/types.js";
-import { resolveGroupAdmin } from "./utils.js";
+import { resolveGroupAdmin } from "../../services/groupUser/groupAccess.js";
 import AppError from "../../utils/appError.js";
 import { logger } from "../../middleware/logger.js";
 import { db } from "../../db/db.js";

--- a/src/controllers/quotas/handleGetCarryOverSuggestion.ts
+++ b/src/controllers/quotas/handleGetCarryOverSuggestion.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { getAuth } from "../../middleware/authSession.js";
 import { createDBServices } from "../../services/DBServices.js";
-import { assertGroupAdmin } from "../groupUser/utils.js";
+import { assertGroupAdmin } from "../../services/groupUser/groupAccess.js";
 
 const services = createDBServices();
 

--- a/src/controllers/quotas/handleGetUserQuota.ts
+++ b/src/controllers/quotas/handleGetUserQuota.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
-import { validateUserGroupAccess } from "../groupUser/utils.js";
+import { validateUserGroupAccess } from "../../services/groupUser/groupAccess.js";
 import { z } from "zod";
 import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";

--- a/src/controllers/quotas/handlePutUserQuota.ts
+++ b/src/controllers/quotas/handlePutUserQuota.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
-import { assertGroupAdmin } from "../groupUser/utils.js";
+import { assertGroupAdmin } from "../../services/groupUser/groupAccess.js";
 import type { ValidatedPutUserQuotaType } from "../../services/userYearQuotas/types.js";
 import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";

--- a/src/controllers/vacation/handleBulkApproveVacation.ts
+++ b/src/controllers/vacation/handleBulkApproveVacation.ts
@@ -8,7 +8,7 @@ import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
 import { assertApprovalWithinQuota } from "../../services/vacation/quotaGuard.js";
-import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
+import { assertMayDecide, assertStillPending } from "../../services/vacation/decisionGuards.js";
 import { assertGroupsWritable } from "../../services/billing/guards.js";
 
 const services = createDBServices();

--- a/src/controllers/vacation/handleBulkApproveVacation.ts
+++ b/src/controllers/vacation/handleBulkApproveVacation.ts
@@ -1,17 +1,7 @@
 import type { Request, Response } from "express";
-import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
-import AppError from "../../utils/appError.js";
-import { db } from "../../db/db.js";
 import type { ValidatedBulkApproveVacationType } from "../../services/vacation/types.js";
-import { generateRandomUUID } from "../../utils/generateUUID.js";
-import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
-import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
-import { assertApprovalWithinQuota } from "../../services/vacation/quotaGuard.js";
-import { assertMayDecide, assertStillPending } from "../../services/vacation/decisionGuards.js";
-import { assertGroupsWritable } from "../../services/billing/guards.js";
-
-const services = createDBServices();
+import { approveRequestBatch } from "../../services/vacation/vacationTransitions.js";
 
 /**
  * Atomically approves many vacation rows. Used by the approvals widget after
@@ -24,55 +14,8 @@ export const handleBulkApproveVacation = async (req: Request, res: Response) => 
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const data: ValidatedBulkApproveVacationType = req.body;
-  const uniqueIds = Array.from(new Set(data.ids));
 
-  const approved = await db.transaction(async (tx) => {
-    const rows = await services.vacation.getVacationsByIds(uniqueIds, tx);
-
-    if (rows.length !== uniqueIds.length) {
-      throw new AppError({
-        code: 404,
-        message: "One or more vacations not found",
-        context: { auth, requested: uniqueIds.length, found: rows.length },
-      });
-    }
-
-    await assertMayDecide(auth.userId, rows, "approve", tx);
-    assertStillPending(rows);
-    await assertGroupsWritable(
-      rows.map((row) => row.groupId),
-      tx
-    );
-    await assertApprovalWithinQuota(rows, tx);
-
-    const updated = await services.vacation.approveVacationsBulk(uniqueIds, auth.userId, tx);
-
-    // A short update means a concurrent decision took part of the batch.
-    if (updated.length !== uniqueIds.length) {
-      throw new AppError({
-        code: 409,
-        message: "One or more of these requests has already been decided",
-        logging: true,
-        context: { auth, requested: uniqueIds, updated: updated.map((row) => row.id) },
-      });
-    }
-
-    await services.vacationEvent.createVacationEvents(
-      updated.map((row) => ({
-        id: generateRandomUUID(),
-        vacationId: row.id,
-        eventType: vacationEventType.Approved,
-        actorUserId: auth.userId,
-      })),
-      tx
-    );
-
-    return updated;
-  });
-
-  // Post-commit and best-effort; the notifier logs its own failures. A bulk
-  // decision can span several requesters, so it fans out one mail per person.
-  await notifyVacationDecision(approved, "approved", { id: auth.userId, name: auth.userName });
+  const approved = await approveRequestBatch({ auth, vacationIds: data.ids });
 
   return res.status(200).json({
     message: "Vacations approved",

--- a/src/controllers/vacation/handleBulkCancelVacation.ts
+++ b/src/controllers/vacation/handleBulkCancelVacation.ts
@@ -1,86 +1,19 @@
 import type { Request, Response } from "express";
-import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
-import AppError from "../../utils/appError.js";
-import { db } from "../../db/db.js";
 import type { ValidatedBulkCancelVacationType } from "../../services/vacation/types.js";
-import { generateRandomUUID } from "../../utils/generateUUID.js";
-import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
-import { notifyVacationsCancelled } from "../../services/vacation/vacationNotifier.js";
-import { assertGroupsWritable } from "../../services/billing/guards.js";
-import { resolveGroupAdmin } from "../../services/groupUser/groupAccess.js";
-
-const services = createDBServices();
+import { cancelRequestBatch } from "../../services/vacation/vacationTransitions.js";
 
 export const handleBulkCancelVacation = async (req: Request, res: Response) => {
   const auth = getAuth(req);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const data: ValidatedBulkCancelVacationType = req.body;
-  const uniqueIds = Array.from(new Set(data.ids));
 
-  const cancelled = await db.transaction(async (tx) => {
-    const rows = await services.vacation.getVacationsByIds(uniqueIds, tx);
-
-    if (rows.length !== uniqueIds.length) {
-      throw new AppError({
-        code: 404,
-        message: "One or more vacations not found",
-        context: { auth, requested: uniqueIds.length, found: rows.length },
-      });
-    }
-
-    const distinctGroupIds = Array.from(new Set(rows.map((r) => r.groupId)));
-    const approvableGroups = new Set(
-      await services.group.getGroupsWhereUserCanApprove(distinctGroupIds, auth.userId, tx)
-    );
-    // Same admin verdict as the single-cancel path (`resolveVacationPermissions`):
-    // group admins and org admins alike.
-    const adminGroups = new Set<string>();
-    for (const groupId of distinctGroupIds) {
-      const { canAdmin } = await resolveGroupAdmin(auth.userId, groupId, tx);
-      if (canAdmin) adminGroups.add(groupId);
-    }
-
-    const unauthorized = rows.filter(
-      (r) =>
-        r.userId !== auth.userId && !approvableGroups.has(r.groupId) && !adminGroups.has(r.groupId)
-    );
-    if (unauthorized.length > 0) {
-      throw new AppError({
-        code: 403,
-        message: "You are not allowed to cancel one or more of these vacations",
-        logging: true,
-        context: { auth, unauthorized: unauthorized.map((r) => r.id) },
-      });
-    }
-
-    await assertGroupsWritable(distinctGroupIds, tx);
-
-    const updated = await services.vacation.cancelVacationsBulk(uniqueIds, auth.userId, tx);
-
-    await services.vacationEvent.createVacationEvents(
-      updated.map((row) => ({
-        id: generateRandomUUID(),
-        vacationId: row.id,
-        eventType: vacationEventType.Cancelled,
-        actorUserId: auth.userId,
-        reason: data.reason ?? null,
-      })),
-      tx
-    );
-
-    // The pre-cancellation rows still carry `approvedAt`, which the notifier
-    // needs to decide whether a cancellation is worth an email.
-    return rows;
+  const cancelled = await cancelRequestBatch({
+    auth,
+    vacationIds: data.ids,
+    reason: data.reason ?? null,
   });
-
-  // Post-commit and best-effort; the notifier logs its own failures.
-  await notifyVacationsCancelled(
-    cancelled,
-    { id: auth.userId, name: auth.userName },
-    data.reason ?? null
-  );
 
   return res.status(200).json({
     message: "Vacations cancelled",

--- a/src/controllers/vacation/handleBulkCancelVacation.ts
+++ b/src/controllers/vacation/handleBulkCancelVacation.ts
@@ -8,7 +8,7 @@ import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationsCancelled } from "../../services/vacation/vacationNotifier.js";
 import { assertGroupsWritable } from "../../services/billing/guards.js";
-import { resolveGroupAdmin } from "../groupUser/utils.js";
+import { resolveGroupAdmin } from "../../services/groupUser/groupAccess.js";
 
 const services = createDBServices();
 

--- a/src/controllers/vacation/handleBulkRejectVacation.ts
+++ b/src/controllers/vacation/handleBulkRejectVacation.ts
@@ -7,7 +7,7 @@ import type { ValidatedBulkRejectVacationType } from "../../services/vacation/ty
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
-import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
+import { assertMayDecide, assertStillPending } from "../../services/vacation/decisionGuards.js";
 import { assertGroupsWritable } from "../../services/billing/guards.js";
 
 const services = createDBServices();

--- a/src/controllers/vacation/handleBulkRejectVacation.ts
+++ b/src/controllers/vacation/handleBulkRejectVacation.ts
@@ -1,81 +1,19 @@
 import type { Request, Response } from "express";
-import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
-import AppError from "../../utils/appError.js";
-import { db } from "../../db/db.js";
 import type { ValidatedBulkRejectVacationType } from "../../services/vacation/types.js";
-import { generateRandomUUID } from "../../utils/generateUUID.js";
-import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
-import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
-import { assertMayDecide, assertStillPending } from "../../services/vacation/decisionGuards.js";
-import { assertGroupsWritable } from "../../services/billing/guards.js";
-
-const services = createDBServices();
+import { rejectRequestBatch } from "../../services/vacation/vacationTransitions.js";
 
 export const handleBulkRejectVacation = async (req: Request, res: Response) => {
   const auth = getAuth(req);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const data: ValidatedBulkRejectVacationType = req.body;
-  const uniqueIds = Array.from(new Set(data.ids));
 
-  const rejected = await db.transaction(async (tx) => {
-    const rows = await services.vacation.getVacationsByIds(uniqueIds, tx);
-
-    if (rows.length !== uniqueIds.length) {
-      throw new AppError({
-        code: 404,
-        message: "One or more vacations not found",
-        context: { auth, requested: uniqueIds.length, found: rows.length },
-      });
-    }
-
-    await assertMayDecide(auth.userId, rows, "reject", tx);
-    assertStillPending(rows);
-    await assertGroupsWritable(
-      rows.map((row) => row.groupId),
-      tx
-    );
-
-    const updated = await services.vacation.rejectVacationsBulk(
-      uniqueIds,
-      auth.userId,
-      data.reason ?? null,
-      tx
-    );
-
-    // A short update means a concurrent decision took part of the batch.
-    if (updated.length !== uniqueIds.length) {
-      throw new AppError({
-        code: 409,
-        message: "One or more of these requests has already been decided",
-        logging: true,
-        context: { auth, requested: uniqueIds, updated: updated.map((row) => row.id) },
-      });
-    }
-
-    await services.vacationEvent.createVacationEvents(
-      updated.map((row) => ({
-        id: generateRandomUUID(),
-        vacationId: row.id,
-        eventType: vacationEventType.Rejected,
-        actorUserId: auth.userId,
-        reason: data.reason ?? null,
-      })),
-      tx
-    );
-
-    return updated;
+  const rejected = await rejectRequestBatch({
+    auth,
+    vacationIds: data.ids,
+    reason: data.reason ?? null,
   });
-
-  // Post-commit and best-effort; the notifier logs its own failures. A bulk
-  // decision can span several requesters, so it fans out one mail per person.
-  await notifyVacationDecision(
-    rejected,
-    "rejected",
-    { id: auth.userId, name: auth.userName },
-    data.reason ?? null
-  );
 
   return res.status(200).json({
     message: "Vacations rejected",

--- a/src/controllers/vacation/handleDeleteVacation.ts
+++ b/src/controllers/vacation/handleDeleteVacation.ts
@@ -1,17 +1,8 @@
 import type { Request, Response } from "express";
-import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
 import { z } from "zod";
-import AppError from "../../utils/appError.js";
-import { db } from "../../db/db.js";
 import type { ValidatedCancelVacationType } from "../../services/vacation/types.js";
-import { generateRandomUUID } from "../../utils/generateUUID.js";
-import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
-import { resolveVacationPermissions } from "../../services/vacation/vacationPermissions.js";
-import { notifyVacationCancelled } from "../../services/vacation/vacationNotifier.js";
-import { assertGroupWritable } from "../../services/billing/guards.js";
-
-const services = createDBServices();
+import { cancelRequest } from "../../services/vacation/vacationTransitions.js";
 
 const validateUUID = z.uuid();
 
@@ -29,62 +20,7 @@ export const handleDeleteVacation = async (req: Request, res: Response) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const body: ValidatedCancelVacationType = req.body ?? {};
 
-  const cancelled = await db.transaction(async (tx) => {
-    const vacationData = await services.vacation.getVacationById(vacationId, tx);
-
-    if (!vacationData) {
-      throw new AppError({
-        code: 404,
-        message: "Vacation not found",
-        context: { auth, vacationId },
-      });
-    }
-
-    const permissions = await resolveVacationPermissions(auth.userId, vacationData, tx);
-
-    if (!permissions.canCancel) {
-      throw new AppError({
-        code: 403,
-        message: "You are not allowed to cancel this vacation",
-        logging: true,
-        context: { auth, vacationId },
-      });
-    }
-
-    await assertGroupWritable(vacationData.groupId, tx);
-
-    const deleted = await services.vacation.deleteVacation(vacationId, auth.userId, tx);
-    if (!deleted) {
-      throw new AppError({
-        code: 500,
-        message: "Failed to cancel vacation",
-        logging: true,
-        context: { auth, vacationId },
-      });
-    }
-
-    await services.vacationEvent.createVacationEvent(
-      {
-        id: generateRandomUUID(),
-        vacationId,
-        eventType: vacationEventType.Cancelled,
-        actorUserId: auth.userId,
-        reason: body.reason ?? null,
-      },
-      tx
-    );
-
-    return vacationData;
-  });
-
-  // Post-commit and best-effort; the notifier logs its own failures. Only
-  // already-approved days are worth an email — it passes the pre-cancellation
-  // row so it can tell.
-  await notifyVacationCancelled(
-    cancelled,
-    { id: auth.userId, name: auth.userName },
-    body.reason ?? null
-  );
+  await cancelRequest({ auth, vacationId, reason: body.reason ?? null });
 
   return res.status(200).json({ message: "Vacation cancelled" });
 };

--- a/src/controllers/vacation/handleDeleteVacation.ts
+++ b/src/controllers/vacation/handleDeleteVacation.ts
@@ -7,7 +7,7 @@ import { db } from "../../db/db.js";
 import type { ValidatedCancelVacationType } from "../../services/vacation/types.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
-import { resolveVacationPermissions } from "./utils.js";
+import { resolveVacationPermissions } from "../../services/vacation/vacationPermissions.js";
 import { notifyVacationCancelled } from "../../services/vacation/vacationNotifier.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
 

--- a/src/controllers/vacation/handleGetVacation.ts
+++ b/src/controllers/vacation/handleGetVacation.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
 import AppError from "../../utils/appError.js";
-import { resolveVacationPermissions } from "./utils.js";
+import { resolveVacationPermissions } from "../../services/vacation/vacationPermissions.js";
 
 const services = createDBServices();
 

--- a/src/controllers/vacation/handleGetVacations.ts
+++ b/src/controllers/vacation/handleGetVacations.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { createDBServices } from "../../services/DBServices.js";
 import { canViewWholeGroup } from "../../services/report/reportScope.js";
 import AppError from "../../utils/appError.js";
-import { resolveCanApproveForList } from "./utils.js";
+import { resolveCanApproveForList } from "../../services/vacation/vacationPermissions.js";
 
 const services = createDBServices();
 

--- a/src/controllers/vacation/handlePostVacation.ts
+++ b/src/controllers/vacation/handlePostVacation.ts
@@ -18,7 +18,7 @@ import {
 } from "../../services/vacation/vacationNotifier.js";
 import { assertRequestWithinQuota } from "../../services/vacation/quotaGuard.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
-import { assertGroupAdmin } from "../groupUser/utils.js";
+import { assertGroupAdmin } from "../../services/groupUser/groupAccess.js";
 
 const services = createDBServices();
 

--- a/src/controllers/vacation/handlePostVacationApproval.ts
+++ b/src/controllers/vacation/handlePostVacationApproval.ts
@@ -1,18 +1,8 @@
 import type { Request, Response } from "express";
-import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
 import { z } from "zod";
-import AppError from "../../utils/appError.js";
-import { db } from "../../db/db.js";
-import { generateRandomUUID } from "../../utils/generateUUID.js";
-import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
-import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
 import type { ValidatedApproveVacationType } from "../../services/vacation/types.js";
-import { assertApprovalWithinQuota } from "../../services/vacation/quotaGuard.js";
-import { assertMayDecide, assertStillPending } from "../../services/vacation/decisionGuards.js";
-import { assertGroupWritable } from "../../services/billing/guards.js";
-
-const services = createDBServices();
+import { approveRequest } from "../../services/vacation/vacationTransitions.js";
 
 const validateUUID = z.uuid();
 
@@ -24,55 +14,7 @@ export const handlePostVacationApproval = async (req: Request, res: Response) =>
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const body: ValidatedApproveVacationType = req.body ?? {};
 
-  const approved = await db.transaction(async (tx) => {
-    const vacationData = await services.vacation.getVacationById(vacationId, tx);
-    if (!vacationData) {
-      throw new AppError({
-        code: 404,
-        message: "Vacation not found",
-        context: { auth, vacationId },
-      });
-    }
-
-    await assertMayDecide(auth.userId, [vacationData], "approve", tx);
-    assertStillPending([vacationData]);
-    await assertGroupWritable(vacationData.groupId, tx);
-    await assertApprovalWithinQuota([vacationData], tx);
-
-    const row = await services.vacation.approveVacation(vacationId, auth.userId, tx);
-
-    // Lost race: decided between the read above and this update.
-    if (!row) {
-      throw new AppError({
-        code: 409,
-        message: "This request has already been decided",
-        logging: true,
-        context: { auth, vacationId },
-      });
-    }
-
-    await services.vacationEvent.createVacationEvent(
-      {
-        id: generateRandomUUID(),
-        vacationId,
-        eventType: vacationEventType.Approved,
-        actorUserId: auth.userId,
-        reason: body.reason ?? null,
-      },
-      tx
-    );
-
-    return row;
-  });
-
-  // Post-commit and best-effort: the notifier logs its own failures so a mail
-  // problem cannot turn a completed approval into an error for the approver.
-  if (approved) {
-    await notifyVacationDecision([approved], "approved", {
-      id: auth.userId,
-      name: auth.userName,
-    });
-  }
+  await approveRequest({ auth, vacationId, reason: body.reason ?? null });
 
   return res.status(200).json({ message: "Vacation approved" });
 };

--- a/src/controllers/vacation/handlePostVacationApproval.ts
+++ b/src/controllers/vacation/handlePostVacationApproval.ts
@@ -9,7 +9,7 @@ import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
 import type { ValidatedApproveVacationType } from "../../services/vacation/types.js";
 import { assertApprovalWithinQuota } from "../../services/vacation/quotaGuard.js";
-import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
+import { assertMayDecide, assertStillPending } from "../../services/vacation/decisionGuards.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
 
 const services = createDBServices();

--- a/src/controllers/vacation/handlePostVacationComment.ts
+++ b/src/controllers/vacation/handlePostVacationComment.ts
@@ -7,7 +7,7 @@ import { db } from "../../db/db.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
 import { notifyVacationComment } from "../../services/vacation/vacationNotifier.js";
-import { resolveVacationPermissions } from "./utils.js";
+import { resolveVacationPermissions } from "../../services/vacation/vacationPermissions.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
 import type { ValidatedCommentVacationType } from "../../services/vacation/types.js";
 

--- a/src/controllers/vacation/handlePostVacationComment.ts
+++ b/src/controllers/vacation/handlePostVacationComment.ts
@@ -1,17 +1,8 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
-import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
-import AppError from "../../utils/appError.js";
-import { db } from "../../db/db.js";
-import { generateRandomUUID } from "../../utils/generateUUID.js";
-import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
-import { notifyVacationComment } from "../../services/vacation/vacationNotifier.js";
-import { resolveVacationPermissions } from "../../services/vacation/vacationPermissions.js";
-import { assertGroupWritable } from "../../services/billing/guards.js";
 import type { ValidatedCommentVacationType } from "../../services/vacation/types.js";
-
-const services = createDBServices();
+import { commentOnRequest } from "../../services/vacation/vacationTransitions.js";
 
 /**
  * Appends a comment to a request timeline without changing its decision. Any
@@ -26,44 +17,7 @@ export const handlePostVacationComment = async (req: Request, res: Response) => 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const body: ValidatedCommentVacationType = req.body;
 
-  const commented = await db.transaction(async (tx) => {
-    const vacationData = await services.vacation.getVacationById(vacationId, tx);
-    if (!vacationData) {
-      throw new AppError({
-        code: 404,
-        message: "Vacation not found",
-        context: { auth, vacationId },
-      });
-    }
-
-    const permissions = await resolveVacationPermissions(auth.userId, vacationData, tx);
-    if (!permissions.canView) {
-      throw new AppError({
-        code: 403,
-        message: "You are not allowed to comment on this vacation",
-        logging: true,
-        context: { userId: auth.userId, vacationId },
-      });
-    }
-
-    await assertGroupWritable(vacationData.groupId, tx);
-
-    await services.vacationEvent.createVacationEvent(
-      {
-        id: generateRandomUUID(),
-        vacationId,
-        eventType: vacationEventType.Comment,
-        actorUserId: auth.userId,
-        reason: body.message,
-      },
-      tx
-    );
-
-    return vacationData;
-  });
-
-  // Post-commit and best-effort: notify the other party of the new comment.
-  await notifyVacationComment(commented, { id: auth.userId, name: auth.userName }, body.message);
+  await commentOnRequest({ auth, vacationId, message: body.message });
 
   return res.status(200).json({ message: "Comment added" });
 };

--- a/src/controllers/vacation/handlePostVacationReject.ts
+++ b/src/controllers/vacation/handlePostVacationReject.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import AppError from "../../utils/appError.js";
 import { db } from "../../db/db.js";
 import type { ValidatedRejectVacationType } from "../../services/vacation/types.js";
-import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
+import { assertMayDecide, assertStillPending } from "../../services/vacation/decisionGuards.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { vacationEventType } from "../../db/schema/vacation-event-schema.js";

--- a/src/controllers/vacation/handlePostVacationReject.ts
+++ b/src/controllers/vacation/handlePostVacationReject.ts
@@ -1,17 +1,8 @@
 import type { Request, Response } from "express";
-import { createDBServices } from "../../services/DBServices.js";
 import { getAuth } from "../../middleware/authSession.js";
 import { z } from "zod";
-import AppError from "../../utils/appError.js";
-import { db } from "../../db/db.js";
 import type { ValidatedRejectVacationType } from "../../services/vacation/types.js";
-import { assertMayDecide, assertStillPending } from "../../services/vacation/decisionGuards.js";
-import { assertGroupWritable } from "../../services/billing/guards.js";
-import { generateRandomUUID } from "../../utils/generateUUID.js";
-import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
-import { notifyVacationDecision } from "../../services/vacation/vacationNotifier.js";
-
-const services = createDBServices();
+import { rejectRequest } from "../../services/vacation/vacationTransitions.js";
 
 const validateUUID = z.uuid();
 
@@ -23,61 +14,7 @@ export const handlePostVacationReject = async (req: Request, res: Response) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const body: ValidatedRejectVacationType = req.body ?? {};
 
-  const rejected = await db.transaction(async (tx) => {
-    const vacationData = await services.vacation.getVacationById(vacationId, tx);
-    if (!vacationData) {
-      throw new AppError({
-        code: 404,
-        message: "Vacation not found",
-        context: { auth, vacationId },
-      });
-    }
-
-    await assertMayDecide(auth.userId, [vacationData], "reject", tx);
-    assertStillPending([vacationData]);
-    await assertGroupWritable(vacationData.groupId, tx);
-
-    const row = await services.vacation.rejectVacation(
-      vacationId,
-      auth.userId,
-      body.reason ?? null,
-      tx
-    );
-
-    // Lost race: decided between the read above and this update.
-    if (!row) {
-      throw new AppError({
-        code: 409,
-        message: "This request has already been decided",
-        logging: true,
-        context: { auth, vacationId },
-      });
-    }
-
-    await services.vacationEvent.createVacationEvent(
-      {
-        id: generateRandomUUID(),
-        vacationId,
-        eventType: vacationEventType.Rejected,
-        actorUserId: auth.userId,
-        reason: body.reason ?? null,
-      },
-      tx
-    );
-
-    return row;
-  });
-
-  // Post-commit and best-effort: the notifier logs its own failures so a mail
-  // problem cannot turn a completed rejection into an error for the approver.
-  if (rejected) {
-    await notifyVacationDecision(
-      [rejected],
-      "rejected",
-      { id: auth.userId, name: auth.userName },
-      body.reason ?? null
-    );
-  }
+  await rejectRequest({ auth, vacationId, reason: body.reason ?? null });
 
   return res.status(200).json({ message: "Vacation rejected" });
 };

--- a/src/controllers/vacation/handleUpdateVacation.ts
+++ b/src/controllers/vacation/handleUpdateVacation.ts
@@ -10,7 +10,7 @@ import type { VacationUpdatePatch } from "../../services/vacation/vacationServic
 import { describeVacationChanges } from "../../services/vacation/vacationChangeDetail.js";
 import { assertEditWithinQuota } from "../../services/vacation/quotaGuard.js";
 import { assertGroupWritable } from "../../services/billing/guards.js";
-import { resolveGroupAdmin } from "../groupUser/utils.js";
+import { resolveGroupAdmin } from "../../services/groupUser/groupAccess.js";
 import { notifyVacationUpdated } from "../../services/vacation/vacationNotifier.js";
 
 const services = createDBServices();

--- a/src/controllers/vacation/tests/handleBulkCancelVacation.test.ts
+++ b/src/controllers/vacation/tests/handleBulkCancelVacation.test.ts
@@ -26,7 +26,7 @@ const {
   mockResolveGroupAdmin: vi.fn(),
 }));
 
-vi.mock("../../groupUser/utils.js", () => ({
+vi.mock("../../../services/groupUser/groupAccess.js", () => ({
   resolveGroupAdmin: mockResolveGroupAdmin,
 }));
 

--- a/src/controllers/vacation/tests/handleDeleteVacation.test.ts
+++ b/src/controllers/vacation/tests/handleDeleteVacation.test.ts
@@ -24,7 +24,7 @@ const {
   mockResolveGroupAdmin: vi.fn(),
 }));
 
-vi.mock("../../groupUser/utils.js", () => ({
+vi.mock("../../../services/groupUser/groupAccess.js", () => ({
   resolveGroupAdmin: mockResolveGroupAdmin,
 }));
 

--- a/src/controllers/vacation/tests/handleGetVacation.test.ts
+++ b/src/controllers/vacation/tests/handleGetVacation.test.ts
@@ -14,7 +14,7 @@ const {
   mockResolveGroupAdmin: vi.fn(),
 }));
 
-vi.mock("../../groupUser/utils.js", () => ({
+vi.mock("../../../services/groupUser/groupAccess.js", () => ({
   resolveGroupAdmin: mockResolveGroupAdmin,
 }));
 

--- a/src/controllers/vacation/tests/handlePostVacation.test.ts
+++ b/src/controllers/vacation/tests/handlePostVacation.test.ts
@@ -36,7 +36,7 @@ const {
   mockGetUserById: vi.fn(),
 }));
 
-vi.mock("../../groupUser/utils.js", () => ({
+vi.mock("../../../services/groupUser/groupAccess.js", () => ({
   assertGroupAdmin: mockAssertGroupAdmin,
 }));
 

--- a/src/controllers/vacation/tests/handlePostVacationComment.test.ts
+++ b/src/controllers/vacation/tests/handlePostVacationComment.test.ts
@@ -33,7 +33,7 @@ vi.mock("../../../services/DBServices.js", () => ({
   }),
 }));
 
-vi.mock("../utils.js", () => ({
+vi.mock("../../../services/vacation/vacationPermissions.js", () => ({
   resolveVacationPermissions: mockResolvePermissions,
 }));
 

--- a/src/controllers/vacation/tests/handleUpdateVacation.test.ts
+++ b/src/controllers/vacation/tests/handleUpdateVacation.test.ts
@@ -32,7 +32,7 @@ vi.mock("../../../middleware/authSession.js", () => ({
   getAuth: vi.fn(),
 }));
 
-vi.mock("../../groupUser/utils.js", () => ({
+vi.mock("../../../services/groupUser/groupAccess.js", () => ({
   resolveGroupAdmin: mockResolveGroupAdmin,
 }));
 

--- a/src/services/groupUser/groupAccess.ts
+++ b/src/services/groupUser/groupAccess.ts
@@ -1,16 +1,13 @@
-import {
-  getAdminGroupIdsForUser,
-  getGroupUser,
-} from "../../services/groupUser/groupUserServices.js";
+import { getAdminGroupIdsForUser, getGroupUser } from "./groupUserServices.js";
 import {
   filterGroupIdsByOrganization,
   getGroup,
   getLiveGroupIdsForOrganizations,
-} from "../../services/group/groupServices.js";
+} from "../group/groupServices.js";
 import {
   getAdminOrganizationsForUser,
   isOrganizationAdmin,
-} from "../../services/organization/organizationServices.js";
+} from "../organization/organizationServices.js";
 import type { DbTransaction } from "../../db/db.js";
 import AppError from "../../utils/appError.js";
 

--- a/src/services/vacation/decisionGuards.ts
+++ b/src/services/vacation/decisionGuards.ts
@@ -5,7 +5,7 @@ import type { VacationType } from "./types.js";
 
 const services = createDBServices();
 
-type Decision = "approve" | "reject";
+export type Decision = "approve" | "reject";
 
 /**
  * Whether the actor may decide on their *own* request in this group. Only the

--- a/src/services/vacation/decisionGuards.ts
+++ b/src/services/vacation/decisionGuards.ts
@@ -1,7 +1,7 @@
 import AppError from "../../utils/appError.js";
 import type { DbTransaction } from "../../db/db.js";
-import { createDBServices } from "../../services/DBServices.js";
-import type { VacationType } from "../../services/vacation/types.js";
+import { createDBServices } from "../DBServices.js";
+import type { VacationType } from "./types.js";
 
 const services = createDBServices();
 

--- a/src/services/vacation/tests/vacationTransitions.test.ts
+++ b/src/services/vacation/tests/vacationTransitions.test.ts
@@ -9,6 +9,8 @@ const {
   mockApproveVacationsBulk,
   mockRejectVacation,
   mockRejectVacationsBulk,
+  mockDeleteVacation,
+  mockCancelVacationsBulk,
   mockCreateVacationEvent,
   mockCreateVacationEvents,
   mockGetGroupsWhereUserCanApprove,
@@ -16,7 +18,12 @@ const {
   mockHasMirrorIntoGroup,
   mockAssertApprovalWithinQuota,
   mockAssertGroupsWritable,
+  mockResolveGroupAdmin,
+  mockResolveVacationPermissions,
   mockNotifyVacationDecision,
+  mockNotifyVacationCancelled,
+  mockNotifyVacationsCancelled,
+  mockNotifyVacationComment,
 } = vi.hoisted(() => ({
   timeline: [] as string[],
   tx: {},
@@ -26,6 +33,8 @@ const {
   mockApproveVacationsBulk: vi.fn(),
   mockRejectVacation: vi.fn(),
   mockRejectVacationsBulk: vi.fn(),
+  mockDeleteVacation: vi.fn(),
+  mockCancelVacationsBulk: vi.fn(),
   mockCreateVacationEvent: vi.fn(),
   mockCreateVacationEvents: vi.fn(),
   mockGetGroupsWhereUserCanApprove: vi.fn(),
@@ -33,7 +42,12 @@ const {
   mockHasMirrorIntoGroup: vi.fn(),
   mockAssertApprovalWithinQuota: vi.fn(),
   mockAssertGroupsWritable: vi.fn(),
+  mockResolveGroupAdmin: vi.fn(),
+  mockResolveVacationPermissions: vi.fn(),
   mockNotifyVacationDecision: vi.fn(),
+  mockNotifyVacationCancelled: vi.fn(),
+  mockNotifyVacationsCancelled: vi.fn(),
+  mockNotifyVacationComment: vi.fn(),
 }));
 
 vi.mock("../../../db/db.js", () => ({
@@ -55,6 +69,8 @@ vi.mock("../../DBServices.js", () => ({
       approveVacationsBulk: mockApproveVacationsBulk,
       rejectVacation: mockRejectVacation,
       rejectVacationsBulk: mockRejectVacationsBulk,
+      deleteVacation: mockDeleteVacation,
+      cancelVacationsBulk: mockCancelVacationsBulk,
     },
     vacationEvent: {
       createVacationEvent: mockCreateVacationEvent,
@@ -75,13 +91,30 @@ vi.mock("../quotaGuard.js", () => ({
   assertApprovalWithinQuota: mockAssertApprovalWithinQuota,
 }));
 
+vi.mock("../../groupUser/groupAccess.js", () => ({
+  resolveGroupAdmin: mockResolveGroupAdmin,
+}));
+
+// Only the per-record resolver is stubbed; the set-based cancel verdict runs
+// for real against the mocked services, so its query count stays under test.
+vi.mock("../vacationPermissions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../vacationPermissions.js")>()),
+  resolveVacationPermissions: mockResolveVacationPermissions,
+}));
+
 vi.mock("../vacationNotifier.js", () => ({
   notifyVacationDecision: mockNotifyVacationDecision,
+  notifyVacationCancelled: mockNotifyVacationCancelled,
+  notifyVacationsCancelled: mockNotifyVacationsCancelled,
+  notifyVacationComment: mockNotifyVacationComment,
 }));
 
 import {
   approveRequest,
   approveRequestBatch,
+  cancelRequest,
+  cancelRequestBatch,
+  commentOnRequest,
   rejectRequest,
   rejectRequestBatch,
 } from "../vacationTransitions.js";
@@ -89,6 +122,7 @@ import { mockAuthData } from "../../../tests/testUtils.js";
 
 const FIRST_ID = "550e8400-e29b-41d4-a716-446655440000";
 const SECOND_ID = "550e8400-e29b-41d4-a716-446655440001";
+const THIRD_ID = "550e8400-e29b-41d4-a716-446655440002";
 
 const pendingVacation = (over: Record<string, unknown> = {}) => ({
   id: FIRST_ID,
@@ -120,10 +154,15 @@ describe("vacationTransitions", () => {
     mockHasMirrorIntoGroup.mockResolvedValue(false);
     mockAssertApprovalWithinQuota.mockResolvedValue(undefined);
     mockAssertGroupsWritable.mockResolvedValue(undefined);
+    mockResolveGroupAdmin.mockResolvedValue({ canAdmin: false, viaOrgAdmin: false });
+    mockResolveVacationPermissions.mockResolvedValue({ canView: true });
 
     mockCreateVacationEvent.mockImplementation(trackedResolve("event", undefined));
     mockCreateVacationEvents.mockImplementation(trackedResolve("event", []));
     mockNotifyVacationDecision.mockImplementation(trackedResolve("notify", undefined));
+    mockNotifyVacationCancelled.mockImplementation(trackedResolve("notify", undefined));
+    mockNotifyVacationsCancelled.mockImplementation(trackedResolve("notify", undefined));
+    mockNotifyVacationComment.mockImplementation(trackedResolve("notify", undefined));
   });
 
   describe("ordering", () => {
@@ -383,6 +422,257 @@ describe("vacationTransitions", () => {
 
       expect(mockGetVacationsByIds).toHaveBeenCalledWith([FIRST_ID], tx);
       expect(mockApproveVacationsBulk).toHaveBeenCalledWith([FIRST_ID], "user_123", tx);
+    });
+  });
+  describe("cancellation", () => {
+    const approvedVacation = (over: Record<string, unknown> = {}) =>
+      pendingVacation({ approvedAt: new Date("2026-08-01T09:00:00Z"), ...over });
+
+    it("appends the cancellation event inside the transaction and notifies after it commits", async () => {
+      mockGetVacationById.mockResolvedValue(approvedVacation());
+      mockDeleteVacation.mockImplementation(
+        trackedResolve("mutate", approvedVacation({ deletedAt: new Date() }))
+      );
+
+      await cancelRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null });
+
+      expect(timeline).toEqual(["mutate", "event", "commit", "notify"]);
+    });
+
+    // The cancelled row has no `approvedAt` left, and the notifier reads it to
+    // decide whether the cancellation is worth an email at all.
+    it("notifies with the row as it stood before the cancellation", async () => {
+      const before = approvedVacation();
+      mockGetVacationById.mockResolvedValue(before);
+      mockDeleteVacation.mockResolvedValue(
+        pendingVacation({ deletedAt: new Date(), approvedAt: null })
+      );
+
+      await cancelRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: "Trip called off" });
+
+      expect(mockNotifyVacationCancelled).toHaveBeenCalledWith(
+        before,
+        { id: "user_123", name: "Test User" },
+        "Trip called off"
+      );
+      expect(mockCreateVacationEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          vacationId: FIRST_ID,
+          eventType: "CANCELLED",
+          actorUserId: "user_123",
+          reason: "Trip called off",
+        }),
+        tx
+      );
+    });
+
+    it("notifies a batch with the pre-cancellation rows", async () => {
+      const rows = [approvedVacation(), approvedVacation({ id: SECOND_ID })];
+      mockGetVacationsByIds.mockResolvedValue(rows);
+      mockCancelVacationsBulk.mockResolvedValue(
+        rows.map((row) => ({ ...row, deletedAt: new Date() }))
+      );
+
+      await cancelRequestBatch({
+        auth: mockAuthData,
+        vacationIds: [FIRST_ID, SECOND_ID],
+        reason: "Plans changed",
+      });
+
+      expect(mockNotifyVacationsCancelled).toHaveBeenCalledWith(
+        rows,
+        { id: "user_123", name: "Test User" },
+        "Plans changed"
+      );
+    });
+
+    it("answers a lost single cancel with its own 500 wording", async () => {
+      mockGetVacationById.mockResolvedValue(approvedVacation());
+      mockDeleteVacation.mockResolvedValue(undefined);
+
+      await expect(
+        cancelRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null })
+      ).rejects.toThrow("Failed to cancel vacation");
+
+      expect(mockCreateVacationEvent).not.toHaveBeenCalled();
+      expect(mockNotifyVacationCancelled).not.toHaveBeenCalled();
+    });
+
+    // Preserved as it stands: the batch route runs no lost-race check, so its
+    // count reports the rows it loaded even when the update moved fewer.
+    it("runs no lost-race check on a batch, and counts what it loaded", async () => {
+      const rows = [approvedVacation(), approvedVacation({ id: SECOND_ID })];
+      mockGetVacationsByIds.mockResolvedValue(rows);
+      mockCancelVacationsBulk.mockResolvedValue([{ ...rows[0], deletedAt: new Date() }]);
+
+      const cancelled = await cancelRequestBatch({
+        auth: mockAuthData,
+        vacationIds: [FIRST_ID, SECOND_ID],
+        reason: null,
+      });
+
+      expect(cancelled).toHaveLength(2);
+      expect(mockCreateVacationEvents).toHaveBeenCalledWith(
+        [expect.objectContaining({ vacationId: FIRST_ID, eventType: "CANCELLED" })],
+        tx
+      );
+    });
+
+    it("lets the owner cancel a request they hold no approver standing over", async () => {
+      mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
+      mockGetVacationById.mockResolvedValue(approvedVacation({ userId: "user_123" }));
+      mockDeleteVacation.mockResolvedValue(approvedVacation({ deletedAt: new Date() }));
+
+      await cancelRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null });
+
+      expect(mockDeleteVacation).toHaveBeenCalledWith(FIRST_ID, "user_123", tx);
+    });
+
+    it("lets a group admin cancel someone else's request", async () => {
+      mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
+      mockResolveGroupAdmin.mockResolvedValue({ canAdmin: true, viaOrgAdmin: true });
+      mockGetVacationById.mockResolvedValue(approvedVacation());
+      mockDeleteVacation.mockResolvedValue(approvedVacation({ deletedAt: new Date() }));
+
+      await cancelRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null });
+
+      expect(mockDeleteVacation).toHaveBeenCalled();
+    });
+
+    it("refuses a plain member cancelling someone else's request", async () => {
+      mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
+      mockGetVacationById.mockResolvedValue(approvedVacation());
+
+      await expect(
+        cancelRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null })
+      ).rejects.toThrow("You are not allowed to cancel this vacation");
+
+      expect(mockDeleteVacation).not.toHaveBeenCalled();
+    });
+
+    it("keeps the bulk wording when a batch holds a request the caller may not cancel", async () => {
+      mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
+      mockGetVacationsByIds.mockResolvedValue([approvedVacation()]);
+
+      await expect(
+        cancelRequestBatch({ auth: mockAuthData, vacationIds: [FIRST_ID], reason: null })
+      ).rejects.toThrow("You are not allowed to cancel one or more of these vacations");
+
+      expect(mockCancelVacationsBulk).not.toHaveBeenCalled();
+    });
+
+    // The per-record resolver would have run this once per row inside an open
+    // transaction holding row locks; the set-based one runs it once per group.
+    it("resolves approver and admin standing once per distinct group", async () => {
+      mockGetGroupsWhereUserCanApprove.mockResolvedValue(["group_123", "group_456"]);
+      const rows = [
+        approvedVacation(),
+        approvedVacation({ id: SECOND_ID }),
+        approvedVacation({ id: THIRD_ID, groupId: "group_456" }),
+      ];
+      mockGetVacationsByIds.mockResolvedValue(rows);
+      mockCancelVacationsBulk.mockResolvedValue(rows);
+
+      await cancelRequestBatch({
+        auth: mockAuthData,
+        vacationIds: [FIRST_ID, SECOND_ID, THIRD_ID],
+        reason: null,
+      });
+
+      expect(mockGetGroupsWhereUserCanApprove).toHaveBeenCalledTimes(1);
+      expect(mockGetGroupsWhereUserCanApprove).toHaveBeenCalledWith(
+        ["group_123", "group_456"],
+        "user_123",
+        tx
+      );
+      expect(mockResolveGroupAdmin).toHaveBeenCalledTimes(2);
+    });
+
+    it("cancels an already-approved request, and runs no quota guard doing it", async () => {
+      mockGetVacationById.mockResolvedValue(approvedVacation());
+      mockDeleteVacation.mockResolvedValue(approvedVacation({ deletedAt: new Date() }));
+
+      await cancelRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null });
+
+      expect(mockDeleteVacation).toHaveBeenCalled();
+      expect(mockAssertApprovalWithinQuota).not.toHaveBeenCalled();
+    });
+
+    it("uses the single-record not-found wording", async () => {
+      mockGetVacationById.mockResolvedValue(undefined);
+
+      await expect(
+        cancelRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null })
+      ).rejects.toThrow("Vacation not found");
+    });
+  });
+
+  describe("comment", () => {
+    it("appends the comment inside the transaction, changing no vacation row", async () => {
+      mockGetVacationById.mockResolvedValue(pendingVacation());
+
+      await commentOnRequest({
+        auth: mockAuthData,
+        vacationId: FIRST_ID,
+        message: "Any update on this?",
+      });
+
+      expect(timeline).toEqual(["event", "commit", "notify"]);
+      expect(mockCreateVacationEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          vacationId: FIRST_ID,
+          eventType: "COMMENT",
+          actorUserId: "user_123",
+          reason: "Any update on this?",
+        }),
+        tx
+      );
+      expect(mockDeleteVacation).not.toHaveBeenCalled();
+      expect(mockApproveVacation).not.toHaveBeenCalled();
+      expect(mockRejectVacation).not.toHaveBeenCalled();
+    });
+
+    it("notifies with the row it loaded", async () => {
+      const row = pendingVacation();
+      mockGetVacationById.mockResolvedValue(row);
+
+      await commentOnRequest({ auth: mockAuthData, vacationId: FIRST_ID, message: "Bumping this" });
+
+      expect(mockNotifyVacationComment).toHaveBeenCalledWith(
+        row,
+        { id: "user_123", name: "Test User" },
+        "Bumping this"
+      );
+    });
+
+    it("refuses a caller who may not view the request", async () => {
+      mockGetVacationById.mockResolvedValue(pendingVacation());
+      mockResolveVacationPermissions.mockResolvedValue({ canView: false });
+
+      await expect(
+        commentOnRequest({ auth: mockAuthData, vacationId: FIRST_ID, message: "Hello" })
+      ).rejects.toThrow("You are not allowed to comment on this vacation");
+
+      expect(mockCreateVacationEvent).not.toHaveBeenCalled();
+      expect(mockNotifyVacationComment).not.toHaveBeenCalled();
+    });
+
+    it("uses the single-record not-found wording", async () => {
+      mockGetVacationById.mockResolvedValue(undefined);
+
+      await expect(
+        commentOnRequest({ auth: mockAuthData, vacationId: FIRST_ID, message: "Hello" })
+      ).rejects.toThrow("Vacation not found");
+
+      expect(mockResolveVacationPermissions).not.toHaveBeenCalled();
+    });
+
+    it("runs no quota guard", async () => {
+      mockGetVacationById.mockResolvedValue(pendingVacation());
+
+      await commentOnRequest({ auth: mockAuthData, vacationId: FIRST_ID, message: "Hello" });
+
+      expect(mockAssertApprovalWithinQuota).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/services/vacation/tests/vacationTransitions.test.ts
+++ b/src/services/vacation/tests/vacationTransitions.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  timeline,
+  tx,
+  mockGetVacationById,
+  mockGetVacationsByIds,
+  mockApproveVacation,
+  mockApproveVacationsBulk,
+  mockRejectVacation,
+  mockRejectVacationsBulk,
+  mockCreateVacationEvent,
+  mockCreateVacationEvents,
+  mockGetGroupsWhereUserCanApprove,
+  mockGetGroupUser,
+  mockHasMirrorIntoGroup,
+  mockAssertApprovalWithinQuota,
+  mockAssertGroupsWritable,
+  mockNotifyVacationDecision,
+} = vi.hoisted(() => ({
+  timeline: [] as string[],
+  tx: {},
+  mockGetVacationById: vi.fn(),
+  mockGetVacationsByIds: vi.fn(),
+  mockApproveVacation: vi.fn(),
+  mockApproveVacationsBulk: vi.fn(),
+  mockRejectVacation: vi.fn(),
+  mockRejectVacationsBulk: vi.fn(),
+  mockCreateVacationEvent: vi.fn(),
+  mockCreateVacationEvents: vi.fn(),
+  mockGetGroupsWhereUserCanApprove: vi.fn(),
+  mockGetGroupUser: vi.fn(),
+  mockHasMirrorIntoGroup: vi.fn(),
+  mockAssertApprovalWithinQuota: vi.fn(),
+  mockAssertGroupsWritable: vi.fn(),
+  mockNotifyVacationDecision: vi.fn(),
+}));
+
+vi.mock("../../../db/db.js", () => ({
+  db: {
+    transaction: vi.fn(async (callback: (handle: unknown) => Promise<unknown>) => {
+      const result = await callback(tx);
+      timeline.push("commit");
+      return result;
+    }),
+  },
+}));
+
+vi.mock("../../DBServices.js", () => ({
+  createDBServices: () => ({
+    vacation: {
+      getVacationById: mockGetVacationById,
+      getVacationsByIds: mockGetVacationsByIds,
+      approveVacation: mockApproveVacation,
+      approveVacationsBulk: mockApproveVacationsBulk,
+      rejectVacation: mockRejectVacation,
+      rejectVacationsBulk: mockRejectVacationsBulk,
+    },
+    vacationEvent: {
+      createVacationEvent: mockCreateVacationEvent,
+      createVacationEvents: mockCreateVacationEvents,
+    },
+    group: { getGroupsWhereUserCanApprove: mockGetGroupsWhereUserCanApprove },
+    groupUser: { getGroupUser: mockGetGroupUser },
+    groupMirror: { hasMirrorIntoGroup: mockHasMirrorIntoGroup },
+  }),
+}));
+
+vi.mock("../../billing/guards.js", () => ({
+  assertGroupWritable: vi.fn(),
+  assertGroupsWritable: mockAssertGroupsWritable,
+}));
+
+vi.mock("../quotaGuard.js", () => ({
+  assertApprovalWithinQuota: mockAssertApprovalWithinQuota,
+}));
+
+vi.mock("../vacationNotifier.js", () => ({
+  notifyVacationDecision: mockNotifyVacationDecision,
+}));
+
+import {
+  approveRequest,
+  approveRequestBatch,
+  rejectRequest,
+  rejectRequestBatch,
+} from "../vacationTransitions.js";
+import { mockAuthData } from "../../../tests/testUtils.js";
+
+const FIRST_ID = "550e8400-e29b-41d4-a716-446655440000";
+const SECOND_ID = "550e8400-e29b-41d4-a716-446655440001";
+
+const pendingVacation = (over: Record<string, unknown> = {}) => ({
+  id: FIRST_ID,
+  userId: "vacation_user_123",
+  groupId: "group_123",
+  requestedDay: "2024-03-15",
+  vacationType: "VACATION",
+  halfDay: false,
+  approvedAt: null,
+  rejectedAt: null,
+  deletedAt: null,
+  ...over,
+});
+
+/** Records where each step happened relative to the commit. */
+const trackedResolve = <T>(step: string, value: T) =>
+  vi.fn(() => {
+    timeline.push(step);
+    return Promise.resolve(value);
+  });
+
+describe("vacationTransitions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    timeline.length = 0;
+
+    mockGetGroupsWhereUserCanApprove.mockResolvedValue(["group_123"]);
+    mockGetGroupUser.mockResolvedValue({ approverAccess: false });
+    mockHasMirrorIntoGroup.mockResolvedValue(false);
+    mockAssertApprovalWithinQuota.mockResolvedValue(undefined);
+    mockAssertGroupsWritable.mockResolvedValue(undefined);
+
+    mockCreateVacationEvent.mockImplementation(trackedResolve("event", undefined));
+    mockCreateVacationEvents.mockImplementation(trackedResolve("event", []));
+    mockNotifyVacationDecision.mockImplementation(trackedResolve("notify", undefined));
+  });
+
+  describe("ordering", () => {
+    it("appends the event inside the transaction and notifies only after it commits", async () => {
+      mockGetVacationById.mockResolvedValue(pendingVacation());
+      mockApproveVacation.mockImplementation(
+        trackedResolve("mutate", pendingVacation({ approvedAt: new Date() }))
+      );
+
+      await approveRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null });
+
+      expect(timeline).toEqual(["mutate", "event", "commit", "notify"]);
+    });
+
+    it("appends the events inside the transaction on the bulk path too", async () => {
+      mockGetVacationsByIds.mockResolvedValue([pendingVacation()]);
+      mockApproveVacationsBulk.mockImplementation(
+        trackedResolve("mutate", [pendingVacation({ approvedAt: new Date() })])
+      );
+
+      await approveRequestBatch({ auth: mockAuthData, vacationIds: [FIRST_ID] });
+
+      expect(timeline).toEqual(["mutate", "event", "commit", "notify"]);
+    });
+
+    it("does not notify when the transaction throws", async () => {
+      mockGetVacationsByIds.mockResolvedValue([pendingVacation()]);
+      mockApproveVacationsBulk.mockRejectedValue(new Error("Failed to update vacation"));
+
+      await expect(
+        approveRequestBatch({ auth: mockAuthData, vacationIds: [FIRST_ID] })
+      ).rejects.toThrow("Failed to update vacation");
+
+      expect(mockNotifyVacationDecision).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("authorization", () => {
+    it("prevents any mutation when the caller may not decide on the group", async () => {
+      mockGetVacationById.mockResolvedValue(pendingVacation());
+      mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
+
+      await expect(
+        approveRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null })
+      ).rejects.toThrow("You are not allowed to approve one or more of these requests");
+
+      expect(mockApproveVacation).not.toHaveBeenCalled();
+      expect(mockCreateVacationEvent).not.toHaveBeenCalled();
+      expect(mockNotifyVacationDecision).not.toHaveBeenCalled();
+    });
+
+    it("prevents any mutation when the caller is deciding on their own request", async () => {
+      mockGetVacationsByIds.mockResolvedValue([pendingVacation({ userId: "user_123" })]);
+
+      await expect(
+        rejectRequestBatch({ auth: mockAuthData, vacationIds: [FIRST_ID], reason: null })
+      ).rejects.toThrow("You cannot decide on your own leave request");
+
+      expect(mockRejectVacationsBulk).not.toHaveBeenCalled();
+      expect(mockCreateVacationEvents).not.toHaveBeenCalled();
+      expect(mockNotifyVacationDecision).not.toHaveBeenCalled();
+    });
+
+    it("refuses a request that was already decided before any mutation runs", async () => {
+      mockGetVacationById.mockResolvedValue(pendingVacation({ approvedAt: new Date() }));
+
+      await expect(
+        approveRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null })
+      ).rejects.toThrow("This request has already been decided");
+
+      expect(mockApproveVacation).not.toHaveBeenCalled();
+    });
+
+    it("refuses to write to a group the plan has turned read-only", async () => {
+      mockGetVacationById.mockResolvedValue(pendingVacation());
+      mockAssertGroupsWritable.mockRejectedValue(
+        new Error("This group is read-only on your current plan")
+      );
+
+      await expect(
+        approveRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null })
+      ).rejects.toThrow("This group is read-only on your current plan");
+
+      expect(mockApproveVacation).not.toHaveBeenCalled();
+    });
+
+    it("stops an approval that would exceed the requester's allowance", async () => {
+      mockGetVacationById.mockResolvedValue(pendingVacation());
+      mockAssertApprovalWithinQuota.mockRejectedValue(
+        new Error("This would exceed the allowance for that leave type")
+      );
+
+      await expect(
+        approveRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null })
+      ).rejects.toThrow("This would exceed the allowance for that leave type");
+
+      expect(mockApproveVacation).not.toHaveBeenCalled();
+    });
+
+    it("runs no quota guard on the reject path", async () => {
+      mockGetVacationById.mockResolvedValue(pendingVacation());
+      mockRejectVacation.mockResolvedValue(pendingVacation({ rejectedAt: new Date() }));
+
+      await rejectRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null });
+
+      expect(mockAssertApprovalWithinQuota).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("wording", () => {
+    it("uses the single-record not-found message for a single approval", async () => {
+      mockGetVacationById.mockResolvedValue(undefined);
+
+      await expect(
+        approveRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null })
+      ).rejects.toThrow("Vacation not found");
+    });
+
+    it("uses the bulk not-found message for a batch approval", async () => {
+      mockGetVacationsByIds.mockResolvedValue([pendingVacation()]);
+
+      await expect(
+        approveRequestBatch({ auth: mockAuthData, vacationIds: [FIRST_ID, SECOND_ID] })
+      ).rejects.toThrow("One or more vacations not found");
+    });
+
+    it("uses the single-record conflict message when a single approval loses the race", async () => {
+      mockGetVacationById.mockResolvedValue(pendingVacation());
+      mockApproveVacation.mockResolvedValue(undefined);
+
+      await expect(
+        approveRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null })
+      ).rejects.toThrow("This request has already been decided");
+
+      expect(mockCreateVacationEvent).not.toHaveBeenCalled();
+    });
+
+    it("uses the bulk conflict message when a batch rejection loses the race", async () => {
+      mockGetVacationsByIds.mockResolvedValue([
+        pendingVacation(),
+        pendingVacation({ id: SECOND_ID }),
+      ]);
+      mockRejectVacationsBulk.mockResolvedValue([pendingVacation({ rejectedAt: new Date() })]);
+
+      await expect(
+        rejectRequestBatch({
+          auth: mockAuthData,
+          vacationIds: [FIRST_ID, SECOND_ID],
+          reason: null,
+        })
+      ).rejects.toThrow("One or more of these requests has already been decided");
+
+      expect(mockCreateVacationEvents).not.toHaveBeenCalled();
+    });
+
+    // The wording belongs to the route, not to how many ids happened to arrive.
+    it("keeps the bulk wording for a batch carrying exactly one id", async () => {
+      mockGetVacationsByIds.mockResolvedValue([pendingVacation()]);
+      mockApproveVacationsBulk.mockResolvedValue([]);
+
+      await expect(
+        approveRequestBatch({ auth: mockAuthData, vacationIds: [FIRST_ID] })
+      ).rejects.toThrow("One or more of these requests has already been decided");
+    });
+
+    it("keeps the bulk not-found wording for a batch carrying exactly one id", async () => {
+      mockGetVacationsByIds.mockResolvedValue([]);
+
+      await expect(
+        approveRequestBatch({ auth: mockAuthData, vacationIds: [FIRST_ID] })
+      ).rejects.toThrow("One or more vacations not found");
+    });
+  });
+
+  describe("event and notification payloads", () => {
+    it("stamps an approval event with the approver's note", async () => {
+      mockGetVacationById.mockResolvedValue(pendingVacation());
+      const approved = pendingVacation({ approvedAt: new Date() });
+      mockApproveVacation.mockResolvedValue(approved);
+
+      await approveRequest({
+        auth: mockAuthData,
+        vacationId: FIRST_ID,
+        reason: "Enjoy the break",
+      });
+
+      expect(mockCreateVacationEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          vacationId: FIRST_ID,
+          eventType: "APPROVED",
+          actorUserId: "user_123",
+          reason: "Enjoy the break",
+        }),
+        tx
+      );
+      expect(mockNotifyVacationDecision).toHaveBeenCalledWith(
+        [approved],
+        "approved",
+        { id: "user_123", name: "Test User" },
+        null
+      );
+    });
+
+    it("carries the rejection reason onto the event and the notification", async () => {
+      mockGetVacationById.mockResolvedValue(pendingVacation());
+      const rejected = pendingVacation({ rejectedAt: new Date() });
+      mockRejectVacation.mockResolvedValue(rejected);
+
+      await rejectRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: "Too busy" });
+
+      expect(mockRejectVacation).toHaveBeenCalledWith(FIRST_ID, "user_123", "Too busy", tx);
+      expect(mockCreateVacationEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ eventType: "REJECTED", reason: "Too busy" }),
+        tx
+      );
+      expect(mockNotifyVacationDecision).toHaveBeenCalledWith(
+        [rejected],
+        "rejected",
+        { id: "user_123", name: "Test User" },
+        "Too busy"
+      );
+    });
+
+    it("appends one event per row on a batch rejection", async () => {
+      const rows = [pendingVacation(), pendingVacation({ id: SECOND_ID })];
+      mockGetVacationsByIds.mockResolvedValue(rows);
+      mockRejectVacationsBulk.mockResolvedValue(rows);
+
+      await rejectRequestBatch({
+        auth: mockAuthData,
+        vacationIds: [FIRST_ID, SECOND_ID],
+        reason: "Coverage gap",
+      });
+
+      expect(mockCreateVacationEvents).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            vacationId: FIRST_ID,
+            eventType: "REJECTED",
+            reason: "Coverage gap",
+          }),
+          expect.objectContaining({
+            vacationId: SECOND_ID,
+            eventType: "REJECTED",
+            reason: "Coverage gap",
+          }),
+        ],
+        tx
+      );
+    });
+
+    it("deduplicates the ids a batch was given", async () => {
+      mockGetVacationsByIds.mockResolvedValue([pendingVacation()]);
+      mockApproveVacationsBulk.mockResolvedValue([pendingVacation({ approvedAt: new Date() })]);
+
+      await approveRequestBatch({ auth: mockAuthData, vacationIds: [FIRST_ID, FIRST_ID] });
+
+      expect(mockGetVacationsByIds).toHaveBeenCalledWith([FIRST_ID], tx);
+      expect(mockApproveVacationsBulk).toHaveBeenCalledWith([FIRST_ID], "user_123", tx);
+    });
+  });
+});

--- a/src/services/vacation/vacationPermissions.ts
+++ b/src/services/vacation/vacationPermissions.ts
@@ -55,6 +55,36 @@ export const resolveVacationPermissions = async (
   };
 };
 
+/** A row a live-only reader returned — never a soft-deleted one. */
+type LiveVacationRow = Pick<VacationType, "userId" | "groupId">;
+
+/**
+ * The same `canCancel` verdict as {@link resolveVacationPermissions}, for a
+ * whole list in a fixed number of queries — the per-record form would turn a
+ * fifty-record cancel into hundreds of queries inside an open transaction
+ * holding row locks. It carries no cancelled-row term, so the rows must come
+ * from a reader that excludes them.
+ */
+export const resolveCanCancelForList = async <T extends LiveVacationRow>(
+  userId: string,
+  rows: T[],
+  tx?: DbTransaction
+): Promise<(row: T) => boolean> => {
+  const groupIds = Array.from(new Set(rows.map((row) => row.groupId)));
+  const approvable = new Set(
+    await services.group.getGroupsWhereUserCanApprove(groupIds, userId, tx)
+  );
+
+  const adminGroups = new Set<string>();
+  for (const groupId of groupIds) {
+    const { canAdmin } = await resolveGroupAdmin(userId, groupId, tx);
+    if (canAdmin) adminGroups.add(groupId);
+  }
+
+  return (row) =>
+    row.userId === userId || approvable.has(row.groupId) || adminGroups.has(row.groupId);
+};
+
 type DecidableRow = Pick<
   VacationType,
   "userId" | "groupId" | "deletedAt" | "approvedAt" | "rejectedAt"

--- a/src/services/vacation/vacationPermissions.ts
+++ b/src/services/vacation/vacationPermissions.ts
@@ -1,8 +1,8 @@
-import { createDBServices } from "../../services/DBServices.js";
+import { createDBServices } from "../DBServices.js";
 import type { DbTransaction } from "../../db/db.js";
-import type { VacationType } from "../../services/vacation/types.js";
+import type { VacationType } from "./types.js";
 import { mayDecideOwn } from "./decisionGuards.js";
-import { resolveGroupAdmin } from "../groupUser/utils.js";
+import { resolveGroupAdmin } from "../groupUser/groupAccess.js";
 
 const services = createDBServices();
 

--- a/src/services/vacation/vacationPermissions.ts
+++ b/src/services/vacation/vacationPermissions.ts
@@ -60,7 +60,8 @@ type LiveVacationRow = Pick<VacationType, "userId" | "groupId">;
 
 /**
  * The same `canCancel` verdict as {@link resolveVacationPermissions}, for a
- * whole list in a fixed number of queries — the per-record form would turn a
+ * whole list in a number of queries that scales with the distinct groups in the
+ * batch rather than with its rows — the per-record form would turn a
  * fifty-record cancel into hundreds of queries inside an open transaction
  * holding row locks. It carries no cancelled-row term, so the rows must come
  * from a reader that excludes them.
@@ -92,7 +93,8 @@ type DecidableRow = Pick<
 
 /**
  * The same `canApprove` verdict as {@link resolveVacationPermissions}, for a
- * whole list in a fixed number of queries.
+ * whole list in a number of queries that scales with the distinct groups in the
+ * batch rather than with its rows.
  */
 export const resolveCanApproveForList = async <T extends DecidableRow>(
   userId: string,

--- a/src/services/vacation/vacationTransitions.ts
+++ b/src/services/vacation/vacationTransitions.ts
@@ -194,7 +194,14 @@ const mayComment =
     // cannot fire. It throws rather than returns so that a guard can never
     // fail open if that ordering ever changes.
     const row = rows[0];
-    if (!row) throw new Error("mayComment called with no vacation row");
+    if (!row) {
+      throw new AppError({
+        code: 500,
+        message: "Failed to add comment",
+        logging: true,
+        context: { auth, vacationId },
+      });
+    }
 
     const permissions = await resolveVacationPermissions(auth.userId, row, tx);
     if (!permissions.canView) {

--- a/src/services/vacation/vacationTransitions.ts
+++ b/src/services/vacation/vacationTransitions.ts
@@ -5,14 +5,31 @@ import AppError from "../../utils/appError.js";
 import { generateRandomUUID } from "../../utils/generateUUID.js";
 import { createDBServices } from "../DBServices.js";
 import { assertGroupsWritable } from "../billing/guards.js";
-import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
+import { assertMayDecide, assertStillPending, type Decision } from "./decisionGuards.js";
 import { assertApprovalWithinQuota } from "./quotaGuard.js";
 import type { VacationType } from "./types.js";
-import { notifyVacationDecision } from "./vacationNotifier.js";
+import {
+  notifyVacationCancelled,
+  notifyVacationComment,
+  notifyVacationDecision,
+  notifyVacationsCancelled,
+} from "./vacationNotifier.js";
+import { resolveCanCancelForList, resolveVacationPermissions } from "./vacationPermissions.js";
 
 const services = createDBServices();
 
-type Decision = "approve" | "reject";
+const actorOf = (auth: AuthSession) => ({ id: auth.userId, name: auth.userName });
+
+/**
+ * The two views of a transition's rows. They part company on the routes that
+ * mail about what a record *was*: a cancellation notice reads the approval
+ * stamp the cancellation has just cleared.
+ */
+type TransitionRows = {
+  loaded: VacationType[];
+  /** What the mutation returned — the loaded rows when there is no mutation. */
+  changed: VacationType[];
+};
 
 /**
  * What one transition supplies to the engine. Everything absent here — the
@@ -29,11 +46,15 @@ type Transition = {
   authorize: (rows: VacationType[], tx: DbTransaction) => Promise<void>;
   /** Only the approving transitions have one. */
   assertWithinQuota?: (rows: VacationType[], tx: DbTransaction) => Promise<void>;
-  mutate: (tx: DbTransaction) => Promise<VacationType[]>;
-  /** This route's own wording for a mutation that moved fewer rows than it loaded. */
-  lostRace: (updated: VacationType[]) => AppError;
+  /** Absent on a comment, which changes no vacation row at all. */
+  mutate?: (tx: DbTransaction) => Promise<VacationType[]>;
+  /**
+   * This route's own wording for a mutation that moved fewer rows than it
+   * loaded. Absent where the route runs no such check.
+   */
+  lostRace?: (updated: VacationType[]) => AppError;
   appendEvents: (updated: VacationType[], tx: DbTransaction) => Promise<void>;
-  notify: (updated: VacationType[]) => Promise<void>;
+  notify: (rows: TransitionRows) => Promise<void>;
 };
 
 /**
@@ -41,29 +62,31 @@ type Transition = {
  * what keeps the event in the same transaction as the change it records, and
  * the mail strictly after that transaction commits.
  */
-const runTransition = async (transition: Transition): Promise<VacationType[]> => {
-  const updated = await db.transaction(async (tx) => {
-    const rows = await transition.load(tx);
-    if (rows.length !== transition.requestedCount) throw transition.notFound(rows);
+const runTransition = async (transition: Transition): Promise<TransitionRows> => {
+  const rows = await db.transaction(async (tx) => {
+    const loaded = await transition.load(tx);
+    if (loaded.length !== transition.requestedCount) throw transition.notFound(loaded);
 
-    await transition.authorize(rows, tx);
+    await transition.authorize(loaded, tx);
     await assertGroupsWritable(
-      rows.map((row) => row.groupId),
+      loaded.map((row) => row.groupId),
       tx
     );
-    await transition.assertWithinQuota?.(rows, tx);
+    await transition.assertWithinQuota?.(loaded, tx);
 
-    const changed = await transition.mutate(tx);
-    if (changed.length !== rows.length) throw transition.lostRace(changed);
+    const changed = (await transition.mutate?.(tx)) ?? loaded;
+    if (transition.lostRace && changed.length !== loaded.length) {
+      throw transition.lostRace(changed);
+    }
 
     await transition.appendEvents(changed, tx);
-    return changed;
+    return { loaded, changed };
   });
 
   // Best-effort: the notifier logs its own failures so a mail problem cannot
   // turn a completed decision into an error for the approver.
-  await transition.notify(updated);
-  return updated;
+  await transition.notify(rows);
+  return rows;
 };
 
 const loadOne =
@@ -152,17 +175,56 @@ const appendEventsInOneInsert =
 // mail per person.
 const notifyDecision =
   (auth: AuthSession, decision: "approved" | "rejected", reason: string | null) =>
-  (updated: VacationType[]): Promise<void> =>
-    notifyVacationDecision(updated, decision, { id: auth.userId, name: auth.userName }, reason);
+  ({ changed }: TransitionRows): Promise<void> =>
+    notifyVacationDecision(changed, decision, actorOf(auth), reason);
 
-export const approveRequest = (params: {
+const mayCancel =
+  (auth: AuthSession, forbidden: (unauthorized: VacationType[]) => AppError) =>
+  async (rows: VacationType[], tx: DbTransaction): Promise<void> => {
+    const canCancel = await resolveCanCancelForList(auth.userId, rows, tx);
+
+    const unauthorized = rows.filter((row) => !canCancel(row));
+    if (unauthorized.length > 0) throw forbidden(unauthorized);
+  };
+
+const mayComment =
+  (auth: AuthSession, vacationId: string) =>
+  async (rows: VacationType[], tx: DbTransaction): Promise<void> => {
+    // The engine has already thrown a not-found for a short load, so this
+    // cannot fire. It throws rather than returns so that a guard can never
+    // fail open if that ordering ever changes.
+    const row = rows[0];
+    if (!row) throw new Error("mayComment called with no vacation row");
+
+    const permissions = await resolveVacationPermissions(auth.userId, row, tx);
+    if (!permissions.canView) {
+      throw new AppError({
+        code: 403,
+        message: "You are not allowed to comment on this vacation",
+        logging: true,
+        context: { userId: auth.userId, vacationId },
+      });
+    }
+  };
+
+// The single-record notifiers take a row rather than an array. The empty case
+// is unreachable — a short load has already thrown — but the index type says
+// otherwise.
+const notifyFirstLoaded =
+  (notifier: (row: VacationType) => Promise<void>) =>
+  ({ loaded }: TransitionRows): Promise<void> => {
+    const row = loaded[0];
+    return row ? notifier(row) : Promise.resolve();
+  };
+
+export const approveRequest = async (params: {
   auth: AuthSession;
   vacationId: string;
   reason: string | null;
 }): Promise<VacationType[]> => {
   const { auth, vacationId, reason } = params;
 
-  return runTransition({
+  const { changed } = await runTransition({
     load: loadOne(vacationId),
     requestedCount: 1,
     notFound: oneNotFound(auth, vacationId),
@@ -177,16 +239,18 @@ export const approveRequest = (params: {
     // An approval carries its note to the timeline, never to the mail.
     notify: notifyDecision(auth, "approved", null),
   });
+
+  return changed;
 };
 
-export const approveRequestBatch = (params: {
+export const approveRequestBatch = async (params: {
   auth: AuthSession;
   vacationIds: string[];
 }): Promise<VacationType[]> => {
   const { auth } = params;
   const vacationIds = Array.from(new Set(params.vacationIds));
 
-  return runTransition({
+  const { changed } = await runTransition({
     load: loadMany(vacationIds),
     requestedCount: vacationIds.length,
     notFound: someNotFound(auth, vacationIds),
@@ -197,16 +261,18 @@ export const approveRequestBatch = (params: {
     appendEvents: appendEventsInOneInsert(auth, vacationEventType.Approved, null),
     notify: notifyDecision(auth, "approved", null),
   });
+
+  return changed;
 };
 
-export const rejectRequest = (params: {
+export const rejectRequest = async (params: {
   auth: AuthSession;
   vacationId: string;
   reason: string | null;
 }): Promise<VacationType[]> => {
   const { auth, vacationId, reason } = params;
 
-  return runTransition({
+  const { changed } = await runTransition({
     load: loadOne(vacationId),
     requestedCount: 1,
     notFound: oneNotFound(auth, vacationId),
@@ -219,9 +285,11 @@ export const rejectRequest = (params: {
     appendEvents: appendEventsRowByRow(auth, vacationEventType.Rejected, reason),
     notify: notifyDecision(auth, "rejected", reason),
   });
+
+  return changed;
 };
 
-export const rejectRequestBatch = (params: {
+export const rejectRequestBatch = async (params: {
   auth: AuthSession;
   vacationIds: string[];
   reason: string | null;
@@ -229,7 +297,7 @@ export const rejectRequestBatch = (params: {
   const { auth, reason } = params;
   const vacationIds = Array.from(new Set(params.vacationIds));
 
-  return runTransition({
+  const { changed } = await runTransition({
     load: loadMany(vacationIds),
     requestedCount: vacationIds.length,
     notFound: someNotFound(auth, vacationIds),
@@ -238,5 +306,97 @@ export const rejectRequestBatch = (params: {
     lostRace: someAlreadyDecided(auth, vacationIds),
     appendEvents: appendEventsInOneInsert(auth, vacationEventType.Rejected, reason),
     notify: notifyDecision(auth, "rejected", reason),
+  });
+
+  return changed;
+};
+
+export const cancelRequest = async (params: {
+  auth: AuthSession;
+  vacationId: string;
+  reason: string | null;
+}): Promise<void> => {
+  const { auth, vacationId, reason } = params;
+
+  await runTransition({
+    load: loadOne(vacationId),
+    requestedCount: 1,
+    notFound: oneNotFound(auth, vacationId),
+    authorize: mayCancel(
+      auth,
+      () =>
+        new AppError({
+          code: 403,
+          message: "You are not allowed to cancel this vacation",
+          logging: true,
+          context: { auth, vacationId },
+        })
+    ),
+    mutate: async (tx) => {
+      const row = await services.vacation.deleteVacation(vacationId, auth.userId, tx);
+      return row ? [row] : [];
+    },
+    // Answering a lost race with a 500 is what this route does today; its
+    // siblings answer 409.
+    lostRace: () =>
+      new AppError({
+        code: 500,
+        message: "Failed to cancel vacation",
+        logging: true,
+        context: { auth, vacationId },
+      }),
+    appendEvents: appendEventsRowByRow(auth, vacationEventType.Cancelled, reason),
+    // The cancelled row no longer carries the approval stamp the notifier reads
+    // to decide whether the cancellation is worth an email.
+    notify: notifyFirstLoaded((row) => notifyVacationCancelled(row, actorOf(auth), reason)),
+  });
+};
+
+export const cancelRequestBatch = async (params: {
+  auth: AuthSession;
+  vacationIds: string[];
+  reason: string | null;
+}): Promise<VacationType[]> => {
+  const { auth, reason } = params;
+  const vacationIds = Array.from(new Set(params.vacationIds));
+
+  // No `lostRace`: this route runs no such check today, so its count reports
+  // the rows it loaded even when the update moved fewer.
+  const { loaded } = await runTransition({
+    load: loadMany(vacationIds),
+    requestedCount: vacationIds.length,
+    notFound: someNotFound(auth, vacationIds),
+    authorize: mayCancel(
+      auth,
+      (unauthorized) =>
+        new AppError({
+          code: 403,
+          message: "You are not allowed to cancel one or more of these vacations",
+          logging: true,
+          context: { auth, unauthorized: unauthorized.map((row) => row.id) },
+        })
+    ),
+    mutate: (tx) => services.vacation.cancelVacationsBulk(vacationIds, auth.userId, tx),
+    appendEvents: appendEventsInOneInsert(auth, vacationEventType.Cancelled, reason),
+    notify: ({ loaded: rows }) => notifyVacationsCancelled(rows, actorOf(auth), reason),
+  });
+
+  return loaded;
+};
+
+export const commentOnRequest = async (params: {
+  auth: AuthSession;
+  vacationId: string;
+  message: string;
+}): Promise<void> => {
+  const { auth, vacationId, message } = params;
+
+  await runTransition({
+    load: loadOne(vacationId),
+    requestedCount: 1,
+    notFound: oneNotFound(auth, vacationId),
+    authorize: mayComment(auth, vacationId),
+    appendEvents: appendEventsRowByRow(auth, vacationEventType.Comment, message),
+    notify: notifyFirstLoaded((row) => notifyVacationComment(row, actorOf(auth), message)),
   });
 };

--- a/src/services/vacation/vacationTransitions.ts
+++ b/src/services/vacation/vacationTransitions.ts
@@ -1,0 +1,242 @@
+import { db, type DbTransaction } from "../../db/db.js";
+import { vacationEventType } from "../../db/schema/vacation-event-schema.js";
+import type { AuthSession } from "../../middleware/authSession.js";
+import AppError from "../../utils/appError.js";
+import { generateRandomUUID } from "../../utils/generateUUID.js";
+import { createDBServices } from "../DBServices.js";
+import { assertGroupsWritable } from "../billing/guards.js";
+import { assertMayDecide, assertStillPending } from "./decisionGuards.js";
+import { assertApprovalWithinQuota } from "./quotaGuard.js";
+import type { VacationType } from "./types.js";
+import { notifyVacationDecision } from "./vacationNotifier.js";
+
+const services = createDBServices();
+
+type Decision = "approve" | "reject";
+
+/**
+ * What one transition supplies to the engine. Everything absent here — the
+ * transaction boundary, the not-found and lost-race comparisons, the plan
+ * writability check, and the ordering of the event append against the commit
+ * — belongs to the engine, and is therefore written once.
+ */
+type Transition = {
+  /** Rows named by the request that are still live; a short result is a not-found. */
+  load: (tx: DbTransaction) => Promise<VacationType[]>;
+  requestedCount: number;
+  /** This route's own wording for a load that came back short. */
+  notFound: (rows: VacationType[]) => AppError;
+  authorize: (rows: VacationType[], tx: DbTransaction) => Promise<void>;
+  /** Only the approving transitions have one. */
+  assertWithinQuota?: (rows: VacationType[], tx: DbTransaction) => Promise<void>;
+  mutate: (tx: DbTransaction) => Promise<VacationType[]>;
+  /** This route's own wording for a mutation that moved fewer rows than it loaded. */
+  lostRace: (updated: VacationType[]) => AppError;
+  appendEvents: (updated: VacationType[], tx: DbTransaction) => Promise<void>;
+  notify: (updated: VacationType[]) => Promise<void>;
+};
+
+/**
+ * The sequence every vacation transition follows. Holding it in one place is
+ * what keeps the event in the same transaction as the change it records, and
+ * the mail strictly after that transaction commits.
+ */
+const runTransition = async (transition: Transition): Promise<VacationType[]> => {
+  const updated = await db.transaction(async (tx) => {
+    const rows = await transition.load(tx);
+    if (rows.length !== transition.requestedCount) throw transition.notFound(rows);
+
+    await transition.authorize(rows, tx);
+    await assertGroupsWritable(
+      rows.map((row) => row.groupId),
+      tx
+    );
+    await transition.assertWithinQuota?.(rows, tx);
+
+    const changed = await transition.mutate(tx);
+    if (changed.length !== rows.length) throw transition.lostRace(changed);
+
+    await transition.appendEvents(changed, tx);
+    return changed;
+  });
+
+  // Best-effort: the notifier logs its own failures so a mail problem cannot
+  // turn a completed decision into an error for the approver.
+  await transition.notify(updated);
+  return updated;
+};
+
+const loadOne =
+  (vacationId: string) =>
+  async (tx: DbTransaction): Promise<VacationType[]> => {
+    const row = await services.vacation.getVacationById(vacationId, tx);
+    return row ? [row] : [];
+  };
+
+const loadMany =
+  (vacationIds: string[]) =>
+  (tx: DbTransaction): Promise<VacationType[]> =>
+    services.vacation.getVacationsByIds(vacationIds, tx);
+
+const oneNotFound = (auth: AuthSession, vacationId: string) => () =>
+  new AppError({
+    code: 404,
+    message: "Vacation not found",
+    context: { auth, vacationId },
+  });
+
+const someNotFound = (auth: AuthSession, vacationIds: string[]) => (rows: VacationType[]) =>
+  new AppError({
+    code: 404,
+    message: "One or more vacations not found",
+    context: { auth, requested: vacationIds.length, found: rows.length },
+  });
+
+const mayDecide =
+  (auth: AuthSession, decision: Decision) =>
+  async (rows: VacationType[], tx: DbTransaction): Promise<void> => {
+    await assertMayDecide(auth.userId, rows, decision, tx);
+    assertStillPending(rows);
+  };
+
+const oneAlreadyDecided = (auth: AuthSession, vacationId: string) => () =>
+  new AppError({
+    code: 409,
+    message: "This request has already been decided",
+    logging: true,
+    context: { auth, vacationId },
+  });
+
+const someAlreadyDecided =
+  (auth: AuthSession, vacationIds: string[]) => (updated: VacationType[]) =>
+    new AppError({
+      code: 409,
+      message: "One or more of these requests has already been decided",
+      logging: true,
+      context: { auth, requested: vacationIds, updated: updated.map((row) => row.id) },
+    });
+
+const appendEventsRowByRow =
+  (auth: AuthSession, eventType: vacationEventType, reason: string | null) =>
+  async (updated: VacationType[], tx: DbTransaction): Promise<void> => {
+    for (const row of updated) {
+      await services.vacationEvent.createVacationEvent(
+        {
+          id: generateRandomUUID(),
+          vacationId: row.id,
+          eventType,
+          actorUserId: auth.userId,
+          reason,
+        },
+        tx
+      );
+    }
+  };
+
+const appendEventsInOneInsert =
+  (auth: AuthSession, eventType: vacationEventType, reason: string | null) =>
+  async (updated: VacationType[], tx: DbTransaction): Promise<void> => {
+    await services.vacationEvent.createVacationEvents(
+      updated.map((row) => ({
+        id: generateRandomUUID(),
+        vacationId: row.id,
+        eventType,
+        actorUserId: auth.userId,
+        reason,
+      })),
+      tx
+    );
+  };
+
+// A bulk decision can span several requesters, so the notifier fans out one
+// mail per person.
+const notifyDecision =
+  (auth: AuthSession, decision: "approved" | "rejected", reason: string | null) =>
+  (updated: VacationType[]): Promise<void> =>
+    notifyVacationDecision(updated, decision, { id: auth.userId, name: auth.userName }, reason);
+
+export const approveRequest = (params: {
+  auth: AuthSession;
+  vacationId: string;
+  reason: string | null;
+}): Promise<VacationType[]> => {
+  const { auth, vacationId, reason } = params;
+
+  return runTransition({
+    load: loadOne(vacationId),
+    requestedCount: 1,
+    notFound: oneNotFound(auth, vacationId),
+    authorize: mayDecide(auth, "approve"),
+    assertWithinQuota: assertApprovalWithinQuota,
+    mutate: async (tx) => {
+      const row = await services.vacation.approveVacation(vacationId, auth.userId, tx);
+      return row ? [row] : [];
+    },
+    lostRace: oneAlreadyDecided(auth, vacationId),
+    appendEvents: appendEventsRowByRow(auth, vacationEventType.Approved, reason),
+    // An approval carries its note to the timeline, never to the mail.
+    notify: notifyDecision(auth, "approved", null),
+  });
+};
+
+export const approveRequestBatch = (params: {
+  auth: AuthSession;
+  vacationIds: string[];
+}): Promise<VacationType[]> => {
+  const { auth } = params;
+  const vacationIds = Array.from(new Set(params.vacationIds));
+
+  return runTransition({
+    load: loadMany(vacationIds),
+    requestedCount: vacationIds.length,
+    notFound: someNotFound(auth, vacationIds),
+    authorize: mayDecide(auth, "approve"),
+    assertWithinQuota: assertApprovalWithinQuota,
+    mutate: (tx) => services.vacation.approveVacationsBulk(vacationIds, auth.userId, tx),
+    lostRace: someAlreadyDecided(auth, vacationIds),
+    appendEvents: appendEventsInOneInsert(auth, vacationEventType.Approved, null),
+    notify: notifyDecision(auth, "approved", null),
+  });
+};
+
+export const rejectRequest = (params: {
+  auth: AuthSession;
+  vacationId: string;
+  reason: string | null;
+}): Promise<VacationType[]> => {
+  const { auth, vacationId, reason } = params;
+
+  return runTransition({
+    load: loadOne(vacationId),
+    requestedCount: 1,
+    notFound: oneNotFound(auth, vacationId),
+    authorize: mayDecide(auth, "reject"),
+    mutate: async (tx) => {
+      const row = await services.vacation.rejectVacation(vacationId, auth.userId, reason, tx);
+      return row ? [row] : [];
+    },
+    lostRace: oneAlreadyDecided(auth, vacationId),
+    appendEvents: appendEventsRowByRow(auth, vacationEventType.Rejected, reason),
+    notify: notifyDecision(auth, "rejected", reason),
+  });
+};
+
+export const rejectRequestBatch = (params: {
+  auth: AuthSession;
+  vacationIds: string[];
+  reason: string | null;
+}): Promise<VacationType[]> => {
+  const { auth, reason } = params;
+  const vacationIds = Array.from(new Set(params.vacationIds));
+
+  return runTransition({
+    load: loadMany(vacationIds),
+    requestedCount: vacationIds.length,
+    notFound: someNotFound(auth, vacationIds),
+    authorize: mayDecide(auth, "reject"),
+    mutate: (tx) => services.vacation.rejectVacationsBulk(vacationIds, auth.userId, reason, tx),
+    lostRace: someAlreadyDecided(auth, vacationIds),
+    appendEvents: appendEventsInOneInsert(auth, vacationEventType.Rejected, reason),
+    notify: notifyDecision(auth, "rejected", reason),
+  });
+};

--- a/src/tests/e2e/organizationAdmin.e2e.test.ts
+++ b/src/tests/e2e/organizationAdmin.e2e.test.ts
@@ -21,7 +21,7 @@ import {
   getAdministrableGroupIds,
   resolveGroupAdmin,
   validateUserGroupAccess,
-} from "../../controllers/groupUser/utils.js";
+} from "../../services/groupUser/groupAccess.js";
 
 /**
  * Org admins administer an organization's groups without belonging to them,

--- a/src/tests/e2e/vacationDecisions.e2e.test.ts
+++ b/src/tests/e2e/vacationDecisions.e2e.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import request from "supertest";
+import type { Response } from "supertest";
+import { eq, sql } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import {
+  setupTestEnvironment,
+  cleanupTestData,
+  createTestVacation,
+  type TestContext,
+} from "./helpers/testSetup.js";
+import { authCookieFor } from "./helpers/authHelper.js";
+import { db } from "../../db/db.js";
+import { vacation } from "../../db/schema/vacation-schema.js";
+import { vacationEvents, vacationEventType } from "../../db/schema/vacation-event-schema.js";
+import { groupUsers } from "../../db/schema/group-users-schema.js";
+import { session } from "../../db/schema/auth-schema.js";
+
+describe("Vacation decision routes E2E", () => {
+  let context: TestContext;
+  let approverCookie: string;
+
+  const eventsFor = async (vacationId: string) =>
+    db.select().from(vacationEvents).where(eq(vacationEvents.vacationId, vacationId));
+
+  const rowFor = async (vacationId: string) =>
+    (await db.select().from(vacation).where(eq(vacation.id, vacationId)))[0];
+
+  const messagesOf = (response: Response) =>
+    (response.body as { errors: { message: string }[] }).errors.map((error) => error.message);
+
+  /** Resolves once a backend is waiting on a lock held by `holderPid`, and no other. */
+  const waitUntilBlockedBy = async (holderPid: number) => {
+    for (let attempt = 0; attempt < 400; attempt++) {
+      const { rows } = await db.execute<{ waiting: number }>(
+        sql`select count(*)::int as waiting from pg_stat_activity
+            where pid <> pg_backend_pid() and ${holderPid} = any(pg_blocking_pids(pid))`
+      );
+      if ((rows[0]?.waiting ?? 0) > 0) return;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error("the request never blocked on the row lock held by the test");
+  };
+
+  /**
+   * Drives the lost-race branch. A held transaction decides the row without
+   * committing, so the request's snapshot read still sees it pending and clears
+   * every guard, and its UPDATE then blocks on the lock. Committing the decision
+   * makes that UPDATE re-check its predicate, skip the row and come back short —
+   * the only path to the bulk conflict wording.
+   */
+  const raceRequestAgainstDecision = async (
+    vacationId: string,
+    stamp: Partial<typeof vacation.$inferInsert>,
+    sendRequest: () => Promise<Response>
+  ): Promise<Response> => {
+    let announceLocked!: (holderPid: number) => void;
+    const locked = new Promise<number>((resolve) => (announceLocked = resolve));
+    let commit!: () => void;
+    const decided = new Promise<void>((resolve) => (commit = resolve));
+
+    const holder = db.transaction(async (tx) => {
+      const { rows } = await tx.execute<{ pid: number }>(sql`select pg_backend_pid() as pid`);
+      await tx.update(vacation).set(stamp).where(eq(vacation.id, vacationId));
+      announceLocked(rows[0]?.pid ?? 0);
+      await decided;
+    });
+
+    let pending: Promise<Response> | undefined;
+    try {
+      const holderPid = await Promise.race([
+        locked,
+        holder.then(() =>
+          Promise.reject(new Error("the holding transaction ended before the row was locked"))
+        ),
+      ]);
+      // supertest sends nothing until the request is awaited, so start it here.
+      pending = Promise.resolve(sendRequest());
+      await waitUntilBlockedBy(holderPid);
+      commit();
+      await holder;
+      return await pending;
+    } finally {
+      commit();
+      await holder.catch(() => undefined);
+      await pending?.catch(() => undefined);
+    }
+  };
+
+  beforeAll(async () => {
+    context = await setupTestEnvironment();
+  });
+
+  afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  beforeEach(async () => {
+    await db.delete(vacation);
+    await db.delete(groupUsers);
+    await db.delete(session);
+    approverCookie = await authCookieFor(context.approverUser.id);
+  });
+
+  describe("POST /api/vacation/reject/:id", () => {
+    let vacationId: string;
+
+    beforeEach(async () => {
+      vacationId = await createTestVacation(context.user1.id, context.group.id, "2025-12-24");
+    });
+
+    it("rejects the request, stamps the rejecter and records the reason on the timeline", async () => {
+      const response = await request(context.app)
+        .post(`/api/vacation/reject/${vacationId}`)
+        .set("Cookie", approverCookie)
+        .send({ reason: "the team is short that week" })
+        .expect(200);
+
+      expect(response.body).toEqual({ message: "Vacation rejected" });
+
+      const row = await rowFor(vacationId);
+      expect(row?.rejectedAt).not.toBeNull();
+      expect(row?.rejectedBy).toBe(context.approverUser.id);
+      expect(row?.rejectionReason).toBe("the team is short that week");
+      expect(row?.approvedAt).toBeNull();
+
+      const events = await eventsFor(vacationId);
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        eventType: vacationEventType.Rejected,
+        actorUserId: context.approverUser.id,
+        reason: "the team is short that week",
+      });
+    });
+
+    it("returns 403 for a caller with no approver standing in the group", async () => {
+      const cookie = await authCookieFor(context.user2.id);
+
+      const response = await request(context.app)
+        .post(`/api/vacation/reject/${vacationId}`)
+        .set("Cookie", cookie)
+        .send({ reason: "no" })
+        .expect(403);
+
+      expect(messagesOf(response)).toEqual([
+        "You are not allowed to reject one or more of these requests",
+      ]);
+
+      const row = await rowFor(vacationId);
+      expect(row?.rejectedAt).toBeNull();
+      expect(await eventsFor(vacationId)).toHaveLength(0);
+    });
+
+    it("returns 409 with the single-record wording once the request is decided", async () => {
+      await db
+        .update(vacation)
+        .set({
+          rejectedAt: new Date(),
+          rejectedBy: context.approverUser.id,
+          rejectionReason: "first",
+        })
+        .where(eq(vacation.id, vacationId));
+
+      const response = await request(context.app)
+        .post(`/api/vacation/reject/${vacationId}`)
+        .set("Cookie", approverCookie)
+        .send({ reason: "second" })
+        .expect(409);
+
+      expect(messagesOf(response)).toEqual(["This request has already been decided"]);
+
+      expect((await rowFor(vacationId))?.rejectionReason).toBe("first");
+      expect(await eventsFor(vacationId)).toHaveLength(0);
+    });
+
+    it("returns 404 for an id that does not exist", async () => {
+      const response = await request(context.app)
+        .post(`/api/vacation/reject/${uuidv4()}`)
+        .set("Cookie", approverCookie)
+        .send({ reason: "no" })
+        .expect(404);
+
+      expect(messagesOf(response)).toEqual(["Vacation not found"]);
+    });
+  });
+
+  describe("POST /api/vacation/approve", () => {
+    let ids: string[];
+
+    beforeEach(async () => {
+      ids = [
+        await createTestVacation(context.user1.id, context.group.id, "2025-12-22"),
+        await createTestVacation(context.user1.id, context.group.id, "2025-12-23"),
+        await createTestVacation(context.user2.id, context.group.id, "2025-12-22"),
+      ];
+    });
+
+    it("approves every record in the batch and appends one event per record", async () => {
+      const response = await request(context.app)
+        .post("/api/vacation/approve")
+        .set("Cookie", approverCookie)
+        .send({ ids })
+        .expect(200);
+
+      expect(response.body).toEqual({ message: "Vacations approved", approvedCount: 3 });
+
+      for (const id of ids) {
+        const row = await rowFor(id);
+        expect(row?.approvedAt).not.toBeNull();
+        expect(row?.approvedBy).toBe(context.approverUser.id);
+
+        const events = await eventsFor(id);
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+          eventType: vacationEventType.Approved,
+          actorUserId: context.approverUser.id,
+          reason: null,
+        });
+      }
+    });
+
+    it("approves a batch carrying exactly one id", async () => {
+      const id = ids[0] ?? "";
+
+      const response = await request(context.app)
+        .post("/api/vacation/approve")
+        .set("Cookie", approverCookie)
+        .send({ ids: [id] })
+        .expect(200);
+
+      expect(response.body).toEqual({ message: "Vacations approved", approvedCount: 1 });
+      expect((await rowFor(id))?.approvedAt).not.toBeNull();
+      expect((await rowFor(ids[1] ?? ""))?.approvedAt).toBeNull();
+    });
+
+    it("returns 403 for a caller with no approver standing in the group", async () => {
+      const cookie = await authCookieFor(context.user2.id);
+      const othersIds = [ids[0] ?? "", ids[1] ?? ""];
+
+      const response = await request(context.app)
+        .post("/api/vacation/approve")
+        .set("Cookie", cookie)
+        .send({ ids: othersIds })
+        .expect(403);
+
+      expect(messagesOf(response)).toEqual([
+        "You are not allowed to approve one or more of these requests",
+      ]);
+
+      for (const id of othersIds) {
+        expect((await rowFor(id))?.approvedAt).toBeNull();
+        expect(await eventsFor(id)).toHaveLength(0);
+      }
+    });
+
+    it("returns 409 with the single-record wording when a record in the batch is already decided", async () => {
+      await db
+        .update(vacation)
+        .set({ approvedAt: new Date(), approvedBy: context.approverUser.id })
+        .where(eq(vacation.id, ids[0] ?? ""));
+
+      const response = await request(context.app)
+        .post("/api/vacation/approve")
+        .set("Cookie", approverCookie)
+        .send({ ids })
+        .expect(409);
+
+      // The pre-read guard is shared with the single-record route, so a batch
+      // whose rows are already decided answers in the single-record wording.
+      expect(messagesOf(response)).toEqual(["This request has already been decided"]);
+
+      expect((await rowFor(ids[1] ?? ""))?.approvedAt).toBeNull();
+    });
+
+    it("returns 409 with the bulk wording when a single-id batch loses the race", async () => {
+      const id = ids[0] ?? "";
+
+      const response = await raceRequestAgainstDecision(
+        id,
+        { approvedAt: new Date(), approvedBy: context.approverUser.id },
+        () =>
+          request(context.app)
+            .post("/api/vacation/approve")
+            .set("Cookie", approverCookie)
+            .send({ ids: [id] })
+      );
+
+      expect(response.status).toBe(409);
+      expect(messagesOf(response)).toEqual([
+        "One or more of these requests has already been decided",
+      ]);
+      expect(await eventsFor(id)).toHaveLength(0);
+    });
+
+    it("returns 404 when one of the ids does not exist", async () => {
+      const response = await request(context.app)
+        .post("/api/vacation/approve")
+        .set("Cookie", approverCookie)
+        .send({ ids: [...ids, uuidv4()] })
+        .expect(404);
+
+      expect(messagesOf(response)).toEqual(["One or more vacations not found"]);
+
+      for (const id of ids) {
+        expect((await rowFor(id))?.approvedAt).toBeNull();
+      }
+    });
+  });
+
+  describe("POST /api/vacation/reject", () => {
+    let ids: string[];
+
+    beforeEach(async () => {
+      ids = [
+        await createTestVacation(context.user1.id, context.group.id, "2025-12-22"),
+        await createTestVacation(context.user1.id, context.group.id, "2025-12-23"),
+        await createTestVacation(context.user2.id, context.group.id, "2025-12-22"),
+      ];
+    });
+
+    it("rejects every record in the batch and appends one event per record carrying the reason", async () => {
+      const response = await request(context.app)
+        .post("/api/vacation/reject")
+        .set("Cookie", approverCookie)
+        .send({ ids, reason: "we cannot cover those days" })
+        .expect(200);
+
+      expect(response.body).toEqual({ message: "Vacations rejected", rejectedCount: 3 });
+
+      for (const id of ids) {
+        const row = await rowFor(id);
+        expect(row?.rejectedAt).not.toBeNull();
+        expect(row?.rejectedBy).toBe(context.approverUser.id);
+        expect(row?.rejectionReason).toBe("we cannot cover those days");
+
+        const events = await eventsFor(id);
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+          eventType: vacationEventType.Rejected,
+          actorUserId: context.approverUser.id,
+          reason: "we cannot cover those days",
+        });
+      }
+    });
+
+    it("returns 403 for a caller with no approver standing in the group", async () => {
+      const cookie = await authCookieFor(context.user2.id);
+      const othersIds = [ids[0] ?? "", ids[1] ?? ""];
+
+      const response = await request(context.app)
+        .post("/api/vacation/reject")
+        .set("Cookie", cookie)
+        .send({ ids: othersIds, reason: "no" })
+        .expect(403);
+
+      expect(messagesOf(response)).toEqual([
+        "You are not allowed to reject one or more of these requests",
+      ]);
+
+      for (const id of othersIds) {
+        expect((await rowFor(id))?.rejectedAt).toBeNull();
+        expect(await eventsFor(id)).toHaveLength(0);
+      }
+    });
+
+    it("returns 409 with the single-record wording when a record in the batch is already decided", async () => {
+      await db
+        .update(vacation)
+        .set({
+          rejectedAt: new Date(),
+          rejectedBy: context.approverUser.id,
+          rejectionReason: "first",
+        })
+        .where(eq(vacation.id, ids[0] ?? ""));
+
+      const response = await request(context.app)
+        .post("/api/vacation/reject")
+        .set("Cookie", approverCookie)
+        .send({ ids, reason: "second" })
+        .expect(409);
+
+      // Same shared pre-read guard as bulk approve: the single-record wording.
+      expect(messagesOf(response)).toEqual(["This request has already been decided"]);
+
+      expect((await rowFor(ids[1] ?? ""))?.rejectedAt).toBeNull();
+    });
+
+    it("returns 409 with the bulk wording when a single-id batch loses the race", async () => {
+      const id = ids[0] ?? "";
+
+      const response = await raceRequestAgainstDecision(
+        id,
+        { rejectedAt: new Date(), rejectedBy: context.approverUser.id, rejectionReason: "first" },
+        () =>
+          request(context.app)
+            .post("/api/vacation/reject")
+            .set("Cookie", approverCookie)
+            .send({ ids: [id], reason: "second" })
+      );
+
+      expect(response.status).toBe(409);
+      expect(messagesOf(response)).toEqual([
+        "One or more of these requests has already been decided",
+      ]);
+      expect((await rowFor(id))?.rejectionReason).toBe("first");
+      expect(await eventsFor(id)).toHaveLength(0);
+    });
+
+    it("returns 404 when one of the ids does not exist", async () => {
+      const response = await request(context.app)
+        .post("/api/vacation/reject")
+        .set("Cookie", approverCookie)
+        .send({ ids: [...ids, uuidv4()], reason: "no" })
+        .expect(404);
+
+      expect(messagesOf(response)).toEqual(["One or more vacations not found"]);
+
+      for (const id of ids) {
+        expect((await rowFor(id))?.rejectedAt).toBeNull();
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #104, #105, #106, #107, #108, #109.

## What changed

Eight route handlers used to carry out the write side of the vacation workflow, and each
re-implemented the same sequence by hand: open a transaction, load the rows, authorize, check the
group is writable under its plan, mutate, detect a lost race, append the vacation events, commit,
notify. Seven of them now go through one module, `src/services/vacation/vacationTransitions.ts`.

A private engine in that module owns the sequence. Each transition supplies only what genuinely
differs: its load, its authorization, its mutation, its event type, its notifier and its own
not-found and conflict wording. The controllers shrank to parsing the request and shaping the
response.

The point is that `CONTEXT.md` claimed the vacation events row lands in the same transaction as the
change it records, and mail goes out only after that transaction commits. Nothing enforced that. It
was true because seven files each happened to do it in the right order. Now one function holds it,
and a new transition inherits the ordering rather than rediscovering it.

The admin edit and create-vacation transitions stay where they are. Both carry validation no other
transition has, and pulling them in now would shape the shared interface around their exceptions.

## This is a refactor

Every status code, message, response body, log context and side effect is unchanged. Two known
inconsistencies were preserved on purpose rather than fixed here, and are recorded as #110:

- single cancel answers a lost race with a 500 where its siblings answer 409
- bulk cancel performs no lost-race check at all

## The commits, in order

1. **`d741cab`** pins reject, bulk approve and bulk reject at the HTTP seam. These three routes had
   no test of any kind, and no test in the repository called a bulk route by URL. Written against
   the old implementation and **not edited by any later commit**, so their staying green is
   evidence rather than decoration. `git diff d741cab..HEAD -- src/tests/e2e/vacationDecisions.e2e.test.ts` is empty.
2. **`34c157f`** moves the vacation decision guards, the vacation permission resolver and the group
   access helpers from the controllers layer to the services layer. Import paths only, no function
   body or signature touched, because the services layer imports nothing from controllers and this
   change must not be what starts that.
3. **`53edc79`** builds the engine and moves approve and reject onto it, single and bulk.
4. **`9db302f`** moves cancel and comment. Cancel's two forms had two separate authorization
   implementations that happened to agree; they now share the set-based one, which resolves
   approver and admin standing once per distinct group instead of once per record. The per-record
   form would have turned a fifty-record cancel into hundreds of queries inside an open transaction
   holding row locks.
5. **`526c935`** rewrites the conventions the refactor invalidated.

## Review notes

Single and bulk forms of a transition run one code path. The differing wording is baked into the two
wrapper functions and never derived from how many ids arrived, so a bulk request carrying exactly
one id still produces the bulk wording. There is a test for that.

The four existing handler unit suites for approve, cancel, comment and bulk cancel appear in this
diff with mock-path changes only, and the approve suite does not appear at all. That is the central
evidence that nothing changed.

Three behaviour-preservation claims are worth a second pair of eyes, all verified but none obvious:

- `resolveCanCancelForList` drops the `!isCancelled` term the per-record resolver carried. Safe
  because `getVacationById` and `getVacationsByIds` both filter on `isNull(vacation.deletedAt)`, so
  the loader has already excluded those rows.
- The single routes now call `assertGroupsWritable([id])` where they called `assertGroupWritable(id)`.
  Both produce the same 404 and 402 with the same context for one group.
- The cancel notifier still receives the pre-cancellation rows, which carry the approval stamp it
  reads to decide whether a cancellation is worth an email.

## Verification

Typecheck, eslint (0 errors), prettier, 601 unit tests across 62 files, 203 e2e tests across 15
files, all green. Reviewed by two agents with no exposure to the design discussion, on standards and
on spec; their findings are addressed in the commits above.

Verified in the browser against the local stack as the group owner: approve on a single-day request,
approve on a two-day request, reject, comment, cancel of a member's approved two-day booking, and
cancel of an own approved booking. Every timeline event appended in the right order with the right
actor, the post-commit notifier fired (suppressed for `@dev.local`, as designed), and no console or
backend errors. Note the frontend calls the bulk endpoints for approve, reject and cancel, so the
single-record routes are covered by the unit and e2e suites rather than by the browser pass.

One deviation from the spec worth naming: #104 and #109 both say `docs/invariants.md` is not
touched. It is, by four lines in `9db302f`. Its org-admin entry pointed at `handleBulkCancelVacation`
as the thing resolving admin standing on a cancel, and that commit makes the pointer wrong. Fixing
it seemed better than leaving a stale reference in a document about security boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrPmNbE8YbGdaZp4A58gSn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent handling for vacation approvals, rejections, cancellations, and comments across individual and bulk actions.
  - Bulk vacation actions now validate permissions, quotas, writable status, duplicates, and concurrent updates consistently.
  - Notifications are sent after successful changes, with improved handling for loaded versus modified cancellations.

- **Bug Fixes**
  - Improved authorization and conflict responses for vacation decisions, including clearer handling of missing or already-processed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->