### PR TITLE
fix(vacation): put the live-rows precondition in the type

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,7 @@ The vacation/day-off domain as the backend models it. Security and permission bo
 | **Quota**          | A user's allowance for one year in one group (`user_year_quotas`).                               |
 | **Mirror**         | A read-side projection of a user's records from one group into another.                          |
 | **Invite link**    | Single-use code binding one email address to one group.                                          |
+| **Live row**       | A vacation row a reader returned under `deleted_at IS NULL`. `LiveVacationType` is its type.     |
 
 ## Vacation workflow
 

--- a/src/services/vacation/tests/vacationPermissions.test.ts
+++ b/src/services/vacation/tests/vacationPermissions.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockGetGroupsWhereUserCanApprove,
+  mockGetGroupUser,
+  mockResolveGroupAdmin,
+  mockMayDecideOwn,
+} = vi.hoisted(() => ({
+  mockGetGroupsWhereUserCanApprove: vi.fn(),
+  mockGetGroupUser: vi.fn(),
+  mockResolveGroupAdmin: vi.fn(),
+  mockMayDecideOwn: vi.fn(),
+}));
+
+vi.mock("../../DBServices.js", () => ({
+  createDBServices: () => ({
+    group: { getGroupsWhereUserCanApprove: mockGetGroupsWhereUserCanApprove },
+    groupUser: { getGroupUser: mockGetGroupUser },
+  }),
+}));
+
+vi.mock("../../groupUser/groupAccess.js", () => ({
+  resolveGroupAdmin: mockResolveGroupAdmin,
+}));
+
+vi.mock("../decisionGuards.js", () => ({
+  mayDecideOwn: mockMayDecideOwn,
+}));
+
+import {
+  resolveCanApproveForList,
+  resolveCanCancelForList,
+  resolveVacationPermissions,
+} from "../vacationPermissions.js";
+
+const userId = "hUdX9mKq4LpR2wZn7tBvC3sYeA6gJfN1";
+const groupId = "550e8400-e29b-41d4-a716-446655440009";
+
+const liveRow = {
+  userId,
+  groupId,
+  deletedAt: null,
+  approvedAt: null,
+  rejectedAt: null,
+};
+
+// A stamp that is missing rather than null, as a hand-built row or a mocked
+// service produces. A strict `!== null` test reads it as cancelled.
+const stampless = { userId, groupId, approvedAt: null, rejectedAt: null } as typeof liveRow;
+
+describe("vacationPermissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGroupsWhereUserCanApprove.mockResolvedValue([]);
+    mockGetGroupUser.mockResolvedValue(null);
+    mockResolveGroupAdmin.mockResolvedValue({ canAdmin: false, viaOrgAdmin: false });
+    mockMayDecideOwn.mockResolvedValue(false);
+  });
+
+  describe("resolveVacationPermissions", () => {
+    it("reads an absent soft-delete stamp as live", async () => {
+      const permissions = await resolveVacationPermissions(userId, stampless);
+
+      expect(permissions.canCancel).toBe(true);
+    });
+
+    it("still refuses to cancel a row carrying a soft-delete stamp", async () => {
+      const cancelled = { ...liveRow, deletedAt: new Date("2026-08-01T00:00:00Z") };
+
+      const permissions = await resolveVacationPermissions(userId, cancelled);
+
+      expect(permissions.canCancel).toBe(false);
+    });
+
+    it("lets an admin edit a row with an absent stamp", async () => {
+      mockResolveGroupAdmin.mockResolvedValue({ canAdmin: true, viaOrgAdmin: false });
+
+      const permissions = await resolveVacationPermissions("someone_else", stampless);
+
+      expect(permissions.canEdit).toBe(true);
+    });
+  });
+
+  describe("resolveCanApproveForList", () => {
+    it("reads an absent soft-delete stamp as live", async () => {
+      mockGetGroupsWhereUserCanApprove.mockResolvedValue([groupId]);
+      mockMayDecideOwn.mockResolvedValue(true);
+
+      const canApprove = await resolveCanApproveForList(userId, [stampless]);
+
+      expect(canApprove(stampless)).toBe(true);
+    });
+
+    it("still refuses to approve a row carrying a soft-delete stamp", async () => {
+      mockGetGroupsWhereUserCanApprove.mockResolvedValue([groupId]);
+      mockMayDecideOwn.mockResolvedValue(true);
+      const cancelled = { ...liveRow, deletedAt: new Date("2026-08-01T00:00:00Z") };
+
+      const canApprove = await resolveCanApproveForList(userId, [cancelled]);
+
+      expect(canApprove(cancelled)).toBe(false);
+    });
+  });
+
+  describe("resolveCanCancelForList", () => {
+    // The set-based verdict is a second implementation of `canCancel`, so the
+    // two are pinned against each other. Only live rows: the row type is what
+    // keeps a cancelled one out, and it cannot be written here.
+    const standings = [
+      { name: "the owner", actor: userId, approvable: [], canAdmin: false },
+      { name: "an approver", actor: "someone_else", approvable: [groupId], canAdmin: false },
+      { name: "a group admin", actor: "someone_else", approvable: [], canAdmin: true },
+      { name: "an outsider", actor: "someone_else", approvable: [], canAdmin: false },
+    ];
+
+    it.each(standings)("agrees with the per-record resolver for $name", async (standing) => {
+      mockGetGroupsWhereUserCanApprove.mockResolvedValue(standing.approvable);
+      mockResolveGroupAdmin.mockResolvedValue({
+        canAdmin: standing.canAdmin,
+        viaOrgAdmin: false,
+      });
+
+      const canCancel = await resolveCanCancelForList(standing.actor, [liveRow]);
+      const permissions = await resolveVacationPermissions(standing.actor, liveRow);
+
+      expect(canCancel(liveRow)).toBe(permissions.canCancel);
+    });
+
+    it("lets the owner cancel, so the pin above is not agreeing on false", async () => {
+      const canCancel = await resolveCanCancelForList(userId, [liveRow]);
+
+      expect(canCancel(liveRow)).toBe(true);
+    });
+  });
+});

