### PR TITLE
fix(vacation): answer a lost cancel race with 409, in both arities

### DIFF
--- a/src/routes/vacationRouter.ts
+++ b/src/routes/vacationRouter.ts
@@ -549,6 +549,10 @@ export const vacationRouter = (): Router => {
    *         description: Not allowed to cancel one or more rows
    *       '404':
    *         description: One or more vacations not found
+   *       '409':
+   *         description: |
+   *           A concurrent cancel won the race for one or more rows. The whole
+   *           batch is refused — nothing is cancelled.
    */
   app.post(
     "/cancel",
@@ -676,6 +680,8 @@ export const vacationRouter = (): Router => {
    *         description: Not allowed
    *       '404':
    *         description: Vacation not found
+   *       '409':
+   *         description: A concurrent cancel won the race; the row is already cancelled
    */
   app.delete(
     "/:id",

--- a/src/services/vacation/tests/vacationTransitions.test.ts
+++ b/src/services/vacation/tests/vacationTransitions.test.ts
@@ -486,24 +486,43 @@ describe("vacationTransitions", () => {
       );
     });
 
-    it("answers a lost single cancel with its own 500 wording", async () => {
+    it("answers a lost single cancel with a conflict, not a server fault", async () => {
       mockGetVacationById.mockResolvedValue(approvedVacation());
       mockDeleteVacation.mockResolvedValue(undefined);
 
       await expect(
         cancelRequest({ auth: mockAuthData, vacationId: FIRST_ID, reason: null })
-      ).rejects.toThrow("Failed to cancel vacation");
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        message: "This request has already been cancelled",
+      });
 
       expect(mockCreateVacationEvent).not.toHaveBeenCalled();
       expect(mockNotifyVacationCancelled).not.toHaveBeenCalled();
     });
 
-    // Preserved as it stands: the batch route runs no lost-race check, so its
-    // count reports the rows it loaded even when the update moved fewer.
-    it("runs no lost-race check on a batch, and counts what it loaded", async () => {
+    it("fails the whole batch when a bulk cancel loses the race", async () => {
       const rows = [approvedVacation(), approvedVacation({ id: SECOND_ID })];
       mockGetVacationsByIds.mockResolvedValue(rows);
       mockCancelVacationsBulk.mockResolvedValue([{ ...rows[0], deletedAt: new Date() }]);
+
+      await expect(
+        cancelRequestBatch({ auth: mockAuthData, vacationIds: [FIRST_ID, SECOND_ID], reason: null })
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        message: "One or more of these requests has already been cancelled",
+      });
+
+      expect(mockCreateVacationEvents).not.toHaveBeenCalled();
+      expect(mockNotifyVacationsCancelled).not.toHaveBeenCalled();
+    });
+
+    it("returns the rows a successful batch actually cancelled", async () => {
+      const rows = [approvedVacation(), approvedVacation({ id: SECOND_ID })];
+      mockGetVacationsByIds.mockResolvedValue(rows);
+      mockCancelVacationsBulk.mockResolvedValue(
+        rows.map((row) => ({ ...row, deletedAt: new Date() }))
+      );
 
       const cancelled = await cancelRequestBatch({
         auth: mockAuthData,
@@ -512,8 +531,13 @@ describe("vacationTransitions", () => {
       });
 
       expect(cancelled).toHaveLength(2);
+      // The rows the update moved, not the rows the load found.
+      expect(cancelled.every((row) => row.deletedAt !== null)).toBe(true);
       expect(mockCreateVacationEvents).toHaveBeenCalledWith(
-        [expect.objectContaining({ vacationId: FIRST_ID, eventType: "CANCELLED" })],
+        [
+          expect.objectContaining({ vacationId: FIRST_ID, eventType: "CANCELLED" }),
+          expect.objectContaining({ vacationId: SECOND_ID, eventType: "CANCELLED" }),
+        ],
         tx
       );
     });

--- a/src/services/vacation/vacationTransitions.ts
+++ b/src/services/vacation/vacationTransitions.ts
@@ -122,22 +122,28 @@ const mayDecide =
     assertStillPending(rows);
   };
 
-const oneAlreadyDecided = (auth: AuthSession, vacationId: string) => () =>
-  new AppError({
-    code: 409,
-    message: "This request has already been decided",
-    logging: true,
-    context: { auth, vacationId },
-  });
+const oneConflict = (message: string) => (auth: AuthSession, vacationId: string) => () =>
+  new AppError({ code: 409, message, logging: true, context: { auth, vacationId } });
 
-const someAlreadyDecided =
-  (auth: AuthSession, vacationIds: string[]) => (updated: VacationType[]) =>
+const someConflict =
+  (message: string) => (auth: AuthSession, vacationIds: string[]) => (updated: VacationType[]) =>
     new AppError({
       code: 409,
-      message: "One or more of these requests has already been decided",
+      message,
       logging: true,
       context: { auth, requested: vacationIds, updated: updated.map((row) => row.id) },
     });
+
+const oneAlreadyDecided = oneConflict("This request has already been decided");
+const someAlreadyDecided = someConflict("One or more of these requests has already been decided");
+
+// Cancel keeps its own wording rather than the decision wording: a cancel is not
+// a decision, and because both cancel loads filter out soft-deleted rows, the
+// only way to lose this race is to another cancel.
+const oneAlreadyCancelled = oneConflict("This request has already been cancelled");
+const someAlreadyCancelled = someConflict(
+  "One or more of these requests has already been cancelled"
+);
 
 const appendEventsRowByRow =
   (auth: AuthSession, eventType: vacationEventType, reason: string | null) =>
@@ -343,15 +349,7 @@ export const cancelRequest = async (params: {
       const row = await services.vacation.deleteVacation(vacationId, auth.userId, tx);
       return row ? [row] : [];
     },
-    // Answering a lost race with a 500 is what this route does today; its
-    // siblings answer 409.
-    lostRace: () =>
-      new AppError({
-        code: 500,
-        message: "Failed to cancel vacation",
-        logging: true,
-        context: { auth, vacationId },
-      }),
+    lostRace: oneAlreadyCancelled(auth, vacationId),
     appendEvents: appendEventsRowByRow(auth, vacationEventType.Cancelled, reason),
     // The cancelled row no longer carries the approval stamp the notifier reads
     // to decide whether the cancellation is worth an email.
@@ -367,9 +365,7 @@ export const cancelRequestBatch = async (params: {
   const { auth, reason } = params;
   const vacationIds = Array.from(new Set(params.vacationIds));
 
-  // No `lostRace`: this route runs no such check today, so its count reports
-  // the rows it loaded even when the update moved fewer.
-  const { loaded } = await runTransition({
+  const { changed } = await runTransition({
     load: loadMany(vacationIds),
     requestedCount: vacationIds.length,
     notFound: someNotFound(auth, vacationIds),
@@ -384,11 +380,12 @@ export const cancelRequestBatch = async (params: {
         })
     ),
     mutate: (tx) => services.vacation.cancelVacationsBulk(vacationIds, auth.userId, tx),
+    lostRace: someAlreadyCancelled(auth, vacationIds),
     appendEvents: appendEventsInOneInsert(auth, vacationEventType.Cancelled, reason),
     notify: ({ loaded: rows }) => notifyVacationsCancelled(rows, actorOf(auth), reason),
   });
 
-  return loaded;
+  return changed;
 };
 
 export const commentOnRequest = async (params: {


### PR DESCRIPTION
Closes #110.

Cancel was the odd transition out. Its single form answered a lost race with a 500, and its bulk form ran no lost-race check at all. Both are now the 409 every other transition returns.

## Single cancel

`cancelRequest` threw `{ code: 500, message: "Failed to cancel vacation" }` when the delete moved no row — which happens when someone else cancelled the same booking a moment earlier. That is the client's ordinary concurrency case, not a server fault: it told the frontend to retry something that would never succeed, and raised a Sentry issue on both sides. It now throws 409, and `errorMiddleware` logs anything under 500 at `warn`.

## Bulk cancel

`cancelRequestBatch` passed no `lostRace`, so a batch whose update moved fewer rows than its load still returned 200, reported the count it *loaded*, and mailed cancellation notices for bookings it had not cancelled. It now supplies the check and fails the whole batch, matching bulk approve and reject. The throw happens inside the transaction, so nothing is cancelled, no events are appended and no mail goes out — and the returned count is honest for free, since a successful batch now moves every row it loaded.

Partial success was considered and rejected in the issue: returning 200 with an honest count leaves the notifier as the remaining problem, and every other bulk transition fails the batch.

## Wording

Cancel keeps its own wording rather than the decision wording its siblings share. A cancel is not a decision, and because both cancel loads filter out soft-deleted rows, the only way to lose this race is to another cancel — a concurrent reject stamps a different column and does not block the cancel.

## Also here

- `oneConflict` / `someConflict` factories, parameterised by wording. The decided and cancelled variants were otherwise byte-identical.
- `409` documented on both cancel routes' `@openapi` blocks. Neither documented one.
- The test pinning the 500 wording is rewritten rather than deleted, plus a bulk lost-race test and one pinning the honest count. That last one was checked to fail if the return reverts to `loaded`.

## Checks

`npm run build`, `lint`, `format:check`, `npm test` (602 pass) and `npm run test:e2e` (203 pass) all green.

## Not here

No `flexi-day` change — nothing in the frontend calls the single-cancel endpoint, and both cancel surfaces go through the bulk hook. Handling the new bulk 409 there is tracked separately.

A pre-existing gap this turned up, left for its own ticket: `/approve`, `/reject` and both bulk forms all throw 409 via `oneAlreadyDecided` / `someAlreadyDecided` and document none of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuzS978Dy1KYpFX6BqAh84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancellation conflicts caused by concurrent requests now return clear `409 Conflict` responses instead of server errors.
  * Single cancellations indicate when the item was already cancelled.
  * Bulk cancellations report when the batch could not be completed due to a concurrent cancellation.
  * Successful bulk cancellations now accurately reflect the records actually cancelled.
  * Conflicted cancellations no longer create events or send notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->