--- a/src/services/vacation/types.ts
+++ b/src/services/vacation/types.ts
@@ -25,6 +25,9 @@ export type VacationType = {
   updatedAt: Date;
 };
 
+/** A row a live-only reader returned: its `deleted_at IS NULL` predicate, as a type. */
+export type LiveVacationType = Omit<VacationType, "deletedAt"> & { deletedAt: null };
+
 export type VacationInsertType = Pick<
   VacationType,
   | "id"

--- a/src/services/vacation/vacationPermissions.ts
+++ b/src/services/vacation/vacationPermissions.ts
@@ -1,6 +1,6 @@
 import { createDBServices } from "../DBServices.js";
 import type { DbTransaction } from "../../db/db.js";
-import type { VacationType } from "./types.js";
+import type { LiveVacationType, VacationType } from "./types.js";
 import { mayDecideOwn } from "./decisionGuards.js";
 import { resolveGroupAdmin } from "../groupUser/groupAccess.js";
 
@@ -40,7 +40,9 @@ export const resolveVacationPermissions = async (
   // members (create / edit / cancel), which is administration — deciding a
   // member-submitted request stays an approver-only power (`canApprove`).
   const { canAdmin } = await resolveGroupAdmin(userId, vacationRow.groupId, tx);
-  const isCancelled = vacationRow.deletedAt !== null;
+  // Nullish, not strict: a row whose stamp is absent rather than null is live.
+  // A strict test reads `undefined` as cancelled and denies the owner.
+  const isCancelled = vacationRow.deletedAt != null;
   // A decision is final; re-deciding would overturn it and wipe its stamps.
   const isDecidable =
     !isCancelled && vacationRow.approvedAt === null && vacationRow.rejectedAt === null;
@@ -55,16 +57,15 @@ export const resolveVacationPermissions = async (
   };
 };
 
-/** A row a live-only reader returned — never a soft-deleted one. */
-type LiveVacationRow = Pick<VacationType, "userId" | "groupId">;
+type LiveVacationRow = Pick<LiveVacationType, "userId" | "groupId" | "deletedAt">;
 
 /**
  * The same `canCancel` verdict as {@link resolveVacationPermissions}, for a
  * whole list in a number of queries that scales with the distinct groups in the
  * batch rather than with its rows — the per-record form would turn a
  * fifty-record cancel into hundreds of queries inside an open transaction
- * holding row locks. It carries no cancelled-row term, so the rows must come
- * from a reader that excludes them.
+ * holding row locks. It carries no cancelled-row term; the row type is what
+ * keeps a soft-deleted row out, so only a live-only reader can feed it.
  */
 export const resolveCanCancelForList = async <T extends LiveVacationRow>(
   userId: string,
@@ -114,7 +115,7 @@ export const resolveCanApproveForList = async <T extends DecidableRow>(
 
   return (row) => {
     if (!approvable.has(row.groupId)) return false;
-    if (row.deletedAt !== null || row.approvedAt !== null || row.rejectedAt !== null) return false;
+    if (row.deletedAt != null || row.approvedAt !== null || row.rejectedAt !== null) return false;
     return row.userId !== userId || selfDecidable.has(row.groupId);
   };
 };

--- a/src/services/vacation/vacationServices.ts
+++ b/src/services/vacation/vacationServices.ts
@@ -22,6 +22,7 @@ import {
 } from "drizzle-orm";
 import type {
   GroupVacationListItem,
+  LiveVacationType,
   VacationDetail,
   VacationInsertType,
   VacationListItem,
@@ -368,13 +369,15 @@ export const getVacationsByIds = async (
   vacationIds: string[],
   tx?: DbTransaction,
   options?: { forUpdate?: boolean }
-): Promise<VacationType[]> => {
+): Promise<LiveVacationType[]> => {
   if (vacationIds.length === 0) return [];
   const query = (tx ?? db)
     .select()
     .from(vacation)
     .where(and(inArray(vacation.id, vacationIds), isNull(vacation.deletedAt)));
-  return options?.forUpdate ? query.for("update") : query;
+  const rows = await (options?.forUpdate ? query.for("update") : query);
+  // Live by the `isNull` above; nothing checks the narrowing at runtime.
+  return rows as LiveVacationType[];
 };
 
 export const rejectVacation = async (
@@ -567,13 +570,14 @@ export const getVacationDetailById = async (
 export const getVacationById = async (
   vacationId: string,
   tx?: DbTransaction
-): Promise<VacationType | undefined> => {
+): Promise<LiveVacationType | undefined> => {
   const [row] = await (tx ?? db)
     .select()
     .from(vacation)
     .where(and(eq(vacation.id, vacationId), isNull(vacation.deletedAt)));
 
-  return row;
+  // Live by the `isNull` above; nothing checks the narrowing at runtime.
+  return row as LiveVacationType | undefined;
 };
 
 export type PendingApprovalRow = {

--- a/src/services/vacation/vacationTransitions.ts
+++ b/src/services/vacation/vacationTransitions.ts
@@ -7,7 +7,7 @@ import { createDBServices } from "../DBServices.js";
 import { assertGroupsWritable } from "../billing/guards.js";
 import { assertMayDecide, assertStillPending, type Decision } from "./decisionGuards.js";
 import { assertApprovalWithinQuota } from "./quotaGuard.js";
-import type { VacationType } from "./types.js";
+import type { LiveVacationType, VacationType } from "./types.js";
 import {
   notifyVacationCancelled,
   notifyVacationComment,
@@ -26,7 +26,7 @@ const actorOf = (auth: AuthSession) => ({ id: auth.userId, name: auth.userName }
  * stamp the cancellation has just cleared.
  */
 type TransitionRows = {
-  loaded: VacationType[];
+  loaded: LiveVacationType[];
   /** What the mutation returned — the loaded rows when there is no mutation. */
   changed: VacationType[];
 };
@@ -39,13 +39,13 @@ type TransitionRows = {
  */
 type Transition = {
   /** Rows named by the request that are still live; a short result is a not-found. */
-  load: (tx: DbTransaction) => Promise<VacationType[]>;
+  load: (tx: DbTransaction) => Promise<LiveVacationType[]>;
   requestedCount: number;
   /** This route's own wording for a load that came back short. */
-  notFound: (rows: VacationType[]) => AppError;
-  authorize: (rows: VacationType[], tx: DbTransaction) => Promise<void>;
+  notFound: (rows: LiveVacationType[]) => AppError;
+  authorize: (rows: LiveVacationType[], tx: DbTransaction) => Promise<void>;
   /** Only the approving transitions have one. */
-  assertWithinQuota?: (rows: VacationType[], tx: DbTransaction) => Promise<void>;
+  assertWithinQuota?: (rows: LiveVacationType[], tx: DbTransaction) => Promise<void>;
   /** Absent on a comment, which changes no vacation row at all. */
   mutate?: (tx: DbTransaction) => Promise<VacationType[]>;
   /**
@@ -91,14 +91,14 @@ const runTransition = async (transition: Transition): Promise<TransitionRows> =>
 
 const loadOne =
   (vacationId: string) =>
-  async (tx: DbTransaction): Promise<VacationType[]> => {
+  async (tx: DbTransaction): Promise<LiveVacationType[]> => {
     const row = await services.vacation.getVacationById(vacationId, tx);
     return row ? [row] : [];
   };
 
 const loadMany =
   (vacationIds: string[]) =>
-  (tx: DbTransaction): Promise<VacationType[]> =>
+  (tx: DbTransaction): Promise<LiveVacationType[]> =>
     services.vacation.getVacationsByIds(vacationIds, tx);
 
 const oneNotFound = (auth: AuthSession, vacationId: string) => () =>
@@ -108,7 +108,7 @@ const oneNotFound = (auth: AuthSession, vacationId: string) => () =>
     context: { auth, vacationId },
   });
 
-const someNotFound = (auth: AuthSession, vacationIds: string[]) => (rows: VacationType[]) =>
+const someNotFound = (auth: AuthSession, vacationIds: string[]) => (rows: LiveVacationType[]) =>
   new AppError({
     code: 404,
     message: "One or more vacations not found",
@@ -185,8 +185,8 @@ const notifyDecision =
     notifyVacationDecision(changed, decision, actorOf(auth), reason);
 
 const mayCancel =
-  (auth: AuthSession, forbidden: (unauthorized: VacationType[]) => AppError) =>
-  async (rows: VacationType[], tx: DbTransaction): Promise<void> => {
+  (auth: AuthSession, forbidden: (unauthorized: LiveVacationType[]) => AppError) =>
+  async (rows: LiveVacationType[], tx: DbTransaction): Promise<void> => {
     const canCancel = await resolveCanCancelForList(auth.userId, rows, tx);
 
     const unauthorized = rows.filter((row) => !canCancel(row));
@@ -195,7 +195,7 @@ const mayCancel =
 
 const mayComment =
   (auth: AuthSession, vacationId: string) =>
-  async (rows: VacationType[], tx: DbTransaction): Promise<void> => {
+  async (rows: LiveVacationType[], tx: DbTransaction): Promise<void> => {
     // The engine has already thrown a not-found for a short load, so this
     // cannot fire. It throws rather than returns so that a guard can never
     // fail open if that ordering ever changes.


### PR DESCRIPTION
Closes #112.

## What changed

`resolveCanCancelForList` answers the same `canCancel` question as `resolveVacationPermissions` without the latter's cancelled-row term. That is correct for every caller today, because the cancel transitions load through readers that filter `deleted_at IS NULL`. Nothing enforced it but a line of JSDoc, and the row type accepted a soft-deleted row as readily as a live one. A future transition loading through `getVacationDetailById`, which returns soft-deleted rows on purpose, would have been told it may cancel an already-cancelled request. The delete predicate would then match nothing and the route would answer 500 where 403 was right.

`LiveVacationType` carries the readers' `isNull` predicate into the type. The two live-only readers return it, the transition engine types its loaded rows with it, and the resolver's row constraint narrows `deletedAt` to null. Passing a detail row now fails to compile at the call site:

```
error TS2345: Argument of type 'VacationDetail' is not assignable to parameter of type 'LiveVacationRow'.
  Types of property 'deletedAt' are incompatible.
    Type 'Date | null' is not assignable to type 'null'.
```

The engine's `changed` rows stay `VacationType`. A cancel stamps them, so narrowing there would be a lie.

## The second half: an absent stamp is not a cancellation

All three resolvers tested the stamp with `!== null`, so a row built without the field counted as cancelled and its own owner was denied. They test it nullish now.

This is why #111 could not simply add the runtime term to the set-based resolver. Doing so fails three `handleBulkCancelVacation` tests whose fixtures omit `deletedAt`. Those fixtures are untouched here, and they still pass. A database row always carries the field, as null or a date, so no runtime behaviour changes for any real request.

## Why the type rather than a runtime check

The set-based resolver exists because the per-record form would turn a fifty-record cancel into hundreds of queries inside an open transaction holding row locks. Adding a term to it costs a check per row for a condition the SQL has already decided. The type states the precondition where the reader produces it and costs nothing at runtime.

The guarantee rests on two `as` assertions, one per live-only reader, each sitting beside the `isNull` that justifies it. That is the honest weak point: dropping an `isNull` while keeping the cast would reintroduce the bug silently. Worth knowing when editing those two readers.

## Tests

New `vacationPermissions.test.ts`, written before the fix and red on three cases. It pins that an absent stamp reads as live in each resolver, that a real stamp is still refused, and that the set-based cancel verdict agrees with the per-record one across four standings: owner, approver, group admin and outsider.

## Verification

Typecheck clean, eslint 0 errors, prettier clean, 612 unit tests across 63 files green. The compile-error guarantee was checked with a scratch file handing a detail row to the resolver, then deleted. Reviewed on standards and on spec by two agents with no exposure to the implementation; their findings are in the commit.

No e2e run. The change is compile-time plus a nullish relaxation no database row can reach, so e2e would only re-exercise unchanged paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc29PKrGEMeZQD3VAkKqim


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected vacation status handling so records without a deletion timestamp remain active.
  - Prevented cancelled vacations from being returned by live-only lookups.
  - Aligned individual and batch cancellation permission checks across owners, approvers, administrators, and other users.

- **Documentation**
  - Added a glossary definition for “Live row,” clarifying how active vacation records are identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->